### PR TITLE
Add ownable shielded

### DIFF
--- a/contracts/src/access/ZOwnablePK.compact
+++ b/contracts/src/access/ZOwnablePK.compact
@@ -1,0 +1,310 @@
+// SPDX-License-Identifier: MIT
+
+pragma language_version >= 0.16.0;
+
+/**
+ * @module ZOwnablePK
+ * @description A shielded, public key-derived Ownable module.
+ *
+ * `ZOwnablePK` provides a privacy-preserving access control mechanism
+ * for contracts with a single administrative user. Unlike traditional
+ * `Ownable` implementations that store or expose the owner's public key
+ * on-chain, this module stores only a commitment to a hashed identifier
+ * derived from the owner's public key and a secret nonce.
+ * For the strongest security guarantees, use an Air-Gapped Public Key.
+ *
+ * @notice This module explicitly supports commitments derived from public keys;
+ * however, it may be possible to use contract addresses when contract-to-contract
+ * calls become available. This will be revisited when it's known if/how witnesses
+ * are used from a contract address context.
+ *
+ * @dev Features:
+ * - Obfuscated owner identity: The owner's public key is never revealed on-chain.
+ * - Stateless verification: The contract never needs access to the full public key.
+ * - Built-in support for transfer and renounce functionality.
+ * - Instance-specific salts to prevent cross-contract correlation.
+ * - Deterministic hashing with `persistentHash` to support zero-knowledge verification.
+ *
+ * @dev Commitment structure:
+ * ```
+ * id = SHA256(pk, secretNonce)
+ * commitment = SHA256(id, instanceSalt, counter, "ZOwnablePK:shield:")
+ * ```
+ * The commitment changes on each transfer due to the incrementing `counter`,
+ * providing unlinkability across ownership changes.
+ *
+ * @dev Security Considerations:
+ * - The `secretNonce` must be kept private. Loss of the nonce prevents the
+ *   owner from proving ownership or transferring it.
+ * - Ownership validation is entirely circuit-based using witness-provided values.
+ * - The `_instanceSalt` is immutable and used to differentiate deployments.
+ *
+ * @notice Best used for single-admin contracts with privacy requirements.
+ * It is not designed for multi-owner or role-based access control.
+ */
+module ZOwnablePK {
+  import CompactStandardLibrary;
+  import "../security/Initializable" prefix Initializable_;
+
+  /**
+   * @ledger _ownerCommitment
+   * @description Stores the current hashed commitment representing the owner.
+   * This commitment is derived from the public identifier (e.g., `SHA256(pk, nonce)`),
+   * the `instanceSalt`, the transfer `counter`, and a domain separator.
+   *
+   * A commitment of `default<Bytes<32>>` (i.e., zero) indicates the contract is unowned.
+   */
+  export ledger _ownerCommitment: Bytes<32>;
+  /**
+   * @ledger _counter
+   * @description Internal transfer counter used to prevent commitment reuse.
+   *
+   * Increments by 1 on every successful ownership transfer. Combined with `id` and
+   * `instanceSalt` to compute unique owner commitments over time.
+   */
+  export ledger _counter: Counter;
+  /**
+   * @sealed @ledger _instanceSalt
+   * @description A per-instance value provided at initialization used to namespace
+   * commitments for this contract instance.
+   *
+   * This salt prevents commitment collisions across contracts that might otherwise use
+   * the same owner identifiers or domain parameters. It is immutable after initialization.
+   */
+  export sealed ledger _instanceSalt: Bytes<32>;
+
+  /**
+   * @witness wit_secretNonce
+   * @description A private per-user nonce used in deriving the shielded owner identifier.
+   *
+   * Combined with the user's public key as `SHA256(pk, nonce)` to produce an obfuscated,
+   * unlinkable identity commitment. Users are encouraged to rotate this value on ownership changes.
+   */
+  export witness wit_secretNonce(): Bytes<32>;
+
+  /**
+   * @description Initializes the contract by setting the initial owner via `ownerId`
+   * and storing the `instanceSalt` that acts as a privacy additive for preventing
+   * duplicate commitments among other contracts implementing ZOwnablePK.
+   *
+   * @warning The `ownerId` must be calculated prior to contract deployment using the SHA256 hashing algorithm.
+   * Using any other algorithm will result in a permanent loss of contract access.
+   *
+   * @circuitInfo k=14, rows=14933
+   *
+   * Requirements:
+   *
+   * - Contract is not initialized.
+   * - `ownerId` is not zero.
+   *
+   * @param {Bytes<32>} ownerId - The owner's unique identifier SHA256(pk, nonce).
+   * @param {Bytes<32>} instanceSalt - Contract salt to prevent duplicate commitments if
+   * users reuse their PK and secretNonce witness (not recommended).
+   * @returns {[]} Empty tuple.
+   */
+  export circuit initialize(ownerId: Bytes<32>, instanceSalt: Bytes<32>): [] {
+    Initializable_initialize();
+
+    assert(ownerId != default<Bytes<32>>, "ZOwnablePK: invalid id");
+    _instanceSalt = disclose(instanceSalt);
+    _transferOwnership(ownerId);
+  }
+
+  /**
+   * @description Returns the current commitment representing the contract owner.
+   * The full commitment is: `SHA256(SHA256(pk, nonce), instanceSalt, counter, domain)`.
+   *
+   * @circuitInfo k=10, rows=57
+   *
+   * Requirements:
+   *
+   * - Contract is initialized.
+   *
+   * @returns {Bytes<32>} The current owner's commitment.
+   */
+  export circuit owner(): Bytes<32> {
+    Initializable_assertInitialized();
+    return _ownerCommitment;
+  }
+
+  /**
+   * @description Transfers ownership to `newOwnerId`.
+   * `newOwnerId` must be precalculated and given to the current owner off chain.
+   *
+   * @circuitInfo k=16, rows=39240
+   *
+   * Requirements:
+   *
+   * - Contract is initialized.
+   * - Caller is the the current owner.
+   * - `newOwnerId` is not an empty array.
+   *
+   * @param {Bytes<32>} newOwnerId - The new owner's unique identifier (`SHA256(pk, nonce)`).
+   * @returns {[]} Empty tuple.
+   */
+  export circuit transferOwnership(newOwnerId: Bytes<32>): [] {
+    Initializable_assertInitialized();
+
+    assertOnlyOwner();
+    assert(newOwnerId != default<Bytes<32>>, "ZOwnablePK: invalid id");
+    _transferOwnership(newOwnerId);
+  }
+
+  /**
+   * @description Leaves the contract without an owner.
+   * It will not be possible to call `assertOnlyOnwer` circuits anymore.
+   * Can only be called by the current owner.
+   *
+   * @circuitInfo k=15, rows=24442
+   *
+   * Requirements:
+   *
+   * - Contract is initialized.
+   * - Caller is the the current owner.
+   *
+   * @returns {[]} Empty tuple.
+   */
+  export circuit renounceOwnership(): [] {
+    Initializable_assertInitialized();
+
+    assertOnlyOwner();
+    _ownerCommitment.resetToDefault();
+  }
+
+  /**
+   * @description Throws if called by any account whose id hash `SHA256(pk, nonce)` does not match
+   * the stored owner commitment.
+   * Use this to only allow the owner to call specific circuits.
+   *
+   * @circuitInfo k=15, rows=24437
+   *
+   * Requirements:
+   *
+   * - Contract is initialized.
+   * - Caller's id (`SHA256(pk, nonce)`) when used in `_computeOwnerCommitment` equals
+   * the stored `_ownerCommitment`, thus verifying themselves as the owner.
+   *
+   * @returns {[]} Empty tuple.
+   */
+  export circuit assertOnlyOwner(): [] {
+    Initializable_assertInitialized();
+
+    const nonce = wit_secretNonce();
+    const callerAsEither = Either<ZswapCoinPublicKey, ContractAddress> {
+      is_left: true,
+      left: ownPublicKey(),
+      right: ContractAddress { bytes: pad(32, "") }
+    };
+    const id = _computeOwnerId(callerAsEither, nonce);
+    assert(_ownerCommitment == _computeOwnerCommitment(id, _counter), "ZOwnablePK: caller is not the owner");
+  }
+
+  /**
+   * @description Computes the owner commitment from the given `id` and `counter`.
+   *
+   * ## Owner ID (`id`)
+   * The `id` is expected to be computed off-chain as:
+   * `id = SHA256(pk, nonce)`
+   *
+   * - `pk`: The owner's public key.
+   * - `nonce`: A secret nonce scoped to the instance, ideally rotated with each transfer.
+   *
+   * ## Commitment Derivation
+   * `commitment = SHA256(id, instanceSalt, counter, domain)`
+   *
+   * - `id`: See above.
+   * - `instanceSalt`: A unique per-deployment salt, stored during initialization.
+   * This prevents commitment collisions across deployments.
+   * - `counter`: Incremented with each ownership transfer, ensuring uniqueness
+   * even with repeated `id` values. Cast to `Field` then `Bytes<32>` for hashing.
+   * - `domain`: Domain separator `"ZOwnablePK:shield:"` (padded to 32 bytes) to prevent
+   * hash collisions when extending the module or using similar commitment schemes.
+   *
+   * @circuitInfo k=14, rows=14853
+   *
+   * Requirements:
+   *
+   * - Contract is initialized.
+   *
+   * @param {Bytes<32>} id - The unique identifier of the owner calculated by `SHA256(pk, nonce)`.
+   * @param {Uint<64>} counter - The current counter or round. This increments by `1`
+   * after every transfer to prevent duplicate commitments given the same `id`.
+   * @returns {Bytes<32>} The commitment derived from `id` and `counter`.
+   */
+  export circuit _computeOwnerCommitment(
+    id: Bytes<32>,
+    counter: Uint<64>,
+  ): Bytes<32> {
+    Initializable_assertInitialized();
+    return persistentHash<Vector<4, Bytes<32>>>(
+      [
+        id,
+        _instanceSalt,
+        counter as Field as Bytes<32>,
+        pad(32, "ZOwnablePK:shield:")
+      ]
+    );
+  }
+
+  /**
+   * @description Computes the unique identifier (`id`) of the owner from their
+   * public key and a secret nonce.
+   *
+   * ## ID Derivation
+   * `id = SHA256(pk, nonce)`
+   *
+   * - `pk`: The public key of the caller. This is passed explicitly to allow
+   * for off-chain derivation, testing, or scenarios where the caller is
+   * different from the subject of the computation.
+   * We recommend using an Air-Gapped Public Key.
+   * - `nonce`: A secret nonce tied to the identity. The generation strategy is
+   * left to the user, offering different security/convenience trade-offs.
+   *
+   * The result is a 32-byte commitment that uniquely identifies the owner.
+   * This value is later used in owner commitment hashing,
+   * and acts as a privacy-preserving alternative to a raw public key.
+   *
+   * @notice This module allows ownership to be tied to an identity commitment derived
+   * from a public key and secret nonce.
+   * While typically used with user public keys, this mechanism may also
+   * support contract addresses as identifiers in future contract-to-contract
+   * interactions. Both are treated as 32-byte values (`Bytes<32>`).
+   *
+   * Requirements:
+   *
+   * - `pk` is not a ContractAddress.
+   *
+   * @param {Either<ZswapCoinPublicKey, ContractAddress>} pk - The public key of the identity being committed.
+   * @param {Bytes<32>} nonce - A private nonce to scope the commitment.
+   * @returns {Bytes<32>} The computed owner ID.
+   */
+  export pure circuit _computeOwnerId(
+    pk: Either<ZswapCoinPublicKey, ContractAddress>,
+    nonce: Bytes<32>
+  ): Bytes<32> {
+    assert(pk.is_left, "ZOwnablePK: contract address owners are not yet supported");
+
+    return persistentHash<Vector<2, Bytes<32>>>([pk.left.bytes, nonce]);
+  }
+
+  /**
+   * @description Transfers ownership to owner id `newOwnerId` without
+   * enforcing permission checks on the caller.
+   *
+   * @circuitInfo k=14, rows=14823
+   *
+   * Requirements:
+   *
+   * - Contract is initialized.
+   *
+   * @param {Bytes<32>} newOwnerId - The unique identifier of the new owner
+   * calculated by `SHA256(pk, nonce)`.
+   * @returns {[]} Empty tuple.
+   */
+  export circuit _transferOwnership(newOwnerId: Bytes<32>): [] {
+    Initializable_assertInitialized();
+
+    _counter.increment(1);
+    _ownerCommitment = _computeOwnerCommitment(disclose(newOwnerId), _counter);
+  }
+}

