### PR TITLE
Add node auth token to release 

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ yarn && \
 SKIP_ZK=true yarn compact
 ```
 
-
 ### Write a custom contract using library modules
 
 In the root of `my-project`, create a custom contract using OpenZeppelin Compact modules.


### PR DESCRIPTION
Packages need to be published first before using OICD hence the auth token

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to improve npm publish authentication handling.

---

**Note:** This release contains no user-facing changes. The update addresses internal release process infrastructure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->