### PR TITLE
Fix `Hash mismatch` error in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,7 +80,7 @@ jobs:
 
             echo "✅ Language version matches: $COMPUTED_LANGUAGE_VERSION"
 
-      - name: Compile contracts (with automatic retry on hash mismatch)
+      - name: Compile contracts (with retry on hash mismatch)
         shell: bash
         run: |
           set -euo pipefail


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

This PR proposes to compile with a concurrency of 1 to avoid parallel processes corrupting the cache during the attempt

This PR also proposes to have a retry mechanism that triggers if `Hash mismatch` is in the output and if `.cache/midnight/zk-params` exists after failure. The CI will `rm -rf` the `zk-params/` directory and attempt to recompile—the idea is to force a re-fetch as the error msg suggests

This PR also proposes to separate `turbo types` and `turbo test` for easier debugging

Fixes #147

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [ ] Documentation
