### PR TITLE
fix(`simulator`): Export `IMinimalContract` type to prevent TS2742 errors

### DIFF
--- a/packages/simulator/src/index.ts
+++ b/packages/simulator/src/index.ts
@@ -9,5 +9,6 @@ export type {
   ExtractImpureCircuits,
   ExtractPureCircuits,
   IContractSimulator,
+  IMinimalContract
 } from './types/index.js';
 export type { BaseSimulatorOptions } from './types/Options.js';


### PR DESCRIPTION
## Summary
This PR re-exports the `IMinimalContract` type from the simulator package’s main barrel file to ensure it’s publicly available.
Previously, consumers encountered a TS2742 error (The inferred type of 'MySimulatorBase' cannot be named without a reference...) due to `IMinimalContract` being referenced from an internal path in generated declarations.

## Changes

- Added `IMinimalContract` export to the main `index.ts` barrel file of the `simulator` package.

- Verified that declaration generation no longer references internal module paths.

## Result

Consumers no longer see TS2742 errors related to inferred types from internal files.

NOTE: Description generated by ChatGPT