### PR TITLE
Remove packageManager override from compact package

### DIFF
--- a/compact/package.json
+++ b/compact/package.json
@@ -1,5 +1,4 @@
 {
-  "packageManager": "yarn@4.1.0",
   "name": "@openzeppelin-compact/compact",
   "private": true,
   "version": "0.0.1",


### PR DESCRIPTION
Remove packageManager override from compact package to keep yarn version in sync across workspace  