### PR TITLE
Bump yarn to newest stable version

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "openzeppelin-compact",
   "description": "Secure Smart Contract library written in Compact for Midnight",
   "private": true,
-  "packageManager": "yarn@4.9.4",
+  "packageManager": "yarn@4.10.3",
   "workspaces": [
     "compact/",
     "contracts/",


### PR DESCRIPTION
Bumps yarn 4.9.4 -> 4.10.3