--- a/contracts/src/access/test/Ownable.test.ts
+++ b/contracts/src/access/test/Ownable.test.ts
@@ -3,14 +3,12 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import { OwnableSimulator } from './simulators/OwnableSimulator.js';
 import * as utils from './utils/address.js';
 
-// Callers
-const OWNER = utils.toHexPadded('OWNER');
-const NEW_OWNER = utils.toHexPadded('NEW_OWNER');
-const UNAUTHORIZED = utils.toHexPadded('UNAUTHORIZED');
+// PKs
+const [OWNER, Z_OWNER] = utils.generateEitherPubKeyPair('OWNER');
+const [NEW_OWNER, Z_NEW_OWNER] = utils.generateEitherPubKeyPair('NEW_OWNER');
+const [UNAUTHORIZED, _] = utils.generateEitherPubKeyPair('UNAUTHORIZED');
 
-// Encoded PK/Addresses
-const Z_OWNER = utils.createEitherTestUser('OWNER');
-const Z_NEW_OWNER = utils.createEitherTestUser('NEW_OWNER');
+// Encoded contract addresses
 const Z_OWNER_CONTRACT =
   utils.createEitherTestContractAddress('OWNER_CONTRACT');
 const Z_RECIPIENT_CONTRACT =

--- a/contracts/src/access/test/ZOwnablePK.test.ts
+++ b/contracts/src/access/test/ZOwnablePK.test.ts
@@ -1,0 +1,534 @@
+import {
+  CompactTypeBytes,
+  CompactTypeVector,
+  convert_bigint_to_Uint8Array,
+  persistentHash,
+  transientHash,
+  upgradeFromTransient,
+} from '@midnight-ntwrk/compact-runtime';
+import { beforeEach, describe, expect, it } from 'vitest';
+import type { ZswapCoinPublicKey } from '../../../artifacts/MockOwnable/contract/index.cjs';
+import { ZOwnablePKPrivateState } from '../witnesses/ZOwnablePKWitnesses.js';
+import { ZOwnablePKSimulator } from './simulators/ZOwnablePKSimulator.js';
+import * as utils from './utils/address.js';
+
+// PKs
+const [OWNER, Z_OWNER] = utils.generatePubKeyPair('OWNER');
+const [NEW_OWNER, Z_NEW_OWNER] = utils.generatePubKeyPair('NEW_OWNER');
+const [UNAUTHORIZED, _] = utils.generatePubKeyPair('UNAUTHORIZED');
+
+const INSTANCE_SALT = new Uint8Array(32).fill(8675309);
+const BAD_NONCE = Buffer.from(Buffer.alloc(32, 'BAD_NONCE'));
+const DOMAIN = 'ZOwnablePK:shield:';
+const INIT_COUNTER = 1n;
+
+const isInit = true;
+let secretNonce: Uint8Array;
+let ownable: ZOwnablePKSimulator;
+
+// Helpers
+const createIdHash = (
+  pk: ZswapCoinPublicKey,
+  nonce: Uint8Array,
+): Uint8Array => {
+  const rt_type = new CompactTypeVector(2, new CompactTypeBytes(32));
+
+  const bPK = pk.bytes;
+  return persistentHash(rt_type, [bPK, nonce]);
+};
+
+const buildCommitmentFromId = (
+  id: Uint8Array,
+  instanceSalt: Uint8Array,
+  counter: bigint,
+): Uint8Array => {
+  const rt_type = new CompactTypeVector(4, new CompactTypeBytes(32));
+  const bCounter = convert_bigint_to_Uint8Array(32, counter);
+  const bDomain = new TextEncoder().encode(DOMAIN);
+
+  const commitment = persistentHash(rt_type, [
+    id,
+    instanceSalt,
+    bCounter,
+    bDomain,
+  ]);
+  return commitment;
+};
+
+const buildCommitment = (
+  pk: ZswapCoinPublicKey,
+  nonce: Uint8Array,
+  instanceSalt: Uint8Array,
+  counter: bigint,
+  domain: string,
+): Uint8Array => {
+  const id = createIdHash(pk, nonce);
+
+  const rt_type = new CompactTypeVector(4, new CompactTypeBytes(32));
+  const bCounter = convert_bigint_to_Uint8Array(32, counter);
+  const bDomain = new TextEncoder().encode(domain);
+
+  const commitment = persistentHash(rt_type, [
+    id,
+    instanceSalt,
+    bCounter,
+    bDomain,
+  ]);
+  return commitment;
+};
+
+describe('ZOwnablePK', () => {
+  describe('before initialize', () => {
+    it('should fail when setting owner commitment as 0', () => {
+      expect(() => {
+        const badId = new Uint8Array(32).fill(0);
+        new ZOwnablePKSimulator(badId, INSTANCE_SALT, isInit);
+      }).toThrow('ZOwnablePK: invalid id');
+    });
+
+    it('should initialize with non-zero commitment', () => {
+      const notZeroPK = utils.encodeToPK('NOT_ZERO');
+      const notZeroNonce = new Uint8Array(32).fill(1);
+      const nonZeroId = createIdHash(notZeroPK, notZeroNonce);
+      ownable = new ZOwnablePKSimulator(nonZeroId, INSTANCE_SALT, isInit);
+
+      const nonZeroCommitment = buildCommitmentFromId(
+        nonZeroId,
+        INSTANCE_SALT,
+        INIT_COUNTER,
+      );
+      expect(ownable.owner()).toEqual(nonZeroCommitment);
+    });
+  });
+
+  describe('when not deployed and not initialized', () => {
+    const isNotInit = false;
+
+    beforeEach(() => {
+      ownable = new ZOwnablePKSimulator(
+        randomByteArray,
+        INSTANCE_SALT,
+        isNotInit,
+      );
+    });
+    type FailingCircuits = [method: keyof ZOwnablePKSimulator, args: unknown[]];
+    const randomByteArray = new Uint8Array(32).fill(123);
+    const randomCounter = 321n;
+    // Circuit calls should fail before the args are used
+    const circuitsToFail: FailingCircuits[] = [
+      ['owner', []],
+      ['assertOnlyOwner', []],
+      ['transferOwnership', [randomByteArray]],
+      ['renounceOwnership', []],
+      ['_computeOwnerCommitment', [randomByteArray, randomCounter]],
+      ['_transferOwnership', [randomByteArray]],
+    ];
+    it.each(circuitsToFail)('%s should fail', (circuitName, args) => {
+      expect(() => {
+        (ownable[circuitName] as (...args: unknown[]) => unknown)(...args);
+      }).toThrow('Initializable: contract not initialized');
+    });
+
+    it('should allow pure computeOwnerId', () => {
+      const eitherOwner = utils.createEitherTestUser('OWNER');
+
+      expect(() => {
+        ownable._computeOwnerId(eitherOwner, randomByteArray);
+      }).not.toThrow();
+    });
+  });
+
+  describe('when incorrect hashing algo (not SHA256) is used to generate initial owner id', () => {
+    // ZOwnablePK only supports sha256 for owner id calculation
+    // Obviously, using any other algo for the id will not work
+    const badHashAlgo = (pk: ZswapCoinPublicKey, nonce: Uint8Array) => {
+      const rt_type = new CompactTypeVector(2, new CompactTypeBytes(32));
+      return upgradeFromTransient(transientHash(rt_type, [pk.bytes, nonce]));
+    };
+    const secretNonce = ZOwnablePKPrivateState.generate().secretNonce;
+    const badOwnerId = badHashAlgo(Z_OWNER, secretNonce);
+
+    beforeEach(() => {
+      ownable = new ZOwnablePKSimulator(badOwnerId, INSTANCE_SALT, isInit);
+    });
+    //
+    type FailingCircuits = [method: keyof ZOwnablePKSimulator, args: unknown[]];
+    const protectedCircuits: FailingCircuits[] = [
+      ['assertOnlyOwner', []],
+      ['transferOwnership', [badOwnerId]],
+      ['renounceOwnership', []],
+    ];
+
+    it.each(protectedCircuits)('%s should fail', (circuitName, args) => {
+      ownable.callerCtx.setCaller(OWNER);
+
+      expect(() => {
+        (ownable[circuitName] as (...args: unknown[]) => unknown)(...args);
+      }).toThrow('ZOwnablePK: caller is not the owner');
+    });
+  });
+
+  describe('after initialization', () => {
+    beforeEach(() => {
+      // Create private state object and generate nonce
+      const PS = ZOwnablePKPrivateState.generate();
+      // Bind nonce for convenience
+      secretNonce = PS.secretNonce;
+      // Prepare owner ID with gen nonce
+      const ownerId = createIdHash(Z_OWNER, secretNonce);
+      // Deploy contract with derived owner commitment and PS
+      ownable = new ZOwnablePKSimulator(ownerId, INSTANCE_SALT, isInit, {
+        privateState: PS,
+      });
+    });
+
+    describe('owner', () => {
+      it('should return the correct owner commitment', () => {
+        const expCommitment = buildCommitment(
+          Z_OWNER,
+          secretNonce,
+          INSTANCE_SALT,
+          INIT_COUNTER,
+          DOMAIN,
+        );
+        expect(ownable.owner()).toEqual(expCommitment);
+      });
+    });
+
+    describe('transferOwnership', () => {
+      let newOwnerCommitment: Uint8Array;
+      let newOwnerNonce: Uint8Array;
+      let newIdHash: Uint8Array;
+      let newCounter: bigint;
+
+      beforeEach(() => {
+        // Prepare new owner commitment
+        newOwnerNonce = ZOwnablePKPrivateState.generate().secretNonce;
+        newCounter = INIT_COUNTER + 1n;
+        newIdHash = createIdHash(Z_NEW_OWNER, newOwnerNonce);
+        newOwnerCommitment = buildCommitment(
+          Z_NEW_OWNER,
+          newOwnerNonce,
+          INSTANCE_SALT,
+          newCounter,
+          DOMAIN,
+        );
+      });
+
+      it('should transfer ownership', () => {
+        ownable.callerCtx.setCaller(OWNER);
+        ownable.transferOwnership(newIdHash);
+        expect(ownable.owner()).toEqual(newOwnerCommitment);
+
+        // Old owner
+        ownable.callerCtx.setCaller(OWNER);
+        expect(() => {
+          ownable.assertOnlyOwner();
+        }).toThrow('ZOwnablePK: caller is not the owner');
+
+        // Unauthorized
+        ownable.callerCtx.setCaller(UNAUTHORIZED);
+        expect(() => {
+          ownable.assertOnlyOwner();
+        }).toThrow('ZOwnablePK: caller is not the owner');
+
+        // New owner
+        ownable.callerCtx.setCaller(NEW_OWNER);
+        ownable.privateState.injectSecretNonce(Buffer.from(newOwnerNonce));
+        expect(ownable.assertOnlyOwner()).not.to.throw;
+      });
+
+      it('should fail when transferring to id zero', () => {
+        ownable.callerCtx.setCaller(OWNER);
+        const badId = new Uint8Array(32).fill(0);
+        expect(() => {
+          ownable.transferOwnership(badId);
+        }).toThrow('ZOwnablePK: invalid id');
+      });
+
+      it('should fail when unauthorized transfers ownership', () => {
+        ownable.callerCtx.setCaller(UNAUTHORIZED);
+        expect(() => {
+          ownable.transferOwnership(newOwnerCommitment);
+        }).toThrow('ZOwnablePK: caller is not the owner');
+      });
+
+      /**
+       * @description More thoroughly tested in `_transferOwnership`
+       * */
+      it('should bump instance after transfer', () => {
+        const beforeInstance = ownable.getPublicState().ZOwnablePK__counter;
+
+        // Transfer
+        ownable.callerCtx.setCaller(OWNER);
+        ownable.transferOwnership(newOwnerCommitment);
+
+        // Check counter
+        const afterInstance = ownable.getPublicState().ZOwnablePK__counter;
+        expect(afterInstance).toEqual(beforeInstance + 1n);
+      });
+
+      it('should change commitment when transferring ownership to self with same pk + nonce)', () => {
+        // Confirm current commitment
+        const repeatedId = createIdHash(Z_OWNER, secretNonce);
+        const initCommitment = ownable.owner();
+        const expInitCommitment = buildCommitmentFromId(
+          repeatedId,
+          INSTANCE_SALT,
+          INIT_COUNTER,
+        );
+        expect(initCommitment).toEqual(expInitCommitment);
+
+        // Transfer ownership to self with the same id -> `H(pk, nonce)`
+        ownable.callerCtx.setCaller(OWNER);
+        ownable.transferOwnership(repeatedId);
+
+        // Check commitments don't match
+        const newCommitment = ownable.owner();
+        expect(initCommitment).not.toEqual(newCommitment);
+
+        // Build commitment locally and validate new commitment == expected
+        const bumpedCounter = INIT_COUNTER + 1n;
+        const expNewCommitment = buildCommitmentFromId(
+          repeatedId,
+          INSTANCE_SALT,
+          bumpedCounter,
+        );
+        expect(newCommitment).toEqual(expNewCommitment);
+
+        // Check same owner maintains permissions after transfer
+        ownable.callerCtx.setCaller(OWNER);
+        expect(ownable.assertOnlyOwner()).not.to.throw;
+      });
+    });
+
+    describe('renounceOwnership', () => {
+      it('should renounce ownership', () => {
+        ownable.callerCtx.setCaller(OWNER);
+        ownable.renounceOwnership();
+
+        // Check owner is reset
+        expect(ownable.owner()).toEqual(new Uint8Array(32).fill(0));
+
+        // Check revoked permissions
+        expect(() => {
+          ownable.assertOnlyOwner();
+        }).toThrow('ZOwnablePK: caller is not the owner');
+      });
+
+      it('should fail when renouncing from unauthorized', () => {
+        ownable.callerCtx.setCaller(UNAUTHORIZED);
+        expect(() => {
+          ownable.renounceOwnership();
+        });
+      });
+
+      it('should fail when renouncing from authorized with bad nonce', () => {
+        ownable.callerCtx.setCaller(OWNER);
+        ownable.privateState.injectSecretNonce(BAD_NONCE);
+        expect(() => {
+          ownable.renounceOwnership();
+        });
+      });
+
+      it('should fail when renouncing from unauthorized with bad nonce', () => {
+        ownable.callerCtx.setCaller(UNAUTHORIZED);
+        ownable.privateState.injectSecretNonce(BAD_NONCE);
+        expect(() => {
+          ownable.renounceOwnership();
+        });
+      });
+    });
+
+    describe('assertOnlyOwner', () => {
+      it('should allow authorized caller with correct nonce to call', () => {
+        // Check nonce is correct
+        expect(ownable.privateState.getCurrentSecretNonce()).toEqual(
+          secretNonce,
+        );
+
+        ownable.callerCtx.setCaller(OWNER);
+        expect(ownable.assertOnlyOwner()).to.not.throw;
+      });
+
+      it('should fail when the authorized caller has the wrong nonce', () => {
+        // Inject bad nonce
+        ownable.privateState.injectSecretNonce(BAD_NONCE);
+
+        // Check nonce does not match
+        expect(ownable.privateState.getCurrentSecretNonce()).not.toEqual(
+          secretNonce,
+        );
+
+        // Set caller and call circuit
+        ownable.callerCtx.setCaller(OWNER);
+        expect(() => {
+          ownable.assertOnlyOwner();
+        }).toThrow('ZOwnablePK: caller is not the owner');
+      });
+
+      it('should fail when unauthorized caller has the correct nonce', () => {
+        // Check nonce is correct
+        expect(ownable.privateState.getCurrentSecretNonce()).toEqual(
+          secretNonce,
+        );
+
+        ownable.callerCtx.setCaller(UNAUTHORIZED);
+        expect(() => {
+          ownable.assertOnlyOwner();
+        }).toThrow('ZOwnablePK: caller is not the owner');
+      });
+
+      it('should fail when unauthorized caller has the wrong nonce', () => {
+        // Inject bad nonce
+        ownable.privateState.injectSecretNonce(BAD_NONCE);
+
+        // Check nonce does not match
+        expect(ownable.privateState.getCurrentSecretNonce()).not.toEqual(
+          secretNonce,
+        );
+
+        // Set unauthorized caller and call circuit
+        ownable.callerCtx.setCaller(UNAUTHORIZED);
+        expect(() => {
+          ownable.assertOnlyOwner();
+        }).toThrow('ZOwnablePK: caller is not the owner');
+      });
+    });
+
+    describe('_computeOwnerCommitment', () => {
+      const MAX_U64 = 2n ** 64n - 1n;
+      const testCases = [
+        ...Array.from({ length: 10 }, (_, i) => ({
+          label: `User${i}`,
+          ownerPK: utils.encodeToPK(`User${i}`),
+          counter: BigInt(Math.floor(Math.random() * 2 ** 64 - 1)),
+        })),
+        {
+          label: 'ZeroCounter',
+          ownerPK: utils.encodeToPK('ZeroCounter'),
+          counter: 0n,
+        },
+        {
+          label: 'MaxCounter',
+          ownerPK: utils.encodeToPK('MaxUser'),
+          counter: MAX_U64,
+        },
+      ];
+      it.each(testCases)(
+        'should match commitment for $label with counter $counter',
+        ({ ownerPK, counter }) => {
+          const id = createIdHash(ownerPK, secretNonce);
+
+          // Check buildCommitmentFromId
+          const hashFromContract = ownable._computeOwnerCommitment(id, counter);
+          const hashFromHelper1 = buildCommitmentFromId(
+            id,
+            INSTANCE_SALT,
+            counter,
+          );
+          expect(hashFromContract).toEqual(hashFromHelper1);
+
+          // Check buildCommitment
+          const hashFromHelper2 = buildCommitment(
+            ownerPK,
+            secretNonce,
+            INSTANCE_SALT,
+            counter,
+            DOMAIN,
+          );
+          expect(hashFromHelper1).toEqual(hashFromHelper2);
+        },
+      );
+    });
+
+    describe('_computeOwnerId', () => {
+      const testCases = [
+        ...Array.from({ length: 10 }, (_, i) => ({
+          label: `User${i}`,
+          eitherOwner: utils.createEitherTestUser(`User${i}`),
+          nonce: new Uint8Array(32).fill(i),
+        })),
+        {
+          label: 'All-zero nonce',
+          eitherOwner: utils.createEitherTestUser('ZeroUser'),
+          nonce: new Uint8Array(32).fill(0),
+        },
+        {
+          label: 'Max nonce',
+          eitherOwner: utils.createEitherTestUser('MaxUser'),
+          nonce: new Uint8Array(32).fill(255),
+        },
+      ];
+
+      it.each(testCases)(
+        'should match local and contract owner id for $label',
+        ({ eitherOwner, nonce }) => {
+          const ownerId = ownable._computeOwnerId(eitherOwner, nonce);
+          const expId = createIdHash(eitherOwner.left, nonce);
+          expect(ownerId).toEqual(expId);
+        },
+      );
+
+      it('should fail to compute ContractAddress id', () => {
+        const eitherContract =
+          utils.createEitherTestContractAddress('CONTRACT');
+        expect(() => {
+          ownable._computeOwnerId(eitherContract, secretNonce);
+        }).toThrow('ZOwnablePK: contract address owners are not yet supported');
+      });
+    });
+
+    describe('_transferOwnership', () => {
+      it('should transfer ownership', () => {
+        const id = createIdHash(Z_OWNER, secretNonce);
+        ownable._transferOwnership(id);
+
+        const nextCounter = INIT_COUNTER + 1n;
+        const expCommitment = buildCommitmentFromId(
+          id,
+          INSTANCE_SALT,
+          nextCounter,
+        );
+        expect(ownable.owner()).toEqual(expCommitment);
+      });
+
+      it('should bump the counter with each transfer', () => {
+        const nTransfers = 10;
+        const counterStart = 2; // count starts at 2 bc the constructor bumps the count to 1
+        for (let i = counterStart; i <= nTransfers; i++) {
+          const pk = utils.encodeToPK(`Id${i}`);
+          const nonce = new Uint8Array(32).fill(i);
+          const id = createIdHash(pk, nonce);
+          ownable._transferOwnership(id);
+
+          expect(ownable.getPublicState().ZOwnablePK__counter).toEqual(
+            BigInt(i),
+          );
+        }
+      });
+
+      it('should allow transfer to all zeroes id', () => {
+        const zeroId = utils.zeroUint8Array();
+        ownable._transferOwnership(zeroId);
+
+        const nextCounter = INIT_COUNTER + 1n;
+        const expCommitment = buildCommitmentFromId(
+          zeroId,
+          INSTANCE_SALT,
+          nextCounter,
+        );
+        expect(ownable.owner()).toEqual(expCommitment);
+      });
+
+      it('should allow anyone to transfer', () => {
+        ownable.callerCtx.setCaller(OWNER);
+        const id = createIdHash(Z_OWNER, secretNonce);
+        expect(ownable._transferOwnership(id)).not.to.throw;
+
+        ownable.callerCtx.setCaller(UNAUTHORIZED);
+        expect(ownable._transferOwnership(id)).not.to.throw;
+      });
+    });
+  });
+});

