### PR TITLE
Add legal language to security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,3 +1,7 @@
 # Security
 
 Security vulnerabilities should be disclosed to the project maintainers by email to <security@openzeppelin.com>.
+
+## Legal
+
+Blockchain is a nascent technology and carries a high level of risk and uncertainty. OpenZeppelin makes certain software available under open source licenses, which disclaim all warranties in relation to the project and which limits the liability of OpenZeppelin. Subject to any particular licensing terms, your use of the project is governed by the terms found at [www.openzeppelin.com/tos](https://www.openzeppelin.com/tos) (the "Terms"). As set out in the Terms, you are solely responsible for any use of the project and you assume all risks associated with any such use. This Security Policy in no way evidences or represents an ongoing duty by any contributor, including OpenZeppelin, to correct any issues or vulnerabilities or alert you to all or any of the risks of utilizing the project.


### PR DESCRIPTION
Adds legal language to the repository security policy per request from OpenZeppelin legal team. Closes #104 
