### PR TITLE
Pin versions to sha commit

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -29,7 +29,7 @@ runs:
       run: corepack enable
 
     - name: Cache turbo build setup
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: .turbo
         key: ${{ runner.os }}-turbo-${{ hashFiles('.turbo/*') }}-${{ github.sha }}
@@ -38,7 +38,7 @@ runs:
 
     - name: Cache Compact compiler
       if: inputs.skip-compact != 'true'
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       id: compact-cache
       with:
         path: |
@@ -46,7 +46,7 @@ runs:
         key: compact-compiler-${{ env.COMPILER_VERSION }}-${{ runner.os }}
 
     - name: Setup Node.js
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
       with:
         node-version-file: ".nvmrc"
         cache: "yarn"

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           fetch-depth: 2 # Recommended by turbo team
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           fetch-depth: 2 # Recommended by turbo team
 
@@ -35,13 +35,13 @@ jobs:
         uses: ./.github/actions/setup
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@fe4161a26a8629af62121b670040955b330f9af2 # v4
         with:
           languages: ${{ matrix.language }}
           # We can add custom queries later when needed
           # queries: security-extended
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@fe4161a26a8629af62121b670040955b330f9af2 # v4
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: Setup Environment
         uses: ./.github/actions/setup
@@ -35,7 +35,7 @@ jobs:
           echo "✅ Version consistency validated: $RELEASE_VERSION"
 
       - name: Setup npm registry
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
         with:
           registry-url: "https://registry.npmjs.org"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           fetch-depth: 2 # Recommended by turbo team
 


### PR DESCRIPTION
Enhances supply chain security of Github workflows by pinning action versions to specific SHA commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build system dependencies to pinned versions for improved reliability and consistency across builds.
  * Enhanced caching mechanism with fallback options to optimize build performance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->