--- a/contracts/src/access/test/mocks/MockZOwnablePK.compact
+++ b/contracts/src/access/test/mocks/MockZOwnablePK.compact
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: MIT
+
+pragma language_version >= 0.16.0;
+
+import CompactStandardLibrary;
+import "../../ZOwnablePK" prefix ZOwnablePK_;
+
+export { ZswapCoinPublicKey, ContractAddress, Either, Maybe };
+export { ZOwnablePK__ownerCommitment, ZOwnablePK__counter };
+
+/**
+ * @description `isInit` is a param for testing.
+ *
+ * If `isInit` is false, the constructor will not initialize the contract.
+ * This behavior is to test that circuits are not callable unless the
+ * contract is initialized.
+*/
+constructor(initOwnerCommitment: Bytes<32>, instanceSalt: Bytes<32>, isInit: Boolean) {
+  if (disclose(isInit)) {
+    ZOwnablePK_initialize(initOwnerCommitment, instanceSalt);
+  }
+}
+
+export circuit owner(): Bytes<32> {
+  return ZOwnablePK_owner();
+}
+
+export circuit transferOwnership(newOwnerCommitment: Bytes<32>): [] {
+  return ZOwnablePK_transferOwnership(disclose(newOwnerCommitment));
+}
+
+export circuit renounceOwnership(): [] {
+  return ZOwnablePK_renounceOwnership();
+}
+
+export circuit assertOnlyOwner(): [] {
+  return ZOwnablePK_assertOnlyOwner();
+}
+
+export circuit _computeOwnerCommitment(id: Bytes<32>, counter: Uint<64>): Bytes<32> {
+  return ZOwnablePK__computeOwnerCommitment(id, counter);
+}
+
+export pure circuit _computeOwnerId(pk: Either<ZswapCoinPublicKey, ContractAddress>, nonce: Bytes<32>): Bytes<32> {
+  return ZOwnablePK__computeOwnerId(pk, nonce);
+}
+
+export circuit _transferOwnership(newOwnerCommitment: Bytes<32>): [] {
+  return ZOwnablePK__transferOwnership(newOwnerCommitment);
+}

