### PR TITLE
Add Circuit Info to Method Docs

### DIFF
--- a/contracts/accessControl/src/AccessControl.compact
+++ b/contracts/accessControl/src/AccessControl.compact
@@ -96,7 +96,7 @@ module AccessControl {
    /**
     * @description Returns `true` if `account` has been granted `roleId`.
     *
-    * @circuitInfo
+    * @circuitInfo k=10, rows=487
     *
     * @param {Bytes<32>} roleId - The role identifier.
     * @param {Either<ZswapCoinPublicKey, ContractAddress>} account - The account to query.
@@ -120,7 +120,7 @@ module AccessControl {
   /**
    * @description Reverts if `own_public_key()` is missing `roleId`.
    *
-   * @circuitInfo
+   * @circuitInfo k=10, rows=345
    *
    * Requirements:
    *
@@ -137,7 +137,7 @@ module AccessControl {
   /**
    * @description Reverts if `account` is missing `roleId`.
    *
-   * @circuitInfo
+   * @circuitInfo k=10, rows=467
    *
    * Requirements:
    *
@@ -157,7 +157,7 @@ module AccessControl {
    *
    * To change a role’s admin use {_setRoleAdmin}.
    *
-   * @circuitInfo
+   * @circuitInfo k=10, rows=207
    *
    * @param {Bytes<32>} roleId - The role identifier.
    * @return {Bytes<32>} roleAdmin - The admin role that controls `roleId`.
@@ -172,7 +172,7 @@ module AccessControl {
   /**
    * @description Grants `roleId` to `account`.
    *
-   * @circuitInfo
+   * @circuitInfo k=10, rows=994
    *
    * Requirements:
    *
@@ -191,7 +191,7 @@ module AccessControl {
   /**
    * @description Revokes `roleId` from `account`.
    *
-   * @circuitInfo
+   * @circuitInfo k=10, rows=827
    *
    * Requirements:
    *
@@ -213,7 +213,7 @@ module AccessControl {
   * purpose is to provide a mechanism for accounts to lose their privileges
   * if they are compromised (such as when a trusted device is misplaced).
   *
-  * @circuitInfo
+  * @circuitInfo k=10, rows=640
   *
   * Requirements:
   *
@@ -233,7 +233,7 @@ module AccessControl {
   /**
    * @description Sets `adminRole` as `roleId`'s admin role.
    *
-   * @circuitInfo
+   * @circuitInfo k=10, rows=209
    *
    * @param {Bytes<32>} roleId - The role identifier.
    * @param {Bytes<32>} adminRole - The admin role identifier.
@@ -247,7 +247,7 @@ module AccessControl {
    * @description Attempts to grant `roleId` to `account` and returns a boolean indicating if `roleId` was granted.
    * Internal circuit without access restriction.
    *
-   * @circuitInfo
+   * @circuitInfo k=10, rows=734
    *
    * Requirements:
    *
@@ -266,7 +266,7 @@ module AccessControl {
    * @description Attempts to grant `roleId` to `account` and returns a boolean indicating if `roleId` was granted.
    * Internal circuit without access restriction. It does NOT check if the role is granted to a ContractAddress.
    *
-   * @circuitInfo
+   * @circuitInfo k=10, rows=733
    *
    * @notice External smart contracts cannot call the token contract at this time, so granting a role to an ContractAddress may
    * render a circuit permanently inaccessible.
@@ -302,7 +302,7 @@ module AccessControl {
    * @description Attempts to revoke `roleId` from `account` and returns a boolean indicating if `roleId` was revoked.
    * Internal circuit without access restriction.
    *
-   * @circuitInfo
+   * @circuitInfo k=10, rows=563
    *
    * @param {Bytes<32>} roleId - The role identifier.
    * @param {Bytes<32>} adminRole - The admin role identifier.

--- a/contracts/fungibleToken/src/FungibleToken.compact
+++ b/contracts/fungibleToken/src/FungibleToken.compact
@@ -66,7 +66,7 @@ module FungibleToken {
   export sealed ledger _name: Opaque<"string">;
   export sealed ledger _symbol: Opaque<"string">;
   export sealed ledger _decimals: Uint<8>;
-  
+
   /**
    * @description Initializes the contract by setting the name, symbol, and decimals.
    * @dev This MUST be called in the implementing contract's constructor. Failure to do so
@@ -91,6 +91,8 @@ module FungibleToken {
   /**
    * @description Returns the token name.
    *
+   * @circuitInfo k=10, rows=37
+   *
    * Requirements:
    *
    * - Contract is initialized.
@@ -104,6 +106,8 @@ module FungibleToken {
 
   /**
    * @description Returns the symbol of the token.
+   *
+   * @circuitInfo k=10, rows=37
    *
    * Requirements:
    *
@@ -119,6 +123,8 @@ module FungibleToken {
   /**
    * @description Returns the number of decimals used to get its user representation.
    *
+   * @circuitInfo k=10, rows=36
+   *
    * Requirements:
    *
    * - Contract is initialized.
@@ -133,6 +139,8 @@ module FungibleToken {
   /**
    * @description Returns the value of tokens in existence.
    *
+   * @circuitInfo k=10, rows=36
+   *
    * Requirements:
    *
    * - Contract is initialized.
@@ -146,6 +154,8 @@ module FungibleToken {
 
   /**
    * @description Returns the value of tokens owned by `account`.
+   *
+   * @circuitInfo k=10, rows=310
    *
    * @dev Manually checks if `account` is a key in the map and returns 0 if it is not.
    *
@@ -167,6 +177,8 @@ module FungibleToken {
 
   /**
    * @description Moves a `value` amount of tokens from the caller's account to `to`.
+   *
+   * @circuitInfo k=11, rows=1173
    *
    * @notice Transfers to contract addresses are currently disallowed until contract-to-contract
    * interactions are supported in Compact. This restriction prevents assets from
@@ -191,6 +203,8 @@ module FungibleToken {
 
   /**
    * @description Unsafe variant of `transfer` which allows transfers to contract addresses.
+   *
+   * @circuitInfo k=11, rows=1170
    *
    * @warning Transfers to contract addresses are considered unsafe because contract-to-contract
    * calls are not currently supported. Tokens sent to a contract address may become irretrievable.
@@ -217,6 +231,8 @@ module FungibleToken {
    * @description Returns the remaining number of tokens that `spender` will be allowed to spend on behalf of `owner`
    * through `transferFrom`. This value changes when `approve` or `transferFrom` are called.
    *
+   * @circuitInfo k=10, rows=624
+   *
    * @dev Manually checks if `owner` and `spender` are keys in the map and returns 0 if they are not.
    *
    * Requirements:
@@ -242,6 +258,8 @@ module FungibleToken {
   /**
    * @description Sets a `value` amount of tokens as allowance of `spender` over the caller's tokens.
    *
+   * @circuitInfo k=10, rows=452
+   *
    * Requirements:
    *
    * - Contract is initialized.
@@ -262,6 +280,8 @@ module FungibleToken {
   /**
    * @description Moves `value` tokens from `from` to `to` using the allowance mechanism.
    * `value` is the deducted from the caller's allowance.
+   *
+   * @circuitInfo k=11, rows=1821
    *
    * @notice Transfers to contract addresses are currently disallowed until contract-to-contract
    * interactions are supported in Compact. This restriction prevents assets from
@@ -293,6 +313,8 @@ module FungibleToken {
 
   /**
    * @description Unsafe variant of `transferFrom` which allows transfers to contract addresses.
+   *
+   * @circuitInfo k=11, rows=1818
    *
    * @warning Transfers to contract addresses are considered unsafe because contract-to-contract
    * calls are not currently supported. Tokens sent to a contract address may become irretrievable.
@@ -329,6 +351,8 @@ module FungibleToken {
    * This circuit is equivalent to {transfer}, and can be used to
    * e.g. implement automatic token fees, slashing mechanisms, etc.
    *
+   * @circuitInfo k=11, rows=1818
+   *
    * @notice Transfers to contract addresses are currently disallowed until contract-to-contract
    * interactions are supported in Compact. This restriction prevents assets from
    * being inadvertently locked in contracts that cannot currently handle token receipt.
@@ -358,6 +382,8 @@ module FungibleToken {
 
   /**
    * @description Unsafe variant of `transferFrom` which allows transfers to contract addresses.
+   *
+   * @circuitInfo k=11, rows=1309
    *
    * @warning Transfers to contract addresses are considered unsafe because contract-to-contract
    * calls are not currently supported. Tokens sent to a contract address may become irretrievable.
@@ -390,6 +416,8 @@ module FungibleToken {
    * @description Transfers a `value` amount of tokens from `from` to `to`, or alternatively mints (or burns) if `from`
    * (or `to`) is the zero address.
    * @dev Checks for a mint overflow in order to output a more readable error message.
+   *
+   * @circuitInfo k=11, rows=1305
    *
    * Requirements:
    *
@@ -431,6 +459,8 @@ module FungibleToken {
    * @description Creates a `value` amount of tokens and assigns them to `account`,
    * by transferring it from the zero address. Relies on the `update` mechanism.
    *
+   * @circuitInfo k=10, rows=752
+   *
    * @notice Transfers to contract addresses are currently disallowed until contract-to-contract
    * interactions are supported in Compact. This restriction prevents assets from
    * being inadvertently locked in contracts that cannot currently handle token receipt.
@@ -456,6 +486,8 @@ module FungibleToken {
 
   /**
    * @description Unsafe variant of `_mint` which allows transfers to contract addresses.
+   *
+   * @circuitInfo k=10, rows=749
    *
    * @warning Transfers to contract addresses are considered unsafe because contract-to-contract
    * calls are not currently supported. Tokens sent to a contract address may become irretrievable.
@@ -483,6 +515,8 @@ module FungibleToken {
    * @description Destroys a `value` amount of tokens from `account`, lowering the total supply.
    * Relies on the `_update` mechanism.
    *
+   * @circuitInfo k=10, rows=773
+   *
    * Requirements:
    *
    * - Contract is initialized.
@@ -505,6 +539,9 @@ module FungibleToken {
   /**
    * @description Sets `value` as the allowance of `spender` over the `owner`'s tokens.
    * This circuit is equivalent to `approve`, and can be used to
+   *
+   * @circuitInfo k=10, rows=583
+   *
    * e.g. set automatic allowances for certain subsystems, etc.
    *
    * Requirements:
@@ -536,6 +573,8 @@ module FungibleToken {
   /**
    * @description Updates `owner`'s allowance for `spender` based on spent `value`.
    * Does not update the allowance value in case of infinite allowance.
+   *
+   * @circuitInfo k=10, rows=931
    *
    * Requirements:
    *

--- a/contracts/multiToken/src/MultiToken.compact
+++ b/contracts/multiToken/src/MultiToken.compact
@@ -116,6 +116,8 @@ module MultiToken {
    * Clients calling this function must replace the `\{id\}` substring with the
    * actual token type ID.
    *
+   * @circuitInfo k=10, rows=90
+   *
    * Requirements:
    *
    * - Contract is initialized.
@@ -131,6 +133,8 @@ module MultiToken {
 
   /**
    * @description Returns the amount of `id` tokens owned by `account`.
+   *
+   * @circuitInfo k=10, rows=439
    *
    * Requirements:
    *
@@ -151,6 +155,8 @@ module MultiToken {
 
   /**
    * @description Enables or disables approval for `operator` to manage all of the caller's assets.
+   *
+   * @circuitInfo k=10, rows=404
    *
    * Requirements:
    *
@@ -173,6 +179,8 @@ module MultiToken {
 
   /**
    * @description Queries if `operator` is an authorized operator for `owner`.
+   *
+   * @circuitInfo k=10, rows=619
    *
    * Requirements:
    *
@@ -198,6 +206,8 @@ module MultiToken {
   /**
    * @description Transfers ownership of `value` amount of `id` tokens from `from` to `to`.
    * The caller must be `from` or approved to transfer on their behalf.
+   *
+   * @circuitInfo k=11, rows=1882
    *
    * @notice Transfers to contract addresses are currently disallowed until contract-to-contract
    * interactions are supported in Compact. This restriction prevents assets from
@@ -236,6 +246,8 @@ module MultiToken {
    * Does not impose restrictions on the caller, making it suitable for composition
    * in higher-level contract logic.
    *
+   * @circuitInfo k=11, rows=1487
+   *
    * @notice Transfers to contract addresses are currently disallowed until contract-to-contract
    * interactions are supported in Compact. This restriction prevents assets from
    * being inadvertently locked in contracts that cannot currently handle token receipt.
@@ -267,6 +279,8 @@ module MultiToken {
   /**
    * @description Transfers a value amount of tokens of type id from from to to.
    * This circuit will mint (or burn) if `from` (or `to`) is the zero address.
+   *
+   * @circuitInfo k=11, rows=1482
    *
    * Requirements:
    *
@@ -314,6 +328,8 @@ module MultiToken {
    * @description Unsafe variant of `transferFrom` which allows transfers to contract addresses.
    * The caller must be `from` or approved to transfer on their behalf.
    *
+   * @circuitInfo k=11, rows=1881
+   *
    * @warning Transfers to contract addresses are considered unsafe because contract-to-contract
    * calls are not currently supported. Tokens sent to a contract address may become irretrievable.
    * Once contract-to-contract calls are supported, this circuit may be deprecated.
@@ -355,6 +371,8 @@ module MultiToken {
    * Does not impose restrictions on the caller, making it suitable as a low-level
    * building block for advanced contract logic.
    *
+   * @circuitInfo k=11, rows=1486
+   *
    * @warning Transfers to contract addresses are considered unsafe because contract-to-contract
    * calls are not currently supported. Tokens sent to a contract address may become irretrievable.
    * Once contract-to-contract calls are supported, this circuit may be deprecated.
@@ -390,6 +408,8 @@ module MultiToken {
    * substitution mechanism defined in the MultiToken standard.
    * See https://eips.ethereum.org/EIPS/eip-1155#metadata.
    *
+   * @circuitInfo k=10, rows=39
+   *
    * @notice By this mechanism, any occurrence of the `\{id\}` substring in either the
    * URI or any of the values in the JSON file at said URI will be replaced by
    * clients with the token type ID.
@@ -415,6 +435,8 @@ module MultiToken {
   /**
    * @description Creates a `value` amount of tokens of type `token_id`, and assigns them to `to`.
    *
+   * @circuitInfo k=10, rows=912
+   *
    * @notice Transfers to contract addresses are currently disallowed until contract-to-contract
    * interactions are supported in Compact. This restriction prevents assets from
    * being inadvertently locked in contracts that cannot currently handle token receipt.
@@ -437,6 +459,8 @@ module MultiToken {
 
   /**
    * @description Unsafe variant of `_mint` which allows transfers to contract addresses.
+   *
+   * @circuitInfo k=10, rows=911
    *
    * @warning Transfers to contract addresses are considered unsafe because contract-to-contract
    * calls are not currently supported. Tokens sent to a contract address may become irretrievable.
@@ -462,6 +486,8 @@ module MultiToken {
   /**
    * @description Destroys a `value` amount of tokens of type `token_id` from `from`.
    *
+   * @circuitInfo k=10, rows=688
+   *
    * Requirements:
    *
    * - Contract is initialized.
@@ -482,6 +508,9 @@ module MultiToken {
 
   /**
    * @description Enables or disables approval for `operator` to manage all of the caller's assets.
+   *
+   * @circuitInfo k=10, rows=518
+   *
    * @notice This circuit does not check for access permissions but can be useful as a building block
    * for more complex contract logic.
    *

--- a/contracts/ownable/src/Ownable.compact
+++ b/contracts/ownable/src/Ownable.compact
@@ -59,6 +59,8 @@ module Ownable {
   /**
    * @description Returns the current contract owner.
    *
+   * @circuitInfo k=10, rows=84
+   *
    * Requirements:
    *
    * - Contract is initialized.
@@ -72,6 +74,8 @@ module Ownable {
 
   /**
    * @description Transfers ownership of the contract to `newOwner`.
+   *
+   * @circuitInfo k=10, rows=219
    *
    * @notice Ownership transfers to contract addresses are currently disallowed until contract-to-contract
    * interactions are supported in Compact.
@@ -95,6 +99,8 @@ module Ownable {
 
   /**
    * @description Unsafe variant of `transferOwnership`.
+   *
+   * @circuitInfo k=10, rows=335
    *
    * @warning Ownership transfers to contract addresses are considered unsafe because contract-to-contract
    * calls are not currently supported.
@@ -122,6 +128,8 @@ module Ownable {
    * It will not be possible to call `assertOnlyOnwer` circuits anymore.
    * Can only be called by the current owner.
    *
+   * @circuitInfo k=10, rows=124
+   *
    * Requirements:
    *
    * - Contract is initialized.
@@ -139,6 +147,8 @@ module Ownable {
    * @description Throws if called by any account other than the owner.
    * Use this to restrict access of specific circuits to the owner.
    *
+   * @circuitInfo k=10, rows=115
+   *
    * Requirements:
    *
    * - Contract is initialized.
@@ -155,6 +165,8 @@ module Ownable {
   /**
    * @description Transfers ownership of the contract to `newOwner` without
    * enforcing permission checks on the caller.
+   *
+   * @circuitInfo k=10, rows=219
    *
    * @notice Ownership transfers to contract addresses are currently disallowed until contract-to-contract
    * interactions are supported in Compact.
@@ -176,6 +188,8 @@ module Ownable {
 
   /**
    * @description Unsafe variant of `_transferOwnership`.
+   *
+   * @circuitInfo k=10, rows=216
    *
    * @warning Ownership transfers to contract addresses are considered unsafe because contract-to-contract
    * calls are not currently supported.

--- a/contracts/utils/src/Initializable.compact
+++ b/contracts/utils/src/Initializable.compact
@@ -14,6 +14,8 @@ module Initializable {
   /**
    * @description Initializes the state thus ensuring the calling circuit can only be called once.
    *
+   * @circuitInfo k=10, rows=38
+   *
    * Requirements:
    *
    * - Contract must not be initialized.
@@ -28,6 +30,8 @@ module Initializable {
   /**
    * @description Asserts that the contract has been initialized, throwing an error if not.
    *
+   * @circuitInfo k=10, rows=31
+   *
    * Requirements:
    *
    * - Contract must be initialized.
@@ -40,6 +44,8 @@ module Initializable {
 
   /**
    * @description Asserts that the contract has not been initialized, throwing an error if it has.
+   *
+   * @circuitInfo k=10, rows=35
    *
    * Requirements:
    *

--- a/contracts/utils/src/Pausable.compact
+++ b/contracts/utils/src/Pausable.compact
@@ -16,6 +16,8 @@ module Pausable {
   /**
    * @description Returns true if the contract is paused, and false otherwise.
    *
+   * @circuitInfo k=10, rows=32
+   *
    * @return {Boolean} True if paused.
    */
   export circuit isPaused(): Boolean {
@@ -24,6 +26,8 @@ module Pausable {
 
   /**
    * @description Makes a circuit only callable when the contract is paused.
+   *
+   * @circuitInfo k=10, rows=31
    *
    * Requirements:
    *
@@ -38,6 +42,8 @@ module Pausable {
   /**
    * @description Makes a circuit only callable when the contract is not paused.
    *
+   * @circuitInfo k=10, rows=35
+   *
    * Requirements:
    *
    * - Contract must not be paused.
@@ -50,6 +56,8 @@ module Pausable {
 
   /**
    * @description Triggers a stopped state.
+   *
+   * @circuitInfo k=10, rows=38
    *
    * Requirements:
    *
@@ -64,6 +72,8 @@ module Pausable {
 
   /**
    * @description Lifts the pause on the contract.
+   *
+   * @circuitInfo k=10, rows=34
    *
    * Requirements:
    *

--- a/docs/modules/ROOT/pages/api/accessControl.adoc
+++ b/docs/modules/ROOT/pages/api/accessControl.adoc
@@ -67,13 +67,17 @@ import "./node_modules/@openzeppelin-compact/access-control/src/AccessControl" p
 
 [.contract-item]
 [[AccessControl-hasRole]]
-==== `[.contract-item-name]#++hasRole++#++(roleId: Bytes<32>, account: Either<ZswapCoinPublicKey, ContractAddress>) → Boolean++` [.item-kind]#circuit#
+==== `[.contract-item-name]#++hasRole++#++(roleId: Bytes<32>, account: Either<ZswapCoinPublicKey, ContractAddress>) → Boolean++`  [.item-kind]#circuit#
+
+k=10, rows=487
 
 Returns `true` if `account` has been granted `roleId`.
 
 [.contract-item]
 [[AccessControl-assertOnlyRole]]
 ==== `[.contract-item-name]#++assertOnlyRole++#++(roleId: Bytes<32>) → []++` [.item-kind]#circuit#
+
+k=10, rows=345
 
 Reverts if caller is missing `roleId`.
 
@@ -86,6 +90,8 @@ Requirements:
 [[AccessControl-_checkRole]]
 ==== `[.contract-item-name]#++_checkRole++#++(roleId: Bytes<32>, account: Either<ZswapCoinPublicKey, ContractAddress>) → []++` [.item-kind]#circuit#
 
+k=10, rows=467
+
 Reverts if `account` is missing `roleId`.
 
 Requirements:
@@ -96,6 +102,8 @@ Requirements:
 [[AccessControl-getRoleAdmin]]
 ==== `[.contract-item-name]#++getRoleAdmin++#++(roleId: Bytes<32>) → Bytes<32>++` [.item-kind]#circuit#
 
+k=10, rows=207
+
 Returns the admin role that controls `roleId` or a byte array with all zero bytes if `roleId` doesn't exist. See {grantRole} and {revokeRole}.
 
 To change a role's admin use <<AccessControl-_setRoleAdmin, _setRoleAdmin>>.
@@ -103,6 +111,8 @@ To change a role's admin use <<AccessControl-_setRoleAdmin, _setRoleAdmin>>.
 [.contract-item]
 [[AccessControl-grantRole]]
 ==== `[.contract-item-name]#++grantRole++#++(roleId: Bytes<32>, account: Either<ZswapCoinPublicKey, ContractAddress>) → []++` [.item-kind]#circuit#
+
+k=10, rows=994
 
 Grants `roleId` to `account`.
 
@@ -118,6 +128,8 @@ Requirements:
 [[AccessControl-revokeRole]]
 ==== `[.contract-item-name]#++revokeRole++#++(roleId: Bytes<32>, account: Either<ZswapCoinPublicKey, ContractAddress>) → []++` [.item-kind]#circuit#
 
+k=10, rows=827
+
 Revokes `roleId` from `account`.
 
 Requirements:
@@ -127,6 +139,8 @@ Requirements:
 [.contract-item]
 [[AccessControl-renounceRole]]
 ==== `[.contract-item-name]#++renounceRole++#++(roleId: Bytes<32>, callerConfirmation: Either<ZswapCoinPublicKey, ContractAddress>) → []++` [.item-kind]#circuit#
+
+k=10, rows=640
 
 Revokes `roleId` from the calling account.
 
@@ -144,6 +158,8 @@ Requirements:
 [.contract-item]
 [[AccessControl-_setRoleAdmin]]
 ==== `[.contract-item-name]#++_setRoleAdmin++#++(roleId: Bytes<32>, adminRole: Bytes<32>) → []++` [.item-kind]#circuit#
+
+k=10, rows=209
 
 Sets `adminRole` as ``roleId``'s admin role.
 
@@ -166,6 +182,8 @@ Requirements:
 [[AccessControl-_unsafeGrantRole]]
 ==== `[.contract-item-name]#++_unsafeGrantRole++#++(roleId: Bytes<32>, account: Either<ZswapCoinPublicKey, ContractAddress>) → Boolean++` [.item-kind]#circuit#
 
+k=10, rows=733
+
 Unsafe variant of <<AccessControl-_grantRole,_grantRole>>.
 
 WARNING: Granting roles to contract addresses is considered unsafe because contract-to-contract calls are not currently supported.
@@ -175,6 +193,8 @@ Once contract-to-contract calls are supported, this circuit may be deprecated.
 [.contract-item]
 [[AccessControl-_revokeRole]]
 ==== `[.contract-item-name]#++_revokeRole++#++(roleId: Bytes<32>, account: Either<ZswapCoinPublicKey, ContractAddress>) → Boolean++` [.item-kind]#circuit#
+
+k=10, rows=563
 
 Attempts to revoke `roleId` from `account` and returns a boolean indicating if `roleId` was revoked.
 

--- a/docs/modules/ROOT/pages/api/fungibleToken.adoc
+++ b/docs/modules/ROOT/pages/api/fungibleToken.adoc
@@ -61,6 +61,8 @@ Requirements:
 [[FungibleTokenModule-name]]
 ==== `[.contract-item-name]#++name++#++() → Opaque<"string">++` [.item-kind]#circuit#
 
+k=10, rows=37
+
 Returns the token name.
 
 Requirements:
@@ -71,6 +73,8 @@ Requirements:
 [.contract-item]
 [[FungibleTokenModule-symbol]]
 ==== `[.contract-item-name]#++symbol++#++() → Opaque<"string">++` [.item-kind]#circuit#
+
+k=10, rows=37
 
 Returns the symbol of the token.
 
@@ -83,6 +87,8 @@ Requirements:
 [[FungibleTokenModule-decimals]]
 ==== `[.contract-item-name]#++decimals++#++() → Uint<8>++` [.item-kind]#circuit#
 
+k=10, rows=36
+
 Returns the number of decimals used to get its user representation.
 
 Requirements:
@@ -93,6 +99,8 @@ Requirements:
 [.contract-item]
 [[FungibleTokenModule-totalSupply]]
 ==== `[.contract-item-name]#++totalSupply++#++() → Uint<128>++` [.item-kind]#circuit#
+
+k=10, rows=36
 
 Returns the value of tokens in existence.
 
@@ -105,6 +113,8 @@ Requirements:
 [[FungibleTokenModule-balanceOf]]
 ==== `[.contract-item-name]#++balanceOf++#++(account: Either<ZswapCoinPublicKey, ContractAddress>) → Uint<128>++` [.item-kind]#circuit#
 
+k=10, rows=310
+
 Returns the value of tokens owned by `account`.
 
 Requirements:
@@ -115,6 +125,8 @@ Requirements:
 [.contract-item]
 [[FungibleTokenModule-transfer]]
 ==== `[.contract-item-name]#++transfer++#++(to: Either<ZswapCoinPublicKey, ContractAddress>, value: Uint<128>) → Boolean++` [.item-kind]#circuit#
+
+k=11, rows=1173
 
 Moves a `value` amount of tokens from the caller's account to `to`.
 
@@ -132,6 +144,8 @@ Requirements:
 [[FungibleTokenModule-_unsafeTransfer]]
 ==== `[.contract-item-name]#++_unsafeTransfer++#++(to: Either<ZswapCoinPublicKey, ContractAddress>, value: Uint<128>) → Boolean++` [.item-kind]#circuit#
 
+k=11, rows=1170
+
 Unsafe variant of <<FungibleTokenModule-transfer,transfer>> which allows transfers to contract addresses.
 
 WARNING: Transfers to contract addresses are considered unsafe because contract-to-contract calls are not currently supported. Tokens sent to a contract address may become irretrievable.
@@ -147,6 +161,8 @@ Requirements:
 [[FungibleTokenModule-allowance]]
 ==== `[.contract-item-name]#++allowance++#++(owner: Either<ZswapCoinPublicKey, ContractAddress>, spender: Either<ZswapCoinPublicKey, ContractAddress>) → Uint<128>++` [.item-kind]#circuit#
 
+k=10, rows=624
+
 Returns the remaining number of tokens that `spender` will be allowed to spend on behalf of `owner` through <<FungibleTokenModule-transferFrom,transferFrom>>.
 This value changes when <<FungibleTokenModule-approve,approve>> or <<FungibleTokenModule-transferFrom,transferFrom>> are called.
 
@@ -158,6 +174,8 @@ Requirements:
 [[FungibleTokenModule-approve]]
 ==== `[.contract-item-name]#++approve++#++(spender: Either<ZswapCoinPublicKey, ContractAddress>, value: Uint<128>) → Boolean++` [.item-kind]#circuit#
 
+k=10, rows=452
+
 Sets a `value` amount of tokens as allowance of `spender` over the caller's tokens.
 
 Requirements:
@@ -168,6 +186,8 @@ Requirements:
 [.contract-item]
 [[FungibleTokenModule-transferFrom]]
 ==== `[.contract-item-name]#++transferFrom++#++(from: Either<ZswapCoinPublicKey, ContractAddress>, to: Either<ZswapCoinPublicKey, ContractAddress>, value: Uint<128>) → Boolean++` [.item-kind]#circuit#
+
+k=11, rows=1821
 
 Moves `value` tokens from `from` to `to` using the allowance mechanism.
 `value` is the deducted from the caller's allowance.
@@ -188,6 +208,8 @@ Requirements:
 [[FungibleTokenModule-_unsafeTransferFrom]]
 ==== `[.contract-item-name]#++_unsafeTransferFrom++#++(from: Either<ZswapCoinPublicKey, ContractAddress>, to: Either<ZswapCoinPublicKey, ContractAddress>, value: Uint<128>) → Boolean++` [.item-kind]#circuit#
 
+k=11, rows=1818
+
 Unsafe variant of <<FungibleTokenModule-transferFrom,transferFrom>> which allows transfers to contract addresses.
 
 WARNING: Transfers to contract addresses are considered unsafe because contract-to-contract calls are not currently supported.
@@ -205,6 +227,8 @@ Requirements:
 [.contract-item]
 [[FungibleTokenModule-_transfer]]
 ==== `[.contract-item-name]#++_transfer++#++(from: Either<ZswapCoinPublicKey, ContractAddress>, to: Either<ZswapCoinPublicKey, ContractAddress>, value: Uint<128>) → []++` [.item-kind]#circuit#
+
+k=11, rows=1312
 
 Moves a `value` amount of tokens from `from` to `to`.
 This circuit is equivalent to <<FungibleTokenModule-transfer,transfer>>, and can be used to e.g.
@@ -225,6 +249,8 @@ Requirements:
 [[FungibleTokenModule-_unsafeUncheckedTransfer]]
 ==== `[.contract-item-name]#++_unsafeUncheckedTransfer++#++(from: Either<ZswapCoinPublicKey, ContractAddress>, to: Either<ZswapCoinPublicKey, ContractAddress>, value: Uint<128>) → []++` [.item-kind]#circuit#
 
+k=11, rows=1309
+
 Unsafe variant of <<FungibleTokenModule-_transfer,_transfer>> which allows transfers to contract addresses.
 
 WARNING: Transfers to contract addresses are considered unsafe because contract-to-contract calls are not currently supported. Tokens sent to a contract address may become irretrievable.
@@ -240,6 +266,8 @@ Requirements:
 [[FungibleTokenModule-_update]]
 ==== `[.contract-item-name]#++_update++#++(from: Either<ZswapCoinPublicKey, ContractAddress>, to: Either<ZswapCoinPublicKey, ContractAddress>, value: Uint<128>) → []++` [.item-kind]#circuit#
 
+k=11, rows=1305
+
 Transfers a `value` amount of tokens from `from` to `to`,
 or alternatively mints (or burns) if `from` (or `to`) is the zero address.
 
@@ -250,6 +278,8 @@ Requirements:
 [.contract-item]
 [[FungibleTokenModule-_mint]]
 ==== `[.contract-item-name]#++_mint++#++(account: Either<ZswapCoinPublicKey, ContractAddress>, value: Uint<128>) → []++` [.item-kind]#circuit#
+
+k=10, rows=752
 
 Creates a `value` amount of tokens and assigns them to `account`, by transferring it from the zero address.
 Relies on the `update` mechanism.
@@ -263,6 +293,8 @@ Requirements:
 [.contract-item]
 [[FungibleTokenModule-_unsafeMint]]
 ==== `[.contract-item-name]#++_unsafeMint++#++(account: Either<ZswapCoinPublicKey, ContractAddress>, value: Uint<128>) → []++` [.item-kind]#circuit#
+
+k=10, rows=749
 
 Unsafe variant of <<FungibleTokenModule-_mint,_mint>> which allows transfers to contract addresses.
 
@@ -279,6 +311,8 @@ Requirements:
 [[FungibleTokenModule-_burn]]
 ==== `[.contract-item-name]#++_burn++#++(account: Either<ZswapCoinPublicKey, ContractAddress>, value: Uint<128>) → []++` [.item-kind]#circuit#
 
+k=10, rows=773
+
 Destroys a `value` amount of tokens from `account`, lowering the total supply.
 Relies on the `_update` mechanism.
 
@@ -292,6 +326,8 @@ Requirements:
 [[FungibleTokenModule-_approve]]
 ==== `[.contract-item-name]#++_approve++#++(owner: Either<ZswapCoinPublicKey, ContractAddress>, spender: Either<ZswapCoinPublicKey, ContractAddress>, value: Uint<128>) → []++` [.item-kind]#circuit#
 
+k=10, rows=583
+
 Sets `value` as the allowance of `spender` over the ``owner``'s tokens.
 This circuit is equivalent to `approve`, and can be used to e.g. set automatic allowances for certain subsystems, etc.
 
@@ -304,6 +340,8 @@ Requirements:
 [.contract-item]
 [[FungibleTokenModule-_spendAllowance]]
 ==== `[.contract-item-name]#++_spendAllowance++#++(owner: Either<ZswapCoinPublicKey, ContractAddress>, spender: Either<ZswapCoinPublicKey, ContractAddress>, value: Uint<128>) → []++` [.item-kind]#circuit#
+
+k=10, rows=931
 
 Updates ``owner``'s allowance for `spender` based on spent `value`.
 Does not update the allowance value in case of infinite allowance.

--- a/docs/modules/ROOT/pages/api/multitoken.adoc
+++ b/docs/modules/ROOT/pages/api/multitoken.adoc
@@ -58,6 +58,8 @@ Requirements:
 [[MultiTokenModule-uri]]
 ==== `[.contract-item-name]#++uri++#++(id: Uint<128>) → Opaque<"string">++` [.item-kind]#circuit#
 
+k=10, rows=90
+
 This implementation returns the same URI for *all* token types.
 It relies on the token type ID substitution mechanism defined in the EIP: {erc1155-metadata}.
 Clients calling this function must replace the `\{id\}` substring with the actual token type ID.
@@ -70,6 +72,8 @@ Requirements:
 [[MultiTokenModule-balanceOf]]
 ==== `[.contract-item-name]#++balanceOf++#++(account: Either<ZswapCoinPublicKey, ContractAddress>, id: Uint<128>) → Uint<128>++` [.item-kind]#circuit#
 
+k=10, rows=439
+
 Returns the amount of `id` tokens owned by `account`.
 
 Requirements:
@@ -79,6 +83,8 @@ Requirements:
 [.contract-item]
 [[MultiTokenModule-setApprovalForAll]]
 ==== `[.contract-item-name]#++setApprovalForAll++#++(operator: Either<ZswapCoinPublicKey, ContractAddress>, approved: Boolean) → []++` [.item-kind]#circuit#
+
+k=10, rows=404
 
 Enables or disables approval for `operator` to manage all of the caller's assets.
 
@@ -91,6 +97,8 @@ Requirements:
 [[MultiTokenModule-isApprovedForAll]]
 ==== `[.contract-item-name]#++balanceOf++#++(account: Either<ZswapCoinPublicKey, ContractAddress>, operator: Either<ZswapCoinPublicKey, ContractAddress>) → Boolean++` [.item-kind]#circuit#
 
+k=10, rows=619
+
 Queries if `operator` is an authorized operator for `owner`.
 
 Requirements:
@@ -100,6 +108,8 @@ Requirements:
 [.contract-item]
 [[MultiTokenModule-transferFrom]]
 ==== `[.contract-item-name]#++transferFrom++#++(from: Either<ZswapCoinPublicKey, ContractAddress>, to: Either<ZswapCoinPublicKey, ContractAddress>, id: Uint<128>, value: Uint<128>) → []++` [.item-kind]#circuit#
+
+k=11, rows=1882
 
 Transfers ownership of `value` amount of `id` tokens from `from` to `to`.
 The caller must be `from` or approved to transfer on their behalf.
@@ -120,6 +130,8 @@ Requirements:
 [[MultiTokenModule-_transfer]]
 ==== `[.contract-item-name]#++_transfer++#++(from: Either<ZswapCoinPublicKey, ContractAddress>, to: Either<ZswapCoinPublicKey, ContractAddress>, id: Uint<128>, value: Uint<128>)++` [.item-kind]#circuit#
 
+k=11, rows=1487
+
 Transfers ownership of `value` amount of `id` tokens from `from` to `to`.
 Does not impose restrictions on the caller, making it suitable for composition in higher-level contract logic.
 
@@ -138,6 +150,8 @@ Requirements:
 [[MultiTokenModule-_update]]
 ==== `[.contract-item-name]#++_update++#++(from: Either<ZswapCoinPublicKey, ContractAddress>, to: Either<ZswapCoinPublicKey, ContractAddress>, id: Uint<128>, value: Uint<128>)++` [.item-kind]#internal#
 
+k=11, rows=1482
+
 Transfers a value amount of tokens of type id from from to to.
 This circuit will mint (or burn) if `from` (or `to`) is the zero address.
 
@@ -149,6 +163,8 @@ Requirements:
 [.contract-item]
 [[MultiTokenModule-_unsafeTransferFrom]]
 ==== `[.contract-item-name]#++_unsafeTransferFrom++#++(from: Either<ZswapCoinPublicKey, ContractAddress>, to: Either<ZswapCoinPublicKey, ContractAddress>, id: Uint<128>, value: Uint<128>) → []++` [.item-kind]#circuit#
+
+k=11, rows=1881
 
 Unsafe variant of <<MultiTokenModule-transferFrom,transferFrom>> which allows transfers to contract addresses.
 The caller must be `from` or approved to transfer on their behalf.
@@ -168,6 +184,8 @@ Requirements:
 [[MultiTokenModule-_unsafeTransfer]]
 ==== `[.contract-item-name]#++_unsafeTransfer++#++(from: Either<ZswapCoinPublicKey, ContractAddress>, to: Either<ZswapCoinPublicKey, ContractAddress>, id: Uint<128>, value: Uint<128>) → []++` [.item-kind]#circuit#
 
+k=11, rows=1486
+
 Unsafe variant of <<MultiTokenModule-_transfer,_transfer>> which allows transfers to contract addresses.
 Does not impose restrictions on the caller, making it suitable as a low-level building block for advanced contract logic.
 
@@ -184,6 +202,8 @@ Requirements:
 [.contract-item]
 [[MultiTokenModule-_setURI]]
 ==== `[.contract-item-name]#++_setURI++#++(newURI: Opaque<"string">) → []++` [.item-kind]#circuit#
+
+k=10, rows=39
 
 Sets a new URI for all token types, by relying on the token type ID substitution mechanism defined in the MultiToken standard.
 See https://eips.ethereum.org/EIPS/eip-1155#metadata.
@@ -202,6 +222,8 @@ Requirements:
 [[MultiTokenModule-_mint]]
 ==== `[.contract-item-name]#++_mint++#++(to: Either<ZswapCoinPublicKey, ContractAddress>, id: Uint<128>, value: Uint<128>) → []++` [.item-kind]#circuit#
 
+k=10, rows=912
+
 Creates a `value` amount of tokens of type `token_id`, and assigns them to `to`.
 
 NOTE: Transfers to contract addresses are currently disallowed until contract-to-contract interactions are supported in Compact.
@@ -216,6 +238,8 @@ Requirements:
 [.contract-item]
 [[MultiTokenModule-_unsafeMint]]
 ==== `[.contract-item-name]#++_unsafeMint++#++(to: Either<ZswapCoinPublicKey, ContractAddress>, id: Uint<128>, value: Uint<128>) → []++` [.item-kind]#circuit#
+
+k=10, rows=911
 
 Unsafe variant of `_mint` which allows transfers to contract addresses.
 
@@ -232,6 +256,8 @@ Requirements:
 [[MultiTokenModule-_burn]]
 ==== `[.contract-item-name]#++_burn++#++(from: Either<ZswapCoinPublicKey, ContractAddress>, id: Uint<128>, value: Uint<128>) → []++` [.item-kind]#circuit#
 
+k=10, rows=688
+
 Destroys a `value` amount of tokens of type `token_id` from `from`.
 
 Requirements:
@@ -243,6 +269,8 @@ Requirements:
 [.contract-item]
 [[MultiTokenModule-_setApprovalForAll]]
 ==== `[.contract-item-name]#++_setApprovalForAll++#++(owner: Either<ZswapCoinPublicKey, ContractAddress>, operator: Either<ZswapCoinPublicKey, ContractAddress>, approved: Boolean) → []++` [.item-kind]#circuit#
+
+k=10, rows=518
 
 Enables or disables approval for `operator` to manage all of the caller's assets.
 This circuit does not check for access permissions but can be useful as a building block for more complex contract logic.

--- a/docs/modules/ROOT/pages/api/nonFungibleToken.adoc
+++ b/docs/modules/ROOT/pages/api/nonFungibleToken.adoc
@@ -67,6 +67,8 @@ Requirements:
 [[NonFungibleTokenModule-balanceOf]]
 ==== `[.contract-item-name]#++balanceOf++#++(owner: Either<ZswapCoinPublicKey, ContractAddress>) → Uint<128>++` [.item-kind]#circuit#
 
+k=10, rows=309
+
 Returns the number of tokens in ``owner``'s account.
 
 Requirements:
@@ -76,6 +78,8 @@ Requirements:
 [.contract-item]
 [[NonFungibleTokenModule-ownerOf]]
 ==== `[.contract-item-name]#++ownerOf++#++(tokenId: Uint<128>) → Either<ZswapCoinPublicKey, ContractAddress>++` [.item-kind]#circuit#
+
+k=10, rows=290
 
 Returns the owner of the `tokenId` token.
 
@@ -88,6 +92,8 @@ Requirements:
 [[NonFungibleTokenModule-name]]
 ==== `[.contract-item-name]#++name++#++() → Opaque<"string">++` [.item-kind]#circuit#
 
+k=10, rows=36
+
 Returns the token name.
 
 Requirements:
@@ -98,6 +104,8 @@ Requirements:
 [[NonFungibleTokenModule-symbol]]
 ==== `[.contract-item-name]#++symbol++#++() → Opaque<"string">++` [.item-kind]#circuit#
 
+k=10, rows=36
+
 Returns the symbol of the token.
 
 Requirements:
@@ -107,6 +115,8 @@ Requirements:
 [.contract-item]
 [[NonFungibleTokenModule-tokenURI]]
 ==== `[.contract-item-name]#++tokenURI++#++(tokenId: Uint<128>) → Opaque<"string">++` [.item-kind]#circuit#
+
+k=10, rows=296
 
 Returns the token URI for the given `tokenId`.
 Returns an empty string if a tokenURI does not exist.
@@ -124,6 +134,8 @@ It's up to the implementation to decide on how to handle this.
 [[NonFungibleTokenModule-_setTokenURI]]
 ==== `[.contract-item-name]#++_setTokenURI++#++(tokenId: Uint<128>, tokenURI: Opaque<"string">) → []++` [.item-kind]#circuit#
 
+k=10, rows=253
+
 Sets the the URI as `tokenURI` for the given `tokenId`.
 
 Requirements:
@@ -136,6 +148,8 @@ NOTE: The URI for a given NFT is usually set when the NFT is minted.
 [.contract-item]
 [[NonFungibleTokenModule-approve]]
 ==== `[.contract-item-name]#++approve++#++(to: Either<ZswapCoinPublicKey, ContractAddress>, tokenId: Uint<128>) → []++` [.item-kind]#circuit#
+
+k=10, rows=966
 
 Gives permission to `to` to transfer `tokenId` token to another account.
 The approval is cleared when the token is transferred.
@@ -153,6 +167,8 @@ Requirements:
 [[NonFungibleTokenModule-getApproved]]
 ==== `[.contract-item-name]#++getApproved++#++(tokenId: Uint<128>) → Either<ZswapCoinPublicKey, ContractAddress>++` [.item-kind]#circuit#
 
+k=10, rows=409
+
 Returns the account approved for `tokenId` token.
 
 Requirements:
@@ -163,6 +179,8 @@ Requirements:
 [.contract-item]
 [[NonFungibleTokenModule-setApprovalForAll]]
 ==== `[.contract-item-name]#++setApprovalForAll++#++(operator: Either<ZswapCoinPublicKey, ContractAddress>, approved: Boolean) → []++` [.item-kind]#circuit#
+
+k=10, rows=409
 
 Approve or remove `operator` as an operator for the caller.
 Operators can call <<NonFungibleTokenModule-transferFrom, transferFrom>> for any token owned by the caller.
@@ -176,6 +194,8 @@ Requirements:
 [[NonFungibleTokenModule-isApprovedForAll]]
 ==== `[.contract-item-name]#++isApprovedForAll++#++(owner: Either<ZswapCoinPublicKey, ContractAddress>, operator: Either<ZswapCoinPublicKey, ContractAddress>) → Boolean++` [.item-kind]#circuit#
 
+k=10, rows=621
+
 Returns if the `operator` is allowed to manage all of the assets of `owner`.
 
 Requirements:
@@ -185,6 +205,8 @@ Requirements:
 [.contract-item]
 [[NonFungibleTokenModule-transferFrom]]
 ==== `[.contract-item-name]#++transferFrom++#++(from: Either<ZswapCoinPublicKey, ContractAddress>, to: Either<ZswapCoinPublicKey, ContractAddress>, tokenId: Uint<128>) → []++` [.item-kind]#circuit#
+
+k=11, rows=1966
 
 Transfers `tokenId` token from `from` to `to`.
 
@@ -204,6 +226,8 @@ Requirements:
 [[NonFungibleTokenModule-_unsafeTransferFrom]]
 ==== `[.contract-item-name]#++_unsafeTransferFrom++#++(from: Either<ZswapCoinPublicKey, ContractAddress>, to: Either<ZswapCoinPublicKey, ContractAddress>, tokenId: Uint<128>) → []++` [.item-kind]#circuit#
 
+k=11, rows=1963
+
 Unsafe variant of <<NonFungibleTokenModule-transferFrom,transferFrom>> which allows transfers to contract addresses.
 
 WARNING: Transfers to contract addresses are considered unsafe because contract-to-contract calls are not currently supported.
@@ -222,6 +246,8 @@ Requirements:
 [[NonFungibleTokenModule-_ownerOf]]
 ==== `[.contract-item-name]#++_ownerOf++#++(tokenId: Uint<128>) → Either<ZswapCoinPublicKey, ContractAddress>++` [.item-kind]#circuit#
 
+k=10, rows=253
+
 Returns the owner of the `tokenId`. Does NOT revert if token doesn't exist
 
 Requirements:
@@ -232,6 +258,8 @@ Requirements:
 [[NonFungibleTokenModule-_getApproved]]
 ==== `[.contract-item-name]#++_getApproved++#++(tokenId: Uint<128>) → Either<ZswapCoinPublicKey, ContractAddress>++` [.item-kind]#circuit#
 
+k=10, rows=253
+
 Returns the approved address for `tokenId`. Returns the zero address if `tokenId` is not minted.
 
 Requirements:
@@ -241,6 +269,8 @@ Requirements:
 [.contract-item]
 [[NonFungibleTokenModule-_isAuthorized]]
 ==== `[.contract-item-name]#++_isAuthorized++#++(owner: Either<ZswapCoinPublicKey, ContractAddress>, spender: Either<ZswapCoinPublicKey, ContractAddress>, tokenId: Uint<128> ) → Boolean++` [.item-kind]#circuit#
+
+k=11, rows=1098
 
 Returns whether `spender` is allowed to manage ``owner``'s tokens, or `tokenId` in particular (ignoring whether it is owned by `owner`).
 
@@ -253,6 +283,8 @@ WARNING: This function assumes that `owner` is the actual owner of `tokenId` and
 [.contract-item]
 [[NonFungibleTokenModule-_checkAuthorized]]
 ==== `[.contract-item-name]#++_checkAuthorized++#++(owner: Either<ZswapCoinPublicKey, ContractAddress>, spender: Either<ZswapCoinPublicKey, ContractAddress>, tokenId: Uint<128> ) → []++` [.item-kind]#circuit#
+
+k=11, rows=1121
 
 Checks if `spender` can operate on `tokenId`, assuming the provided `owner` is the actual owner.
 
@@ -267,6 +299,8 @@ WARNING: This function assumes that `owner` is the actual owner of `tokenId` and
 [[NonFungibleTokenModule-_update]]
 ==== `[.contract-item-name]#++_update++#++(to: Either<ZswapCoinPublicKey, ContractAddress>, tokenId: Uint<128>, auth: Either<ZswapCoinPublicKey, ContractAddress>) → Either<ZswapCoinPublicKey, ContractAddress>++` [.item-kind]#internal#
 
+k=12, rows=2049
+
 Transfers `tokenId` from its current owner to `to`, or alternatively mints (or burns) if the current owner (or `to`) is the zero address.
 Returns the owner of the `tokenId` before the update.
 
@@ -278,6 +312,8 @@ Requirements:
 [.contract-item]
 [[NonFungibleTokenModule-_mint]]
 ==== `[.contract-item-name]#++_mint++#++(to: Either<ZswapCoinPublicKey, ContractAddress>, tokenId: Uint<128>) → []++` [.item-kind]#circuit#
+
+k=10, rows=1013
 
 Mints `tokenId` and transfers it to `to`.
 
@@ -291,6 +327,8 @@ Requirements:
 [.contract-item]
 [[NonFungibleTokenModule-_unsafeMint]]
 ==== `[.contract-item-name]#++_unsafeMint++#++(account: Either<ZswapCoinPublicKey, ContractAddress>, value: Uint<128>) → []++` [.item-kind]#circuit#
+
+k=10, rows=1010
 
 Unsafe variant of <<NonFungibleTokenModule-_mint,_mint>> which allows transfers to contract addresses.
 
@@ -308,6 +346,8 @@ Once contract-to-contract calls are supported, this circuit may be deprecated.
 [[NonFungibleTokenModule-_burn]]
 ==== `[.contract-item-name]#++_burn++#++(tokenId: Uint<128>) → []++` [.item-kind]#circuit#
 
+k=10, rows=479
+
 Destroys `tokenId`.
 The approval is cleared when the token is burned.
 This circuit does not check if the sender is authorized to operate on the token.
@@ -320,6 +360,8 @@ Requirements:
 [.contract-item]
 [[NonFungibleTokenModule-_transfer]]
 ==== `[.contract-item-name]#++_transfer++#++(from: Either<ZswapCoinPublicKey, ContractAddress>, to: Either<ZswapCoinPublicKey, ContractAddress>, tokenId: Uint<128>) → []++` [.item-kind]#circuit#
+
+k=11, rows=1224
 
 Transfers `tokenId` from `from` to `to`. As opposed to <<NonFungibleTokenModule-transferFrom,transferFrom>>, this imposes no restrictions on `own_public_key()`.
 
@@ -336,6 +378,8 @@ Requirements:
 [.contract-item]
 [[NonFungibleTokenModule-_unsafeTransfer]]
 ==== `[.contract-item-name]#++_unsafeTransfer++#++(from: Either<ZswapCoinPublicKey, ContractAddress>, to: Either<ZswapCoinPublicKey, ContractAddress>, tokenId: Uint<128>) → []++` [.item-kind]#circuit#
+
+k=11, rows=1221
 
 Unsafe variant of <<NonFungibleTokenModule-_transfer,_transfer>> which allows transfers to contract addresses.
 
@@ -354,6 +398,8 @@ Requirements:
 [[NonFungibleTokenModule-_approve]]
 ==== `[.contract-item-name]#++_approve++#++(to: Either<ZswapCoinPublicKey, ContractAddress>, tokenId: Uint<128>, auth: Either<ZswapCoinPublicKey, ContractAddress>) → []++` [.item-kind]#circuit#
 
+k=11, rows=1109
+
 Approve `to` to operate on `tokenId`
 
 Requirements:
@@ -365,6 +411,8 @@ Requirements:
 [[NonFungibleTokenModule-_setApprovalForAll]]
 ==== `[.contract-item-name]#++_setApprovalForAll++#++(owner: Either<ZswapCoinPublicKey, ContractAddress>, operator: Either<ZswapCoinPublicKey, ContractAddress>, approved: Boolean) → []++` [.item-kind]#circuit#
 
+k=10, rows=524
+
 Approve `operator` to operate on all of `owner` tokens
 
 Requirements:
@@ -375,6 +423,8 @@ Requirements:
 [.contract-item]
 [[NonFungibleTokenModule-_requireOwned]]
 ==== `[.contract-item-name]#++_requireOwned++#++(tokenId: Uint<128>) →  Either<ZswapCoinPublicKey, ContractAddress>++` [.item-kind]#circuit#
+
+k=10, rows=288
 
 Reverts if the `tokenId` doesn't have a current owner (it hasn't been minted, or it has been burned).
 Returns the owner.

--- a/docs/modules/ROOT/pages/api/ownable.adoc
+++ b/docs/modules/ROOT/pages/api/ownable.adoc
@@ -50,6 +50,8 @@ Requirements:
 [[Ownable-owner]]
 ==== `[.contract-item-name]#++owner++#++() → Either<ZswapCoinPublicKey, ContractAddress>++` [.item-kind]#circuit#
 
+k=10, rows=84
+
 Returns the current contract owner.
 
 Requirements:
@@ -59,6 +61,8 @@ Requirements:
 [.contract-item]
 [[Ownable-transferOwnership]]
 ==== `[.contract-item-name]#++transferOwnership++#++(newOwner: Either<ZswapCoinPublicKey, ContractAddress>) → []++` [.item-kind]#circuit#
+
+k=10, rows=338
 
 Transfers ownership of the contract to `newOwner`.
 
@@ -76,6 +80,8 @@ Requirements:
 [[Ownable-_unsafeTransferOwnership]]
 ==== `[.contract-item-name]#++_unsafeTransferOwnership++#++(newOwner: Either<ZswapCoinPublicKey, ContractAddress>) → []++` [.item-kind]#circuit#
 
+k=10, rows=335
+
 Unsafe variant of <<Ownable-transferOwnership,transferOwnership>>.
 
 WARNING: Ownership transfers to contract addresses are considered unsafe because contract-to-contract calls are not currently supported.
@@ -92,6 +98,8 @@ Requirements:
 [[Ownable-renounceOwnership]]
 ==== `[.contract-item-name]#++renounceOwnership++#++() → []++` [.item-kind]#circuit#
 
+k=10, rows=124
+
 Leaves the contract without an owner.
 It will not be possible to call <<Ownable-assertOnlyOwner,assertOnlyOwner>> circuits anymore.
 Can only be called by the current owner.
@@ -105,6 +113,8 @@ Requirements:
 [[Ownable-assertOnlyOwner]]
 ==== `[.contract-item-name]#++assertOnlyOwner++#++() → []++` [.item-kind]#circuit#
 
+k=10, rows=115
+
 Throws if called by any account other than the owner.
 Use this to restrict access of specific circuits to the owner.
 
@@ -116,6 +126,8 @@ Requirements:
 [.contract-item]
 [[Ownable-_transferOwnership]]
 ==== `[.contract-item-name]#++_transferOwnership++#++(newOwner: Either<ZswapCoinPublicKey, ContractAddress>) → []++` [.item-kind]#circuit#
+
+k=10, rows=219
 
 Transfers ownership of the contract to a `newOwner` without enforcing permission checks on the caller.
 
@@ -130,6 +142,8 @@ Requirements:
 [.contract-item]
 [[Ownable-_unsafeUncheckedTransferOwnership]]
 ==== `[.contract-item-name]#++_unsafeUncheckedTransferOwnership++#++(newOwner: Either<ZswapCoinPublicKey, ContractAddress>) → []++` [.item-kind]#circuit#
+
+k=10, rows=216
 
 Unsafe variant of <<Ownable-_transferOwnership,_transferOwnership>>.
 

--- a/docs/modules/ROOT/pages/api/utils.adoc
+++ b/docs/modules/ROOT/pages/api/utils.adoc
@@ -32,6 +32,8 @@ import "./node_modules/@openzeppelin-compact/utils/src/Initializable" prefix Ini
 [[InitializableModule-initialize]]
 ==== `[.contract-item-name]#++initialize++#++() → []++` [.item-kind]#circuit#
 
+k=10, rows=38
+
 Initializes the state thus ensuring the calling circuit can only be called once.
 
 Requirements:
@@ -42,6 +44,8 @@ Requirements:
 [[InitializableModule-assertInitialized]]
 ==== `[.contract-item-name]#++assertInitialized++#++() → []++` [.item-kind]#circuit#
 
+k=10, rows=31
+
 Asserts that the contract has been initialized, throwing an error if not.
 
 Requirements:
@@ -51,6 +55,8 @@ Requirements:
 [.contract-item]
 [[InitializableModule-assertNotInitialized]]
 ==== `[.contract-item-name]#++assertNotInitialized++#++() → []++` [.item-kind]#circuit#
+
+k=10, rows=35
 
 Asserts that the contract has not been initialized, throwing an error if it has.
 

--- a/docs/modules/ROOT/pages/api/utils.adoc
+++ b/docs/modules/ROOT/pages/api/utils.adoc
@@ -91,11 +91,15 @@ import "./node_modules/@openzeppelin-compact/utils/src/Pausable" prefix Pausable
 [[PausableModule-isPaused]]
 ==== `[.contract-item-name]#++isPaused++#++() → Boolean++` [.item-kind]#circuit#
 
+k=10, rows=32
+
 Returns true if the contract is paused, and false otherwise.
 
 [.contract-item]
 [[PausableModule-assertPaused]]
 ==== `[.contract-item-name]#++assertPaused++#++() → []++` [.item-kind]#circuit#
+
+k=10, rows=31
 
 Makes a circuit only callable when the contract is paused.
 
@@ -107,6 +111,8 @@ Requirements:
 [[PausableModule-assertNotPaused]]
 ==== `[.contract-item-name]#++assertNotPaused++#++() → []++` [.item-kind]#circuit#
 
+k=10, rows=35
+
 Makes a circuit only callable when the contract is not paused.
 
 Requirements:
@@ -117,6 +123,8 @@ Requirements:
 [[PausableModule-_pause]]
 ==== `[.contract-item-name]#++_pause++#++() → []++` [.item-kind]#circuit#
 
+k=10, rows=38
+
 Triggers a stopped state.
 
 Requirements:
@@ -126,6 +134,8 @@ Requirements:
 [.contract-item]
 [[PausableModule-_unpause]]
 ==== `[.contract-item-name]#++_unpause++#++() → []++` [.item-kind]#circuit#
+
+k=10, rows=34
 
 Lifts the pause on the contract.
 

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -10,6 +10,23 @@ This library consists of modules to build custom smart contracts.
 
 WARNING: This repo contains highly experimental code. Expect rapid iteration. *Use at your own risk.*
 
+== ZK Circuit Primer
+
+Compact code is compiled into zero-knowledge circuits, which are mathematical representations of the contract's logic.
+These circuits are made up of arithmetic gates that enforce the rules and constraints defined in the Compact program.
+At a high level, we can think of ZK circuits as a magic puzzle board that proves we've done a series of steps correctly - like a recipe.
+The puzzle board is laid out in a grid like a giant sheet of graph paper with a certain number of rows.
+Each row is a space where you can write a step or rule that needs to be followed.
+
+The size of the board is called the **domain size** which we refer to as `k` in our documentation. It’s always a power of 2 (like 256, 512, 1024, etc.), because the math behind the scenes needs it that way.
+Now, just because our board has 1024 rows doesn’t mean we use all of them. Maybe our recipe takes only 563 steps, so we fill in 563 rows and leave the rest blank. These filled in rows are called **used rows**.
+So when we say "k = 10, rows = 563" in our API Reference documentation, that means "this circuit has a size of 2^10 = 1024 rows and only uses 563 rows".
+
+Why is this important? Well, when we're writing ZK circuits we want to make the size and number of gates (rules) as small as possible.
+The number of gates in a zero-knowledge circuit directly impacts both the prover time (how long it takes to generate a proof) and, to a lesser extent, the proof size and verifier time.
+Larger circuits with more gates require more computation to generate a proof, which can make proof generation slower and more resource-intensive.
+This is especially relevant for privacy-preserving blockchains like Midnight, where proof generation is often the most computationally expensive part of a transaction.
+
 == Installation
 
 Make sure you have {nvm} and {yarn} installed on your machine.

--- a/docs/modules/ROOT/pages/nonFungibleToken.adoc
+++ b/docs/modules/ROOT/pages/nonFungibleToken.adoc
@@ -44,7 +44,7 @@ WARNING: The `unsafe` circuits will eventually be deprecated after Compact suppo
 == Usage
 
 :extensibility-pattern: xref:extensibility.adoc#the_module_contract_pattern[Module/Contract Pattern]
-:nonfungible-mint: xref:/api/NonFungibleToken.adoc#NonFungibleTokenModule-_mint[_mint]
+:nonfungible-mint: xref:/api/nonFungibleToken.adoc#NonFungibleTokenModule-_mint[_mint]
 
 Import the NonFungibleToken module into the implementing contract.
 It's recommended to prefix the module with `NonFungibleToken_` to avoid circuit signature clashes.


### PR DESCRIPTION
## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

Fixes #181  <!-- Fill in with issue number -->

Adds `@circuitInfo` to methods with info on circuit domain size and rows used. Adds new section to Overview page explaining what ZK circuits are, how they're constructed and why size / rows used matters. 

## PR Checklist

- [x] I have read the [Contributing Guide](CONTRIBUTING.md)
- [ ] CI Workflows Are Passing

