### PR TITLE
Standardize Zero Address Structure

### DIFF
--- a/contracts/utils/src/Utils.compact
+++ b/contracts/utils/src/Utils.compact
@@ -19,6 +19,10 @@ module Utils {
    * @return {Boolean} - Returns true if `keyOrAddress` is zero.
    */
   export pure circuit isKeyOrAddressZero(keyOrAddress: Either<ZswapCoinPublicKey, ContractAddress>): Boolean {
-    return burn_address() == keyOrAddress;
+    if (keyOrAddress.is_left) {
+      return burn_address() == keyOrAddress;
+    } else {
+      return right<ZswapCoinPublicKey, ContractAddress>(default<ContractAddress>) == keyOrAddress;
+    }
   }
 }

--- a/contracts/utils/src/test/utils.test.ts
+++ b/contracts/utils/src/test/utils.test.ts
@@ -14,15 +14,14 @@ describe('Utils', () => {
   describe('isKeyOrAddressZero', () => {
     it('should return zero for the zero address', () => {
       expect(contract.isKeyOrAddressZero(contractUtils.ZERO_KEY)).toBe(true);
+      expect(contract.isKeyOrAddressZero(contractUtils.ZERO_ADDRESS)).toBe(
+        true,
+      );
     });
 
     it('should not return zero for nonzero addresses', () => {
       expect(contract.isKeyOrAddressZero(Z_SOME_KEY)).toBe(false);
       expect(contract.isKeyOrAddressZero(SOME_CONTRACT)).toBe(false);
-    });
-
-    it('should not return zero for a zero contract address', () => {
-      expect(contract.isKeyOrAddressZero(contractUtils.ZERO_ADDRESS)).toBe(false);
     });
   });
 });


### PR DESCRIPTION
Designates the zero address of an `Either<ZswapCoinPublicKey, ContractAddress>` as `left<ZswapCoinPublicKey, ContractAddress>(default<ZswapCoinPublicKey>)`. This is how the `burn_address()` utility function is represented under the hood. We follow this convention since the burn address is functionally equivalent to the zero address.