### PR TITLE
Update TS compiler options and package.json

### DIFF
--- a/compact/package.json
+++ b/compact/package.json
@@ -7,7 +7,10 @@
   "license": "MIT",
   "description": "Compact fetcher",
   "type": "module",
-  "main": "index.js",
+  "exports": "./index.js",
+  "engines": {
+    "node": ">=18"
+  },
   "bin": {
     "compact-builder": "dist/runBuilder.js",
     "compact-compiler": "dist/runCompiler.js"

--- a/compact/tsconfig.json
+++ b/compact/tsconfig.json
@@ -1,15 +1,19 @@
 {
     "compilerOptions": {
-        "target": "ES2020",
-        "module": "ESNext",
         "outDir": "dist",
         "rootDir": "src",
+        "declaration": true,
+        "lib": ["es2023"],
+        "module": "nodenext",
+        "target": "es2022",
         "strict": true,
         "esModuleInterop": true,
         "skipLibCheck": true,
-        "moduleResolution": "node",
-        "declaration": true,
-        "sourceMap": true
+        "moduleResolution": "node16",
+        "sourceMap": true,
+        "rewriteRelativeImportExtensions": true,
+        "erasableSyntaxOnly": true,
+        "verbatimModuleSyntax": true
     },
     "include": [
         "src/**/*"


### PR DESCRIPTION
Updates `compact/tsconfig.json` compilerOptions to recommended options for [Node 22](https://github.com/tsconfig/bases/blob/main/bases/node22.json) and [TypeScript 5.8](https://github.com/tsconfig/bases/blob/main/bases/node-ts.json). 

Updates `compact/package.json` to use standards compliant entry point. Avoids runtime errors for consumers running Node <18