--- a/contracts/src/access/test/simulators/AccessControlSimulator.ts
+++ b/contracts/src/access/test/simulators/AccessControlSimulator.ts
@@ -66,7 +66,7 @@ export class AccessControlSimulator
    * @description Retrieves the current public ledger state of the contract.
    * @returns The ledger state as defined by the contract.
    */
-  public getCurrentPublicState(): Ledger {
+  public getPublicState(): Ledger {
     return ledger(this.circuitContext.transactionContext.state);
   }
 
@@ -74,7 +74,7 @@ export class AccessControlSimulator
    * @description Retrieves the current private state of the contract.
    * @returns The private state of type AccessControlPrivateState.
    */
-  public getCurrentPrivateState(): AccessControlPrivateState {
+  public getPrivateState(): AccessControlPrivateState {
     return this.circuitContext.currentPrivateState;
   }
 
@@ -82,7 +82,7 @@ export class AccessControlSimulator
    * @description Retrieves the current contract state.
    * @returns The contract state object.
    */
-  public getCurrentContractState(): ContractState {
+  public getContractState(): ContractState {
     return this.circuitContext.originalState;
   }
 

--- a/contracts/src/access/test/simulators/OwnableSimulator.ts
+++ b/contracts/src/access/test/simulators/OwnableSimulator.ts
@@ -71,7 +71,7 @@ export class OwnableSimulator
    * @description Retrieves the current public ledger state of the contract.
    * @returns The ledger state as defined by the contract.
    */
-  public getCurrentPublicState(): Ledger {
+  public getPublicState(): Ledger {
     return ledger(this.circuitContext.transactionContext.state);
   }
 
@@ -79,7 +79,7 @@ export class OwnableSimulator
    * @description Retrieves the current private state of the contract.
    * @returns The private state of type OwnablePrivateState.
    */
-  public getCurrentPrivateState(): OwnablePrivateState {
+  public getPrivateState(): OwnablePrivateState {
     return this.circuitContext.currentPrivateState;
   }
 
@@ -87,7 +87,7 @@ export class OwnableSimulator
    * @description Retrieves the current contract state.
    * @returns The contract state object.
    */
-  public getCurrentContractState(): ContractState {
+  public getContractState(): ContractState {
     return this.circuitContext.originalState;
   }
 

--- a/contracts/src/access/test/simulators/ZOwnablePKSimulator.ts
+++ b/contracts/src/access/test/simulators/ZOwnablePKSimulator.ts
@@ -1,0 +1,307 @@
+import {
+  type CircuitContext,
+  type CoinPublicKey,
+  emptyZswapLocalState,
+} from '@midnight-ntwrk/compact-runtime';
+import { sampleContractAddress } from '@midnight-ntwrk/zswap';
+import {
+  type ContractAddress,
+  type Either,
+  type Ledger,
+  ledger,
+  Contract as MockOwnable,
+  type ZswapCoinPublicKey,
+} from '../../../../artifacts/MockZOwnablePK/contract/index.cjs';
+import {
+  ZOwnablePKPrivateState,
+  ZOwnablePKWitnesses,
+} from '../../witnesses/ZOwnablePKWitnesses.js';
+import type {
+  ContextlessCircuits,
+  ExtractImpureCircuits,
+  ExtractPureCircuits,
+  SimulatorOptions,
+} from '../types/test.js';
+import { AbstractContractSimulator } from '../utils/AbstractContractSimulator.js';
+import { SimulatorStateManager } from '../utils/SimualatorStateManager.js';
+
+type OwnableSimOptions = SimulatorOptions<
+  ZOwnablePKPrivateState,
+  typeof ZOwnablePKWitnesses
+>;
+
+/**
+ * @description A simulator implementation of a contract for testing purposes.
+ * @template P - The private state type, fixed to ZOwnablePKPrivateState.
+ * @template L - The ledger type, fixed to Contract.Ledger.
+ */
+export class ZOwnablePKSimulator extends AbstractContractSimulator<
+  ZOwnablePKPrivateState,
+  Ledger
+> {
+  contract: MockOwnable<ZOwnablePKPrivateState>;
+  readonly contractAddress: string;
+  private stateManager: SimulatorStateManager<ZOwnablePKPrivateState>;
+  private callerOverride: CoinPublicKey | null = null;
+  private _witnesses: ReturnType<typeof ZOwnablePKWitnesses>;
+
+  private _pureCircuitProxy?: ContextlessCircuits<
+    ExtractPureCircuits<MockOwnable<ZOwnablePKPrivateState>>,
+    ZOwnablePKPrivateState
+  >;
+
+  private _impureCircuitProxy?: ContextlessCircuits<
+    ExtractImpureCircuits<MockOwnable<ZOwnablePKPrivateState>>,
+    ZOwnablePKPrivateState
+  >;
+
+  constructor(
+    initOwner: Uint8Array,
+    instanceSalt: Uint8Array,
+    isInit: boolean,
+    options: OwnableSimOptions = {},
+  ) {
+    super();
+
+    // Setup initial state
+    const {
+      privateState = ZOwnablePKPrivateState.generate(),
+      witnesses = ZOwnablePKWitnesses(),
+      coinPK = '0'.repeat(64),
+      address = sampleContractAddress(),
+    } = options;
+    const constructorArgs = [initOwner, instanceSalt, isInit];
+
+    this.contract = new MockOwnable<ZOwnablePKPrivateState>(witnesses);
+
+    this.stateManager = new SimulatorStateManager(
+      this.contract,
+      privateState,
+      coinPK,
+      address,
+      ...constructorArgs,
+    );
+    this.contractAddress = this.circuitContext.transactionContext.address;
+    this._witnesses = witnesses;
+    this.contract = new MockOwnable<ZOwnablePKPrivateState>(this._witnesses);
+  }
+
+  get circuitContext() {
+    return this.stateManager.getContext();
+  }
+
+  set circuitContext(ctx) {
+    this.stateManager.setContext(ctx);
+  }
+
+  getPublicState(): Ledger {
+    return ledger(this.circuitContext.transactionContext.state);
+  }
+
+  /**
+   * @description Constructs a caller-specific circuit context.
+   * If a caller override is present, it replaces the current Zswap local state with an empty one
+   * scoped to the overridden caller. Otherwise, the existing context is reused as-is.
+   * @returns A circuit context adjusted for the current simulated caller.
+   */
+  protected getCallerContext(): CircuitContext<ZOwnablePKPrivateState> {
+    return {
+      ...this.circuitContext,
+      currentZswapLocalState: this.callerOverride
+        ? emptyZswapLocalState(this.callerOverride)
+        : this.circuitContext.currentZswapLocalState,
+    };
+  }
+
+  /**
+   * @description Initializes and returns a proxy to pure contract circuits.
+   * The proxy automatically injects the current circuit context into each call,
+   * and returns only the result portion of each circuit's output.
+   * @notice The proxy is created only when first accessed a.k.a lazy initialization.
+   * This approach is efficient in cases where only pure or only impure circuits are used,
+   * avoiding unnecessary proxy creation.
+   * @returns A proxy object exposing pure circuit functions without requiring explicit context.
+   */
+  protected get pureCircuit(): ContextlessCircuits<
+    ExtractPureCircuits<MockOwnable<ZOwnablePKPrivateState>>,
+    ZOwnablePKPrivateState
+  > {
+    if (!this._pureCircuitProxy) {
+      this._pureCircuitProxy = this.createPureCircuitProxy<
+        MockOwnable<ZOwnablePKPrivateState>['circuits']
+      >(this.contract.circuits, () => this.circuitContext);
+    }
+    return this._pureCircuitProxy;
+  }
+
+  /**
+   * @description Initializes and returns a proxy to impure contract circuits.
+   * The proxy automatically injects the current (possibly caller-modified) context into each call,
+   * and updates the circuit context with the one returned by the circuit after execution.
+   * @notice The proxy is created only when first accessed a.k.a. lazy initialization.
+   * This approach is efficient in cases where only pure or only impure circuits are used,
+   * avoiding unnecessary proxy creation.
+   * @returns A proxy object exposing impure circuit functions without requiring explicit context management.
+   */
+  protected get impureCircuit(): ContextlessCircuits<
+    ExtractImpureCircuits<MockOwnable<ZOwnablePKPrivateState>>,
+    ZOwnablePKPrivateState
+  > {
+    if (!this._impureCircuitProxy) {
+      this._impureCircuitProxy = this.createImpureCircuitProxy<
+        MockOwnable<ZOwnablePKPrivateState>['impureCircuits']
+      >(
+        this.contract.impureCircuits,
+        () => this.getCallerContext(),
+        (ctx: any) => {
+          this.circuitContext = ctx;
+        },
+      );
+    }
+    return this._impureCircuitProxy;
+  }
+
+  /**
+   * @description Resets the cached circuit proxy instances.
+   * This is useful if the underlying contract state or circuit context has changed,
+   * and you want to ensure the proxies are recreated with updated context on next access.
+   */
+  public resetCircuitProxies(): void {
+    this._pureCircuitProxy = undefined;
+    this._impureCircuitProxy = undefined;
+  }
+
+  /**
+   * @description Helper method that provides access to both pure and impure circuit proxies.
+   * These proxies automatically inject the appropriate circuit context when invoked.
+   * @returns An object containing `pure` and `impure` circuit proxy interfaces.
+   */
+  public get circuits() {
+    return {
+      pure: this.pureCircuit,
+      impure: this.impureCircuit,
+    };
+  }
+
+  public get witnesses(): ReturnType<typeof ZOwnablePKWitnesses> {
+    return this._witnesses;
+  }
+
+  public set witnesses(newWitnesses: ReturnType<typeof ZOwnablePKWitnesses>) {
+    this._witnesses = newWitnesses;
+    this.contract = new MockOwnable<ZOwnablePKPrivateState>(this._witnesses);
+  }
+
+  public overrideWitness<K extends keyof typeof this._witnesses>(
+    key: K,
+    fn: (typeof this._witnesses)[K],
+  ) {
+    this.witnesses = {
+      ...this._witnesses,
+      [key]: fn,
+    };
+  }
+
+  /**
+   * @description Returns the current commitment representing the contract owner.
+   * The full commitment is: `SHA256(SHA256(pk, nonce), instanceSalt, counter, domain)`.
+   * @returns The current owner's commitment.
+   */
+  public owner(): Uint8Array {
+    return this.circuits.impure.owner();
+  }
+
+  /**
+   * @description Transfers ownership to `newOwnerId`.
+   * `newOwnerId` must be precalculated and given to the current owner off chain.
+   * @param newOwnerId The new owner's unique identifier (`SHA256(pk, nonce)`).
+   */
+  public transferOwnership(newOwnerId: Uint8Array) {
+    this.circuits.impure.transferOwnership(newOwnerId);
+  }
+
+  /**
+   * @description Leaves the contract without an owner.
+   * It will not be possible to call `assertOnlyOnwer` circuits anymore.
+   * Can only be called by the current owner.
+   */
+  public renounceOwnership() {
+    this.circuits.impure.renounceOwnership();
+  }
+
+  /**
+   * @description Throws if called by any account whose id hash `SHA256(pk, nonce)` does not match
+   * the stored owner commitment. Use this to only allow the owner to call specific circuits.
+   */
+  public assertOnlyOwner() {
+    this.circuits.impure.assertOnlyOwner();
+  }
+
+  /**
+   * @description Computes the owner commitment from the given `id` and `counter`.
+   * @param id - The unique identifier of the owner calculated by `SHA256(pk, nonce)`.
+   * @param counter - The current counter or round. This increments by `1`
+   * after every transfer to prevent duplicate commitments given the same `id`.
+   * @returns The commitment derived from `id` and `counter`.
+   */
+  public _computeOwnerCommitment(id: Uint8Array, counter: bigint): Uint8Array {
+    return this.circuits.impure._computeOwnerCommitment(id, counter);
+  }
+
+  /**
+   * @description Computes the unique identifier (`id`) of the owner from their
+   * public key and a secret nonce.
+   * @param pk - The public key of the identity being committed.
+   * @param nonce - A private nonce to scope the commitment.
+   * @returns The computed owner ID.
+   */
+  public _computeOwnerId(
+    pk: Either<ZswapCoinPublicKey, ContractAddress>,
+    nonce: Uint8Array,
+  ): Uint8Array {
+    return this.circuits.pure._computeOwnerId(pk, nonce);
+  }
+
+  /**
+   * @description Transfers ownership to owner id `newOwnerId` without
+   * enforcing permission checks on the caller.
+   * @param newOwnerId - The unique identifier of the new owner calculated by `SHA256(pk, nonce)`.
+   */
+  public _transferOwnership(newOwnerId: Uint8Array) {
+    this.circuits.impure._transferOwnership(newOwnerId);
+  }
+
+  public readonly privateState = {
+    /**
+     * @description Contextually sets a new nonce into the private state.
+     * @param newNonce The secret nonce.
+     * @returns The ZOwnablePK private state after setting the new nonce.
+     */
+    injectSecretNonce: (
+      newNonce: Buffer<ArrayBufferLike>,
+    ): ZOwnablePKPrivateState => {
+      const currentState = this.stateManager.getContext().currentPrivateState;
+      const updatedState = { ...currentState, secretNonce: newNonce };
+      this.stateManager.updatePrivateState(updatedState);
+      return updatedState;
+    },
+
+    /**
+     * @description Returns the secret nonce given the context.
+     * @returns The secret nonce.
+     */
+    getCurrentSecretNonce: (): Uint8Array => {
+      return this.stateManager.getContext().currentPrivateState.secretNonce;
+    },
+  };
+
+  public callerCtx = {
+    /**
+     * @description Sets the caller context.
+     * @param caller The caller in context of the proceeding circuit calls.
+     */
+    setCaller: (caller: CoinPublicKey) => {
+      this.callerOverride = caller;
+    },
+  };
+}

--- a/contracts/src/access/test/types/test.ts
+++ b/contracts/src/access/test/types/test.ts
@@ -4,23 +4,99 @@ import type {
 } from '@midnight-ntwrk/compact-runtime';
 
 /**
- * Generic interface for mock contract implementations.
- * @template P - The type of the contract's private state.
- * @template L - The type of the contract's ledger (public state).
+ * Interface defining a generic contract simulator.
+ *
+ * @template P - Type representing the private contract state.
+ * @template L - Type representing the public ledger state.
  */
 export interface IContractSimulator<P, L> {
-  /** The contract's deployed address. */
+  /**
+   * The deployed contract's address.
+   */
   readonly contractAddress: string;
 
-  /** The current circuit context. */
+  /**
+   * The current circuit context holding the contract state.
+   */
   circuitContext: CircuitContext<P>;
 
-  /** Retrieves the current ledger state. */
-  getCurrentPublicState(): L;
+  /**
+   * Returns the current public ledger state.
+   *
+   * @returns The current ledger state of type L.
+   */
+  getPublicState(): L;
 
-  /** Retrieves the current private state. */
-  getCurrentPrivateState(): P;
+  /**
+   * Returns the current private contract state.
+   *
+   * @returns The current private state of type P.
+   */
+  getPrivateState(): P;
 
-  /** Retrieves the current contract state. */
-  getCurrentContractState(): ContractState;
+  /**
+   * Returns the original contract state.
+   *
+   * @returns The current contract state.
+   */
+  getContractState(): ContractState;
 }
+
+/**
+ * Extracts pure circuits from a contract type.
+ *
+ * Pure circuits are those in `circuits` but not in `impureCircuits`.
+ *
+ * @template TContract - Contract type with `circuits` and `impureCircuits`.
+ */
+export type ExtractPureCircuits<TContract> = TContract extends {
+  circuits: infer TCircuits extends Record<PropertyKey, unknown>;
+  impureCircuits: infer TImpureCircuits extends Record<PropertyKey, unknown>;
+}
+  ? Omit<TCircuits, keyof TImpureCircuits>
+  : never;
+
+/**
+ * Extracts impure circuits from a contract type.
+ *
+ * Impure circuits are those in `impureCircuits`.
+ *
+ * @template TContract - Contract type with `circuits` and `impureCircuits`.
+ */
+export type ExtractImpureCircuits<TContract> = TContract extends {
+  impureCircuits: infer TImpureCircuits;
+}
+  ? TImpureCircuits
+  : never;
+
+/**
+ * Transforms a collection of circuit functions by removing the explicit `CircuitContext` parameter,
+ * producing a version of each function that can be called without passing the context explicitly.
+ *
+ * Each original circuit function is expected to have the signature:
+ * `(ctx: CircuitContext<TState>, ...args) => { result: R; context: CircuitContext<TState> }`
+ * or a compatible shape.
+ *
+ * The transformed type maps each key `K` of the input `Circuits` type to a new function
+ * that takes the same parameters as the original, *except* the first `CircuitContext<TState>` argument,
+ * and returns the `result` part `R` directly.
+ *
+ * @template Circuits - An object type whose values are circuit functions accepting a `CircuitContext<TState>`
+ * and returning an object with `result` and optionally `context`.
+ * @template TState - The type representing the private or contract state passed inside `CircuitContext`.
+ */
+export type ContextlessCircuits<Circuits, TState> = {
+  [K in keyof Circuits]: Circuits[K] extends (
+    ctx: CircuitContext<TState>,
+    ...args: infer P
+  ) => { result: infer R; context: CircuitContext<TState> }
+    ? (...args: P) => R
+    : never;
+};
+
+export type SimulatorOptions<PS, WGen extends (...args: any[]) => any> = {
+  address?: string;
+  coinPK?: string;
+  privateState?: PS;
+  witnesses?: ReturnType<WGen>;
+};

--- a/contracts/src/access/test/utils/AbstractContractSimulator.ts
+++ b/contracts/src/access/test/utils/AbstractContractSimulator.ts
@@ -1,0 +1,131 @@
+import type {
+  CircuitContext,
+  ContractState,
+} from '@midnight-ntwrk/compact-runtime';
+import type { ContextlessCircuits, IContractSimulator } from '../types/test.js';
+
+/**
+ * Abstract base class for simulating contract behavior.
+ * Provides common functionality for managing circuit contexts and creating proxies
+ * for pure and impure circuit functions.
+ *
+ * @template P - The type representing the private state of the contract.
+ * @template L - The type representing the public ledger (contract) state.
+ */
+export abstract class AbstractContractSimulator<P, L>
+  implements IContractSimulator<P, L>
+{
+  /**
+   * The deployed contract's address.
+   * Must be implemented by concrete subclasses.
+   */
+  abstract readonly contractAddress: string;
+
+  /**
+   * The current circuit context containing private state, contract state, and transaction context.
+   * Must be implemented by concrete subclasses.
+   */
+  abstract circuitContext: CircuitContext<P>;
+
+  /**
+   * Retrieves the current public ledger state of the contract.
+   * Must be implemented by concrete subclasses.
+   *
+   * @returns The current public ledger state.
+   */
+  abstract getPublicState(): L;
+
+  /**
+   * Retrieves the current private state from the circuit context.
+   *
+   * @returns The current private state of the contract.
+   */
+  public getPrivateState(): P {
+    return this.circuitContext.currentPrivateState;
+  }
+
+  /**
+   * Retrieves the original contract state from the circuit context.
+   *
+   * @returns The original contract state.
+   */
+  public getContractState(): ContractState {
+    return this.circuitContext.originalState;
+  }
+
+  /**
+   * Creates a proxy wrapper around pure circuits.
+   * Pure circuits do not modify contract state, so only the result is returned.
+   *
+   * @template Circuits - The type of the circuits object to proxy.
+   * @param circuits - The original circuits object containing functions accepting a CircuitContext.
+   * @param context - A function returning the current CircuitContext to pass to circuit functions.
+   * @returns A proxy with contextless circuits that accept the original arguments and return only results.
+   */
+  protected createPureCircuitProxy<Circuits extends object>(
+    circuits: Circuits,
+    context: () => CircuitContext<P>,
+  ): ContextlessCircuits<Circuits, P> {
+    return new Proxy(circuits, {
+      get(target, prop, receiver) {
+        const original = Reflect.get(target, prop, receiver);
+
+        if (typeof original !== 'function') return original;
+
+        return (...args: any[]) => {
+          const ctx = context();
+
+          const fn = original as (
+            ctx: CircuitContext<P>,
+            ...args: any[]
+          ) => { result: any };
+
+          return fn(ctx, ...args).result;
+        };
+      },
+    }) as ContextlessCircuits<Circuits, P>;
+  }
+
+  /**
+   * Creates a proxy wrapper around impure circuits.
+   * Impure circuits can modify contract state, so the circuit context is updated accordingly.
+   *
+   * @template Circuits - The type of the circuits object to proxy.
+   * @param circuits - The original circuits object containing functions accepting a CircuitContext.
+   * @param context - A function returning the current CircuitContext to pass to circuit functions.
+   * @param updateContext - A callback to update the circuit context with the new context returned by the circuit.
+   * @returns A proxy with contextless circuits that accept the original arguments, update context, and return results.
+   */
+  protected createImpureCircuitProxy<Circuits extends object>(
+    circuits: Circuits,
+    context: () => CircuitContext<P>,
+    updateContext: (ctx: CircuitContext<P>) => void,
+  ): ContextlessCircuits<Circuits, P> {
+    return new Proxy(circuits, {
+      get(target, prop, receiver) {
+        const original = Reflect.get(target, prop, receiver);
+
+        if (typeof original !== 'function') return original;
+
+        return (...args: any[]) => {
+          const ctx = context();
+
+          const fn = original as (
+            ctx: CircuitContext<P>,
+            ...args: any[]
+          ) => { result: any; context: CircuitContext<P> };
+
+          const { result, context: newCtx } = fn(ctx, ...args);
+          updateContext(newCtx);
+          return result;
+        };
+      },
+    }) as ContextlessCircuits<Circuits, P>;
+  }
+
+  /**
+   * Optional method to reset any cached circuit proxies.
+   * Concrete subclasses can override this to clear proxies if needed.
+   */
+  public resetCircuitProxies?(): void {}
+}

--- a/contracts/src/access/test/utils/SimualatorStateManager.ts
+++ b/contracts/src/access/test/utils/SimualatorStateManager.ts
@@ -1,0 +1,115 @@
+import {
+  type CircuitContext,
+  type ConstructorContext,
+  type ContractState,
+  constructorContext,
+  QueryContext,
+  sampleContractAddress,
+} from '@midnight-ntwrk/compact-runtime';
+
+/**
+ * A composable utility class for managing Compact contract state in simulations.
+ *
+ * This class handles initialization and lifecycle management of the `CircuitContext`,
+ * which includes private state, public (ledger) state, zswap local state, and transaction context.
+ *
+ * It is designed to be embedded compositionally inside contract simulator classes
+ * (e.g., `FooSimulator`), enabling better separation of concerns and easier test setup.
+ *
+ * @template P - The type of the contract's private state.
+ *
+ * ### Responsibilities
+ * - Initializes the contract state using the compiled contract's `.initialState` method.
+ * - Stores and exposes the `CircuitContext` via getters/setters.
+ * - Supports injection of private state and contract constructor arguments.
+ * - Allows the owning simulator to update private state manually during testing.
+ *
+ * ### Example Usage:
+ * ```ts
+ * const contract = new MyContract(witnesses);
+ * const manager = new SimulatorStateManager(
+ *   contract,
+ *   { foo: 1n },                 // initial private state
+ *   '0'.repeat(64),              // coin public key
+ *   sampleContractAddress(),     // optional contract address
+ *   arg1, arg2                   // additional constructor args
+ * );
+ *
+ * const context = manager.getContext();
+ * ```
+ */
+export class SimulatorStateManager<P> {
+  private context: CircuitContext<P>;
+
+  /**
+   * Creates an instance of `SimulatorStateManager`.
+   *
+   * @param contract - A compiled Compact contract instance (from artifacts), exposing `initialState()`.
+   * @param privateState - The initial private state to inject into the contract.
+   * @param coinPK - The caller's coin public key (used to create the constructor context).
+   * @param contractAddress - Optional override for the contract's address. Defaults to `sampleContractAddress` if not provided.
+   * @param contractArgs - Additional arguments to pass to the contract constructor (e.g., circuit params).
+   */
+  constructor(
+    contract: {
+      initialState: (
+        ctx: ConstructorContext<P>,
+        ...args: any[]
+      ) => {
+        currentPrivateState: P;
+        currentContractState: ContractState;
+        currentZswapLocalState: any;
+      };
+    },
+    privateState: P,
+    coinPK: string,
+    contractAddress?: string,
+    ...contractArgs: any[]
+  ) {
+    const initCtx = constructorContext(privateState, coinPK);
+
+    const {
+      currentPrivateState,
+      currentContractState,
+      currentZswapLocalState,
+    } = contract.initialState(initCtx, ...contractArgs);
+
+    this.context = {
+      currentPrivateState,
+      currentZswapLocalState,
+      originalState: currentContractState,
+      transactionContext: new QueryContext(
+        currentContractState.data,
+        contractAddress ?? sampleContractAddress(),
+      ),
+    };
+  }
+
+  /**
+   * Retrieves the current `CircuitContext`, including private state,
+   * zswap state, contract state, and transaction context.
+   */
+  getContext(): CircuitContext<P> {
+    return this.context;
+  }
+
+  /**
+   * Replaces the internal `CircuitContext` with a new one.
+   *
+   * Useful when circuits mutate state and return an updated context.
+   */
+  setContext(newContext: CircuitContext<P>) {
+    this.context = newContext;
+  }
+
+  /**
+   * Updates just the private state inside the existing context.
+   *
+   * This is a lightweight way to simulate local state changes without reconstructing the full context.
+   *
+   * @param newPrivateState - The new private state object to apply.
+   */
+  updatePrivateState(newPrivateState: P) {
+    this.context.currentPrivateState = newPrivateState;
+  }
+}

--- a/contracts/src/access/test/utils/address.ts
+++ b/contracts/src/access/test/utils/address.ts
@@ -61,6 +61,30 @@ export const createEitherTestContractAddress = (str: string) => ({
   right: encodeToAddress(str),
 });
 
+const baseGeneratePubKeyPair = (
+  str: string,
+  asEither: boolean,
+): [
+  string,
+  (
+    | Compact.ZswapCoinPublicKey
+    | Compact.Either<Compact.ZswapCoinPublicKey, Compact.ContractAddress>
+  ),
+] => {
+  const pk = toHexPadded(str);
+  const zpk = asEither ? createEitherTestUser(str) : encodeToPK(str);
+  return [pk, zpk];
+};
+
+export const generatePubKeyPair = (str: string) =>
+  baseGeneratePubKeyPair(str, false) as [string, Compact.ZswapCoinPublicKey];
+
+export const generateEitherPubKeyPair = (str: string) =>
+  baseGeneratePubKeyPair(str, true) as [
+    string,
+    Compact.Either<Compact.ZswapCoinPublicKey, Compact.ContractAddress>,
+  ];
+
 export const zeroUint8Array = (length = 32) =>
   convert_bigint_to_Uint8Array(length, 0n);
 

--- a/contracts/src/access/test/utils/createCircuitProxies.ts
+++ b/contracts/src/access/test/utils/createCircuitProxies.ts
@@ -1,0 +1,64 @@
+import type { CircuitContext } from '@midnight-ntwrk/compact-runtime';
+import type {
+  ContextlessCircuits,
+  ExtractImpureCircuits,
+  ExtractPureCircuits,
+} from '../types/test.js';
+
+/**
+ * Creates lazily-initialized circuit proxies for pure and impure contract functions.
+ */
+export function createCircuitProxies<
+  P,
+  ContractType extends {
+    circuits: Record<PropertyKey, unknown>;
+    impureCircuits: Record<PropertyKey, unknown>;
+  },
+>(
+  contract: ContractType,
+  getContext: () => CircuitContext<P>,
+  getCallerContext: () => CircuitContext<P>,
+  updateContext: (ctx: CircuitContext<P>) => void,
+  createPureProxy: <C extends Record<PropertyKey, unknown>>(
+    circuits: C,
+    context: () => CircuitContext<P>,
+  ) => ContextlessCircuits<C, P>,
+  createImpureProxy: <C extends Record<PropertyKey, unknown>>(
+    circuits: C,
+    context: () => CircuitContext<P>,
+    updateContext: (ctx: CircuitContext<P>) => void,
+  ) => ContextlessCircuits<C, P>,
+) {
+  let pureProxy:
+    | ContextlessCircuits<ExtractPureCircuits<ContractType>, P>
+    | undefined;
+  let impureProxy:
+    | ContextlessCircuits<ExtractImpureCircuits<ContractType>, P>
+    | undefined;
+
+  return {
+    get circuits() {
+      if (!pureProxy) {
+        pureProxy = createPureProxy(
+          contract.circuits as ExtractPureCircuits<ContractType>,
+          getContext,
+        );
+      }
+      if (!impureProxy) {
+        impureProxy = createImpureProxy(
+          contract.impureCircuits as ExtractImpureCircuits<ContractType>,
+          getCallerContext,
+          updateContext,
+        );
+      }
+      return {
+        pure: pureProxy,
+        impure: impureProxy,
+      };
+    },
+    resetProxies() {
+      pureProxy = undefined;
+      impureProxy = undefined;
+    },
+  };
+}

--- a/contracts/src/access/test/utils/test.ts
+++ b/contracts/src/access/test/utils/test.ts
@@ -55,8 +55,8 @@ export function useCircuitContextSender<
   L,
   C extends IContractSimulator<P, L>,
 >(contract: C, sender: CoinPublicKey): CircuitContext<P> {
-  const currentPrivateState = contract.getCurrentPrivateState();
-  const originalState = contract.getCurrentContractState();
+  const currentPrivateState = contract.getPrivateState();
+  const originalState = contract.getContractState();
   const contractAddress = contract.contractAddress;
 
   return {

--- a/contracts/src/access/witnesses/ZOwnablePKWitnesses.ts
+++ b/contracts/src/access/witnesses/ZOwnablePKWitnesses.ts
@@ -1,0 +1,68 @@
+import { getRandomValues } from 'node:crypto';
+import type { WitnessContext } from '@midnight-ntwrk/compact-runtime';
+import type { Ledger } from '../../../artifacts/MockZOwnablePK/contract/index.cjs';
+
+/**
+ * @description Interface defining the witness methods for ZOwnablePK operations.
+ * @template P - The private state type.
+ */
+export interface IZOwnablePKWitnesses<P> {
+  /**
+   * Retrieves the secret nonce from the private state.
+   * @param context - The witness context containing the private state.
+   * @returns A tuple of the private state and the secret nonce as a Uint8Array.
+   */
+  wit_secretNonce(context: WitnessContext<Ledger, P>): [P, Uint8Array];
+}
+
+/**
+ * @description Represents the private state of an ownable contract, storing a secret nonce.
+ */
+export type ZOwnablePKPrivateState = {
+  /** @description A 32-byte secret nonce used as a privacy additive. */
+  secretNonce: Buffer;
+};
+
+/**
+ * @description Utility object for managing the private state of an Ownable contract.
+ */
+export const ZOwnablePKPrivateState = {
+  /**
+   * @description Generates a new private state with a random secret nonce.
+   * @returns A fresh ZOwnablePKPrivateState instance.
+   */
+  generate: (): ZOwnablePKPrivateState => {
+    return { secretNonce: getRandomValues(Buffer.alloc(32)) };
+  },
+
+  /**
+   * @description Generates a new private state with a user-defined secret nonce.
+   * Useful for deterministic nonce generation or advanced use cases.
+   *
+   * @param nonce - The 32-byte secret nonce to use.
+   * @returns A fresh ZOwnablePKPrivateState instance with the provided nonce.
+   *
+   * @example
+   * ```typescript
+   * // For deterministic nonces (user-defined scheme)
+   * const deterministicNonce = myDeterministicScheme(...);
+   * const privateState = ZOwnablePKPrivateState.withNonce(deterministicNonce);
+   * ```
+   */
+  withNonce: (nonce: Buffer): ZOwnablePKPrivateState => {
+    return { secretNonce: nonce };
+  },
+};
+
+/**
+ * @description Factory function creating witness implementations for Ownable operations.
+ * @returns An object implementing the Witnesses interface for ZOwnablePKPrivateState.
+ */
+export const ZOwnablePKWitnesses =
+  (): IZOwnablePKWitnesses<ZOwnablePKPrivateState> => ({
+    wit_secretNonce(
+      context: WitnessContext<Ledger, ZOwnablePKPrivateState>,
+    ): [ZOwnablePKPrivateState, Uint8Array] {
+      return [context.privateState, context.privateState.secretNonce];
+    },
+  });

--- a/docs/modules/ROOT/pages/access.adoc
+++ b/docs/modules/ROOT/pages/access.adoc
@@ -133,6 +133,254 @@ there is no direct way for a contract to call circuits of other contracts or tra
 
 NOTE: The unsafe circuits are planned to become deprecated once contract-to-contract calls become available.
 
+== Shielded Ownership and `ZOwnablePK`
+
+Privacy-preserving access control is a fundamental building block for confidential smart contracts on Midnight.
+While traditional ownership patterns expose the owner's identity on-chain,
+many applications require administrative control without revealing who holds that authority.
+
+=== Privacy-First Ownership
+
+The most common approach to access control in traditional smart contracts is ownership:
+there's an account that is the owner of a contract and can perform administrative tasks.
+However, this approach reveals the owner's identity to all observers, creating privacy and security risks.
+In privacy-sensitive applications—such as confidential voting systems, private treasuries, or anonymous governance—revealing the administrator's identity may compromise the entire system's confidentiality.
+This library provides the `ZOwnablePK` module that implements shielded ownership—administrative control without identity disclosure.
+The owner's public key is never revealed on-chain; instead,
+the contract stores only a cryptographic commitment that proves ownership without exposing the underlying identity.
+
+=== Commitment Scheme
+
+The `ZOwnablePK` module employs a two-layer cryptographic commitment scheme designed to provide privacy,
+unlinkability, and collision resistance across deployments and ownership transfers.
+
+==== Owner ID Computation
+
+The foundation of the system is the owner identifier, computed as:
+
+```ts
+id = SHA256(pk, nonce)
+```
+
+Where `pk` is the owner's public key and `nonce` is a secret value that may be either randomly generated
+for maximum privacy or deterministically derived for recoverability.
+This identifier serves as a privacy-preserving alternative to exposing the raw public key,
+ensuring the owner's identity remains confidential.
+
+==== Owner Commitment Computation
+
+The final ownership commitment stored on-chain is computed as:
+
+```ts
+commitment = SHA256(id, instanceSalt, counter, pad(32, "ZOwnablePK:shield:"))
+```
+
+This multi-element hash provides several security properties:
+
+- `id`: The privacy-preserving owner identifier described above.
+- `instanceSalt`: A unique per-deployment salt that prevents commitment collisions across different contract instances, even when the same owner and nonce are used.
+- `counter`: Incremented with each ownership transfer to ensure unlinkability—each transfer produces a completely different commitment even with the same underlying owner.
+- `pad(32, "ZOwnablePK:shield:")`: A domain separator padded to 32 bytes that prevents hash collisions with other commitment schemes and enables safe protocol extensions.
+
+==== Security Properties
+
+This commitment scheme ensures that:
+
+- Public keys are never revealed on-chain.
+- Observers cannot correlate past and future ownership.
+- Cross-contract collisions are prevented through instance-specific salting.
+
+=== Nonce Generation Strategies
+
+The choice of nonce generation strategy represents a fundamental trade-off between simplicity/security and recoverability.
+Both approaches are valid, and the best choice depends on your specific threat model and operational requirements.
+
+==== Random Nonce
+
+Generating a cryptographically strong random nonce provides the strongest privacy guarantees:
+
+```typescript
+const randomNonce = crypto.getRandomValues(new Uint8Array(32));
+const ownerId = ZOwnablePK._computeOwnerId(publicKey, randomNonce);
+```
+
+This approach is easy to generate and ensures maximum unlinkability—even with sophisticated analysis,
+observers cannot correlate ownership across different contracts or time periods.
+However, it requires secure backup of both the private key and the nonce.
+*Loss of either component results in permanent, irrecoverable loss of ownership.*
+
+==== Deterministic Nonce
+
+:rfc6979: https://datatracker.ietf.org/doc/html/rfc6979[RFC 6979]
+:ed25519: https://ed25519.cr.yp.to/[Ed25519]
+
+Deriving the nonce deterministically enables recovery through derivation schemes.
+Some examples:
+
+- `H(passphrase + context)` - recoverable from passphrase only, but passphrase becomes critical single point of failure.
+- `H(publicKey + userPassphrase + context)` - requires both public key and passphrase.
+- `H(signature + context)` where `signature = sign(context)` - leverages wallet without exposing private key.
+
+WARNING: When using signature-based nonce derivation,
+ensure the wallet/library uses deterministic signatures ({ed25519} or {rfc6979} for ECDSA).
+Non-deterministic signatures will generate different nonces on each signing, making recovery impossible.
+Test the implementation by signing the same message twice then verify that the signatures match.
+
+*Context-Dependent Derivations:*
+
+- Include contract address, deployment timestamp, user ID, etc.
+- Trade-off: more context is more unique but harder to recreate.
+
+WARNING: Approaches that avoid private key exposure (public key + passphrase, signature-based)
+are generally recommended for operational security.
+
+Deriving the nonce deterministically from an <<air_gapped_public_key_agpk,Air-Gapped Public Key>> and user passphrase provides a balance of security and recoverability:
+
+```typescript
+// Example: Scrypt-based derivation
+import { scryptSync } from 'node:crypto';
+
+const deterministicNonce = scryptSync(
+  userPassphrase
+  publicKey + ":ZOwnablePK:nonce:v1",
+  32,
+  { N: 16384, r: 8, p: 1 } // Standard scrypt parameters
+);
+const recoverableOwnerId = ZOwnablePK._computeOwnerId(publicKey, deterministicNonce);
+```
+
+**Security Considerations**
+
+The `ZOwnablePK` module remains agnostic to nonce generation methods, placing the security/convenience decision entirely with the user. Key considerations include:
+
+- **Backup requirements**: Random nonces require additional secure storage.
+- **Recovery scenarios**: Deterministic nonces enable recovery.
+- **Cross-contract correlation**: Reusing nonce strategies may reduce privacy across deployments.
+- **Rotation costs**: Changing nonces requires ownership transfer transactions with associated DUST costs.
+
+Users should carefully evaluate their threat model, operational requirements,
+and privacy needs when selecting a nonce generation strategy,
+as this choice cannot be easily changed without transferring ownership.
+
+=== Air-Gapped Public Key (AGPK)
+
+For maximum privacy guarantees,
+users should employ an Air-Gapped Public Key (AGPK) exclusively for contract ownership and administrative circuits.
+An AGPK is a public key that maintains complete isolation from all other on-chain activities,
+similar to how air-gapped systems are isolated from networks to prevent data leakage.
+
+==== The Privacy Enhancement
+
+While `ZOwnablePK` provides cryptographic privacy through its commitment scheme,
+operational security practices like using an AGPK provide an additional layer of protection against correlation attacks. Even with the strongest cryptographic commitments,
+reusing a public key across different on-chain activities can potentially compromise privacy
+through transaction pattern analysis.
+
+==== AGPK Principles
+
+An Air-Gapped Public Key must adhere to strict isolation principles:
+
+- *Never used before:* The private key material
+(including any seed, parent key, or entropy source from which this key is derived)
+has never generated any public key that appears in any on-chain transaction, across any blockchain network.
+The key material must be cryptographically pure.
+- *Never used elsewhere:* From the moment of AGPK generation until its destruction,
+the private key material is used exclusively for this contract's administrative functions (i.e. `assertOnlyOwner`).
+No other public keys may ever be derived from or generated with the same key material.
+- *Never used again:* Users commit to destroying all copies of the private key material
+upon ownership renunciation or transfer.
+This relies entirely on user discipline and cannot be externally verified or enforced.
+
+==== Best Practices Recommendation
+
+While neither required nor enforced by the `ZOwnablePK` module,
+an Air-Gapped Public Key provides strong operational privacy hygiene for shielded contract administration.
+Users should evaluate their threat model and privacy requirements when deciding whether to implement AGPK practices.
+
+WARNING: The effectiveness of an AGPK depends entirely on abiding by the AGPK principles.
+A single transaction using the key outside the administrative context compromises all privacy benefits.
+
+=== Usage
+
+Import the `ZOwnablePK` module into the implementing contract and expose the ownership-handling circuits.
+It’s recommended to prefix the module with `ZOwnablePK_` to avoid circuit signature clashes.
+
+```typescript
+// MyZOwnablePKContract.compact
+
+pragma language_version >= 0.16.0;
+
+import CompactStandardLibrary;
+import "./node_modules/@openzeppelin-compact/contracts/src/access/ZOwnablePK"
+  prefix ZOwnablePK_;
+
+constructor(
+  initOwnerCommitment: Bytes<32>,
+  instanceSalt: Bytes<32>,
+) {
+  ZOwnablePK_initialize(initOwnerCommitment, instanceSalt);
+}
+
+export circuit owner(): Bytes<32> {
+  return ZOwnablePK_owner();
+}
+
+export circuit transferOwnership(newOwnerCommitment: Bytes<32>): [] {
+  return ZOwnablePK_transferOwnership(disclose(newOwnerCommitment));
+}
+
+export circuit renounceOwnership(): [] {
+  return ZOwnablePK_renounceOwnership();
+}
+```
+
+Similar to the Ownable module,
+circuits can be protected so that only the contract owner may them by adding `assertOnlyOwner`
+as the first line in the circuit body like this:
+
+```typescript
+export circuit mySensitiveCircuit(): [] {
+  ZOwnablePK_assertOnlyOwner();
+
+  // Do something
+}
+```
+
+This covers the basics for creating a contract, but before deploying the contract,
+the owner's id must be derived for the commitment scheme because it's required to deploy the contract.
+
+First, the owner needs to generate a secret nonce that's stored in the owner's private state.
+See <<nonce_generation_strategies,Nonce Generation Strategies>>.
+
+Once the owner has the secret nonce generated, they can insert their public key and nonce into the following:
+
+```typescript
+import {
+  CompactTypeBytes,
+  CompactTypeVector,
+  persistentHash,
+} from '@midnight-ntwrk/compact-runtime';
+import { getRandomValues } from 'node:crypto';
+
+// Owner ID
+const generateId = (
+  pk: Uint8Array,
+  nonce: Uint8Array,
+): Uint8Array => {
+  const rt_type = new CompactTypeVector(2, new CompactTypeBytes(32));
+  return persistentHash(rt_type, [pk, nonce]);
+};
+
+// Instance salt for the constructor
+const generateInstanceSalt = (): Uint8Array => {
+  return getRandomValues(new Uint8Array(32));
+}
+```
+
+TIP: Another way to get the user ID is to expose `_computeOwnerId` in the contract
+and call this circuit off chain through a contract simulator.
+Be on the lookout for future tooling that makes this process easier.
+
 == Role-Based Access Control
 
 While the simplicity of _ownership_ can be useful for simple systems or quick prototyping, different levels of authorization are often needed.

--- a/docs/modules/ROOT/pages/api/access.adoc
+++ b/docs/modules/ROOT/pages/api/access.adoc
@@ -1,6 +1,8 @@
 :github-icon: pass:[<svg class="icon"><use href="#github-icon"/></svg>]
-:accessControl-guide: xref:accessControl.adoc[AccessControl guide]
-:ownable-guide: xref:ownable.adoc[Ownable guide]
+:accessControl-guide: xref:access.adoc#role_based_access_control[AccessControl guide]
+:ownable-guide: xref:access.adoc#ownership_and_ownable[Ownable guide]
+:zownablepk-guide: xref:access.adoc#shielded_ownership_and_zownablepk[ZOwnablePK guide]
+:agpk: xref:access.adoc#air_gapped_public_key_agpk[Air-Gapped Public Key]
 :grantRole: <<AccessControl-grantRole, grantRole>>
 :revokeRole: <<AccessControl-revokeRole, revokeRole>>
 
@@ -11,6 +13,8 @@ This directory provides ways to restrict who can access the circuits of a contra
 - `<<AccessControl,AccessControl>>` provides a per-contract role based access control mechanism. Multiple hierarchical roles can be created and assigned each to multiple accounts within the same instance.
 
 - `<<Ownable,Ownable>>` is a simpler mechanism with a single owner "role" that can be assigned to a single account. This simpler mechanism can be useful for quick tests but projects with production concerns are likely to outgrow it.
+
+- `<<ZOwnablePK,ZOwnablePK>>` provides a privacy-preserving single owner access control mechanism using cryptographic commitments. The owner's public key is never revealed on-chain, instead storing only a commitment that proves ownership without exposing identity, suitable for applications requiring administrative control with strong privacy guarantees.
 
 == Core
 
@@ -399,3 +403,201 @@ Requirements:
 Constraints:
 
 - k=10, rows=216
+
+[.contract]
+[[ZOwnablePK]]
+=== `++ZOwnablePK++` link:https://github.com/OpenZeppelin/compact-contracts/blob/main/contracts/ownable/src/ZOwnablePK.compact[{github-icon},role=heading-link]
+
+[.hljs-theme-dark]
+```ts
+import "./node_modules/@openzeppelin-compact/contracts/src/access/ZOwnablePK";
+```
+
+`ZOwnablePK` provides a privacy-preserving access control mechanism for contracts with a single administrative user. Unlike traditional `Ownable` implementations that store or expose the owner's public key on-chain,
+this module stores only a commitment to a hashed identifier derived from the owner's public key and a secret nonce.
+For the strongest security guarantees, use an {agpk}.
+
+Ownable provides a basic access control mechanism where an account (an owner) can be granted exclusive access to specific circuits.
+
+This module includes <<ZOwnablePK-assertOnlyOwner,ZOwnablePK-assertOnlyOwner>> to restrict a circuit to be used only by the owner.
+
+TIP: For an overview of the module, read the {zownablepk-guide}.
+
+[.contract-index]
+.Circuits
+--
+
+[.sub-index#ZOwnablePKModule]
+* xref:#ZOwnablePK-initialize[`++initialize(ownerId, instanceSalt)++`]
+* xref:#ZOwnablePK-owner[`++owner()++`]
+* xref:#ZOwnablePK-transferOwnership[`++transferOwnership(newOwnerId)++`]
+* xref:#ZOwnablePK-renounceOwnership[`++renounceOwnership()++`]
+* xref:#ZOwnablePK-assertOnlyOwner[`++assertOnlyOwner()++`]
+* xref:#ZOwnablePK-_computeOwnerCommitment[`++_computeOwnerCommitment(id, counter)++`]
+* xref:#ZOwnablePK-_computeOwnerId[`++_computeOwnerId(pk, nonce)++`]
+* xref:#ZOwnablePK-_transferOwnership[`++_transferOwnership(newOwnerId)++`]
+--
+
+[.contract-item]
+[[ZOwnablePK-initialize]]
+==== `[.contract-item-name]#++initialize++#++(initialOwner: Either<ZswapCoinPublicKey, ContractAddress>) → []++` [.item-kind]#circuit#
+
+Initializes the contract by setting the initial owner via `ownerId`
+and storing the `instanceSalt` that acts as a privacy additive
+for preventing duplicate commitments among other contracts implementing `ZOwnablePK`.
+
+NOTE: The `ownerId` must be calculated prior to contract deployment.
+See <<ZOwnablePK-_computeOwnerId,ZOwnablePK-_computeOwnerId]>>
+
+Requirements:
+
+- Contract is not already initialized.
+- `ownerId` is not an empty array.
+
+Constraints:
+
+- k=14, rows=14933
+
+[.contract-item]
+[[ZOwnablePK-owner]]
+==== `[.contract-item-name]#++owner++#++() → Bytes<32>++` [.item-kind]#circuit#
+
+Returns the current commitment representing the contract owner.
+The full commitment is: `SHA256(SHA256(pk, nonce), instanceSalt, counter, domain)`.
+
+Requirements:
+
+- Contract is initialized.
+
+Constraints:
+
+- k=10, rows=57
+
+[.contract-item]
+[[ZOwnablePK-transferOwnership]]
+==== `[.contract-item-name]#++transferOwnership++#++(newOwnerId: Bytes<32>) → []++` [.item-kind]#circuit#
+
+Transfers ownership of the contract to `newOwnerId`.
+`newOwnerId` must be precalculated and given to the current owner off chain.
+
+Requirements:
+
+- Contract is initialized.
+- Caller is the current contract owner.
+- `newOwnerId` is not an empty array.
+
+Constraints:
+
+- k=16, rows=39240
+
+[.contract-item]
+[[ZOwnablePK-renounceOwnership]]
+==== `[.contract-item-name]#++renounceOwnership++#++() → []++` [.item-kind]#circuit#
+
+Leaves the contract without an owner.
+It will not be possible to call <<ZOwnablePK-assertOnlyOwner,ZOwnablePK-assertOnlyOwner>> circuits anymore.
+Can only be called by the current owner.
+
+Requirements:
+
+- Contract is initialized.
+- Caller is the current owner.
+
+Constraints:
+
+- k=15, rows=24442
+
+[.contract-item]
+[[ZOwnablePK-assertOnlyOwner]]
+==== `[.contract-item-name]#++assertOnlyOwner++#++() → []++` [.item-kind]#circuit#
+
+Throws if called by any account whose id hash `SHA256(pk, nonce)` does not match the stored owner commitment.
+Use this to only allow the owner to call specific circuits.
+
+Requirements:
+
+- Contract is initialized.
+- Caller's id (`SHA256(pk, nonce)`) when used in <<ZOwnablePK-_computeOwnerCommitment,ZOwnablePK-_computeOwnerCommitment>> equals the stored `_ownerCommitment`,
+thus verifying themselves as the owner.
+
+Constraints:
+
+- k=15, rows=24437
+
+[.contract-item]
+[[ZOwnablePK-_computeOwnerCommitment]]
+==== `[.contract-item-name]#++_computeOwnerCommitment++#++(id: Bytes<32>, counter: Uint<64>) → Bytes<32>++` [.item-kind]#circuit#
+
+Computes the owner commitment from the given `id` and `counter`.
+
+**Owner ID (`id`)**
+
+The `id` is expected to be computed off-chain as: `id = SHA256(pk, nonce)`
+
+- `pk`: The owner's public key.
+- `nonce`: A secret nonce scoped to the instance, ideally rotated with each transfer.
+
+**Commitment Derivation**
+
+`commitment = SHA256(id, instanceSalt, counter, domain)`
+
+- `id`: See above.
+- `instanceSalt`: A unique per-deployment salt, stored during initialization.
+This prevents commitment collisions across deployments.
+- `counter`: Incremented with each ownership transfer, ensuring uniqueness even with repeated `id` values.
+Cast to `Field` then `Bytes<32>` for hashing.
+- `domain`: Domain separator `"ZOwnablePK:shield:"` (padded to 32 bytes) to prevent hash collisions
+when extending the module or using similar commitment schemes.
+
+Requirements:
+
+- Contract is initialized.
+
+Constraints:
+
+- k=14, rows=14853
+
+[.contract-item]
+[[ZOwnablePK-_computeOwnerId]]
+==== `[.contract-item-name]#++_computeOwnerId++#++(pk: Either<ZswapCoinPublicKey, ContractAddress>, nonce: Bytes<32>) → Bytes<32>++` [.item-kind]#circuit#
+
+Computes the unique identifier (`id`) of the owner from their public key and a secret nonce.
+
+**ID Derivation**
+`id = SHA256(pk, nonce)`
+
+- `pk`: The public key of the caller.
+This is passed explicitly to allow for off-chain derivation, testing, or scenarios
+where the caller is different from the subject of the computation.
+We recommend using an {agpk}.
+- `nonce`: A secret nonce tied to the identity.
+This value should be randomly generated and kept private.
+It may be rotated periodically for enhanced unlinkability.
+
+The result is a 32-byte commitment that uniquely identifies the owner.
+This value is later used in owner commitment hashing,
+and acts as a privacy-preserving alternative to a raw public key.
+
+NOTE: This module allows ownership to be tied to an identity commitment derived from a public key and secret nonce.
+While typically used with user public keys,
+this mechanism may also support contract addresses as identifiers in future contract-to-contract interactions.
+Both are treated as 32-byte values (`Bytes<32>`).
+
+Requirements:
+
+- Contract is initialized.
+- `pk` is not a ContractAddress.
+
+[.contract-item]
+[[ZOwnablePK-_transferOwnership]]
+==== `[.contract-item-name]#++_transferOwnership++#++(newOwnerId: Bytes<32>) → []++` [.item-kind]#circuit#
+
+Transfers ownership to owner id `newOwnerId` without enforcing permission checks on the caller.
+
+Requirements:
+
+- Contract is initialized.
+
+Constraints:
+
+- k=14, rows=14823


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

## Types of changes

What types of changes does your code introduce to OpenZeppelin Midnight Contracts?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

Fixes #40. Supercedes #61.

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->

## PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [x] I have read the [Contributing Guide](CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added documentation of new methods and any new behavior or changes to existing behavior
- [x] CI Workflows Are Passing

### Overview

This PR proposes to add the ZOwnablePK module which is a variant of the transparent Ownable module. ZOwnablePK allows an account to perform administrative tasks on a contract (circuits protected with `assertOnlyOwner`) while also never revealing the account's public key. The foundation of this design is the user's identifier which is a hash of the user's public key and secret nonce (stored in the user's private state). This design does not enforce how the nonce is derived; therefore, users may choose to make the nonce deterministic and thus retrievable if it is lost. 

### Ownership transfers

Since public keys are neither stored nor revealed, transferring ownership requires off chain communication. In order for Alice to transfer ownership to Bob, Alice needs Bob's id (`H(pk, secretNonce)`). This handshake approach ensures that even in the most adversarial conditions, Alice and Bob are not required to reveal their respective public keys to each other

### Ownership commitment

The ownership commitment is the only user identifier stored on the ledger. The commitment consists of:
- `id`: The privacy-preserving owner identifier -> `H(pk, secretNonce)`.
- `instanceSalt`: A unique per-deployment salt that prevents commitment collisions across different contract instances, even when the same owner and nonce are used (though, it's strongly recommended to rotate the secretNonce after it's been used)
- `counter`: Incremented with each ownership transfer to ensure unlinkability—each transfer produces a completely different commitment even with the same underlying owner.
- `pad(32, "ZOwnablePK:shield:")`: A domain separator padded to 32 bytes that prevents hash collisions with other commitment schemes and enables safe protocol extensions.