### PR TITLE
Remove artifact ledger from witnesses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changes
 
-- Use generic ledger type in ZOwnablePKWitnesses (#)
+- Use generic ledger type in ZOwnablePKWitnesses (#389)
 - Bump compact compiler to v0.29.0 (#366)
 
 ## 0.0.1-alpha.1 (2025-12-2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changes
 
+- Use generic ledger type in ZOwnablePKWitnesses (#)
 - Bump compact compiler to v0.29.0 (#366)
 
 ## 0.0.1-alpha.1 (2025-12-2)

--- a/contracts/src/access/test/simulators/ZOwnablePKSimulator.ts
+++ b/contracts/src/access/test/simulators/ZOwnablePKSimulator.ts
@@ -14,14 +14,15 @@ import {
   ZOwnablePKWitnesses,
 } from '../../witnesses/ZOwnablePKWitnesses.js';
 
-/**
- * Type constructor args
- */
+/** Type constructor args */
 type ZOwnablePKArgs = readonly [
   owner: Uint8Array,
   instanceSalt: Uint8Array,
   isInit: boolean,
 ];
+
+/** Concrete ledger type extracted from the generated artifact */
+type ZOwnablePKLedger = ReturnType<typeof ledger>;
 
 /**
  * Base simulator
@@ -47,7 +48,7 @@ const ZOwnablePKSimulatorBase: any = createSimulator<
     return [owner, instanceSalt, isInit];
   },
   ledgerExtractor: (state) => ledger(state),
-  witnessesFactory: () => ZOwnablePKWitnesses(),
+  witnessesFactory: () => ZOwnablePKWitnesses<ZOwnablePKLedger>(),
 });
 
 /**

--- a/contracts/src/access/witnesses/ZOwnablePKWitnesses.ts
+++ b/contracts/src/access/witnesses/ZOwnablePKWitnesses.ts
@@ -1,18 +1,17 @@
 import { getRandomValues } from 'node:crypto';
 import type { WitnessContext } from '@midnight-ntwrk/compact-runtime';
-import type { Ledger } from '../../../artifacts/MockZOwnablePK/contract/index.js';
 
 /**
  * @description Interface defining the witness methods for ZOwnablePK operations.
  * @template P - The private state type.
  */
-export interface IZOwnablePKWitnesses<P> {
+export interface IZOwnablePKWitnesses<L, P> {
   /**
    * Retrieves the secret nonce from the private state.
    * @param context - The witness context containing the private state.
    * @returns A tuple of the private state and the secret nonce as a Uint8Array.
    */
-  wit_secretNonce(context: WitnessContext<Ledger, P>): [P, Uint8Array];
+  wit_secretNonce(context: WitnessContext<L, P>): [P, Uint8Array];
 }
 
 /**
@@ -58,11 +57,13 @@ export const ZOwnablePKPrivateState = {
  * @description Factory function creating witness implementations for Ownable operations.
  * @returns An object implementing the Witnesses interface for ZOwnablePKPrivateState.
  */
-export const ZOwnablePKWitnesses =
-  (): IZOwnablePKWitnesses<ZOwnablePKPrivateState> => ({
-    wit_secretNonce(
-      context: WitnessContext<Ledger, ZOwnablePKPrivateState>,
-    ): [ZOwnablePKPrivateState, Uint8Array] {
-      return [context.privateState, context.privateState.secretNonce];
-    },
-  });
+export const ZOwnablePKWitnesses = <L>(): IZOwnablePKWitnesses<
+  L,
+  ZOwnablePKPrivateState
+> => ({
+  wit_secretNonce(
+    context: WitnessContext<L, ZOwnablePKPrivateState>,
+  ): [ZOwnablePKPrivateState, Uint8Array] {
+    return [context.privateState, context.privateState.secretNonce];
+  },
+});

--- a/contracts/src/access/witnesses/ZOwnablePKWitnesses.ts
+++ b/contracts/src/access/witnesses/ZOwnablePKWitnesses.ts
@@ -3,12 +3,13 @@ import type { WitnessContext } from '@midnight-ntwrk/compact-runtime';
 
 /**
  * @description Interface defining the witness methods for ZOwnablePK operations.
+ * @template L - The ledger type.
  * @template P - The private state type.
  */
 export interface IZOwnablePKWitnesses<L, P> {
   /**
    * Retrieves the secret nonce from the private state.
-   * @param context - The witness context containing the private state.
+   * @param context - The witness context containing the ledger and private state.
    * @returns A tuple of the private state and the secret nonce as a Uint8Array.
    */
   wit_secretNonce(context: WitnessContext<L, P>): [P, Uint8Array];
@@ -55,6 +56,7 @@ export const ZOwnablePKPrivateState = {
 
 /**
  * @description Factory function creating witness implementations for Ownable operations.
+ * @template L - The ledger type, supplied by the simulator.
  * @returns An object implementing the Witnesses interface for ZOwnablePKPrivateState.
  */
 export const ZOwnablePKWitnesses = <L>(): IZOwnablePKWitnesses<

--- a/packages/simulator/README.md
+++ b/packages/simulator/README.md
@@ -20,7 +20,10 @@ import { Contract, ledger } from './artifacts/MyContract/contract/index.js';
 // 1. Define your contract arguments type
 type MyContractArgs = readonly [owner: Uint8Array, value: bigint];
 
-// 2. Create the simulator
+// 2. Define the extracted ledger type
+type MyContractLedger = ReturnType<typeof ledger>;
+
+// 3. Create the simulator
 const MySimulator = createSimulator<
   MyPrivateState,
   ReturnType<typeof ledger>,
@@ -31,10 +34,10 @@ const MySimulator = createSimulator<
   defaultPrivateState: () => MyPrivateState.generate(),
   contractArgs: (owner, value) => [owner, value],
   ledgerExtractor: (state) => ledger(state),
-  witnessesFactory: () => MyWitnesses(),
+  witnessesFactory: () => MyWitnesses<MyContractLedger>(),
 });
 
-// 3. Use it!
+// 4. Use it!
 const sim = new MySimulator([ownerAddress, 100n], { coinPK: deployerPK });
 ```
 
@@ -52,6 +55,9 @@ import { MyContractWitnesses, MyContractPrivateState } from './MyContractWitness
 // Define contract constructor arguments as a tuple type
 type MyContractArgs = readonly [arg1: bigint, arg2: string];
 
+// Define the extracted ledger type
+type MyContractLedger = ReturnType<typeof ledger>;
+
 // Create the base simulator with full type information
 const MyContractSimulatorBase = createSimulator<
   MyContractPrivateState,                    // Private state type
@@ -63,7 +69,7 @@ const MyContractSimulatorBase = createSimulator<
   defaultPrivateState: () => MyContractPrivateState.generate(),
   contractArgs: (arg1, arg2) => [arg1, arg2],
   ledgerExtractor: (state) => ledger(state),
-  witnessesFactory: () => MyContractWitnesses(),  // Note: Must be a function!
+  witnessesFactory: () => MyContractWitnesses<MyContractLedger>(),  // Note: Must be a function!
 });
 ```
 
@@ -76,7 +82,7 @@ If the Compact contract has no witnesses:
 // Some Compact contract examples use:
 export const MyContractWitnesses = {};
 
-// But for the simulator, wrap it in a function:
+// But for the simulator, wrap it in a generic function:
 export const MyContractWitnesses = () => ({});
 ```
 

--- a/packages/simulator/test/fixtures/sample-contracts/witnesses/SampleZOwnableWitnesses.ts
+++ b/packages/simulator/test/fixtures/sample-contracts/witnesses/SampleZOwnableWitnesses.ts
@@ -1,18 +1,17 @@
 import { getRandomValues } from 'node:crypto';
 import type { WitnessContext } from '@midnight-ntwrk/compact-runtime';
-import type { Ledger } from '../../artifacts/SampleZOwnable/contract/index.js';
 
 /**
  * @description Interface defining the witness methods for SampleZOwnable operations.
  * @template P - The private state type.
  */
-export interface ISampleZOwnableWitnesses<P> {
+export interface ISampleZOwnableWitnesses<L, P> {
   /**
    * Retrieves the secret nonce from the private state.
    * @param context - The witness context containing the private state.
    * @returns A tuple of the private state and the secret nonce as a Uint8Array.
    */
-  secretNonce(context: WitnessContext<Ledger, P>): [P, Uint8Array];
+  secretNonce(context: WitnessContext<L, P>): [P, Uint8Array];
 }
 
 /**
@@ -58,11 +57,13 @@ export const SampleZOwnablePrivateState = {
  * @description Factory function creating witness implementations for Ownable operations.
  * @returns An object implementing the Witnesses interface for SampleZOwnablePrivateState.
  */
-export const SampleZOwnableWitnesses =
-  (): ISampleZOwnableWitnesses<SampleZOwnablePrivateState> => ({
-    secretNonce(
-      context: WitnessContext<Ledger, SampleZOwnablePrivateState>,
-    ): [SampleZOwnablePrivateState, Uint8Array] {
-      return [context.privateState, context.privateState.secretNonce];
-    },
-  });
+export const SampleZOwnableWitnesses = <L>(): ISampleZOwnableWitnesses<
+  L,
+  SampleZOwnablePrivateState
+> => ({
+  secretNonce(
+    context: WitnessContext<L, SampleZOwnablePrivateState>,
+  ): [SampleZOwnablePrivateState, Uint8Array] {
+    return [context.privateState, context.privateState.secretNonce];
+  },
+});

--- a/packages/simulator/test/fixtures/sample-contracts/witnesses/SampleZOwnableWitnesses.ts
+++ b/packages/simulator/test/fixtures/sample-contracts/witnesses/SampleZOwnableWitnesses.ts
@@ -3,12 +3,13 @@ import type { WitnessContext } from '@midnight-ntwrk/compact-runtime';
 
 /**
  * @description Interface defining the witness methods for SampleZOwnable operations.
+ * @template L - The ledger type.
  * @template P - The private state type.
  */
 export interface ISampleZOwnableWitnesses<L, P> {
   /**
    * Retrieves the secret nonce from the private state.
-   * @param context - The witness context containing the private state.
+   * @param context - The witness context containing the ledger and private state.
    * @returns A tuple of the private state and the secret nonce as a Uint8Array.
    */
   secretNonce(context: WitnessContext<L, P>): [P, Uint8Array];
@@ -55,6 +56,7 @@ export const SampleZOwnablePrivateState = {
 
 /**
  * @description Factory function creating witness implementations for Ownable operations.
+ * @template L - The ledger type, supplied by the simulator.
  * @returns An object implementing the Witnesses interface for SampleZOwnablePrivateState.
  */
 export const SampleZOwnableWitnesses = <L>(): ISampleZOwnableWitnesses<

--- a/packages/simulator/test/fixtures/sample-contracts/witnesses/WitnessWitnesses.ts
+++ b/packages/simulator/test/fixtures/sample-contracts/witnesses/WitnessWitnesses.ts
@@ -1,6 +1,5 @@
 import { getRandomValues } from 'node:crypto';
 import type { WitnessContext } from '@midnight-ntwrk/compact-runtime';
-import type { Ledger } from '../../artifacts/Witness/contract/index.js';
 
 const randomBigInt = (bits: number): bigint => {
   const bytes = Math.ceil(bits / 8);
@@ -16,14 +15,14 @@ const randomBigInt = (bits: number): bigint => {
   return result % max;
 };
 
-export interface IWitnessWitnesses<P> {
-  wit_secretBytes(context: WitnessContext<Ledger, P>): [P, Uint8Array];
+export interface IWitnessWitnesses<L, P> {
+  wit_secretBytes(context: WitnessContext<L, P>): [P, Uint8Array];
   wit_secretFieldPlusArg(
-    context: WitnessContext<Ledger, P>,
+    context: WitnessContext<L, P>,
     arg: bigint,
   ): [P, bigint];
   wit_secretUintPlusArgs(
-    context: WitnessContext<Ledger, P>,
+    context: WitnessContext<L, P>,
     arg1: bigint,
     arg2: bigint,
   ): [P, bigint];
@@ -45,20 +44,23 @@ export const WitnessPrivateState = {
   },
 };
 
-export const WitnessWitnesses = (): IWitnessWitnesses<WitnessPrivateState> => ({
+export const WitnessWitnesses = <L>(): IWitnessWitnesses<
+  L,
+  WitnessPrivateState
+> => ({
   wit_secretBytes(
-    context: WitnessContext<Ledger, WitnessPrivateState>,
+    context: WitnessContext<L, WitnessPrivateState>,
   ): [WitnessPrivateState, Uint8Array] {
     return [context.privateState, context.privateState.secretBytes];
   },
   wit_secretFieldPlusArg(
-    context: WitnessContext<Ledger, WitnessPrivateState>,
+    context: WitnessContext<L, WitnessPrivateState>,
     arg: bigint,
   ): [WitnessPrivateState, bigint] {
     return [context.privateState, context.privateState.secretField + arg];
   },
   wit_secretUintPlusArgs(
-    context: WitnessContext<Ledger, WitnessPrivateState>,
+    context: WitnessContext<L, WitnessPrivateState>,
     arg1: bigint,
     arg2: bigint,
   ): [WitnessPrivateState, bigint] {

--- a/packages/simulator/test/integration/SampleZOwnableSimulator.ts
+++ b/packages/simulator/test/integration/SampleZOwnableSimulator.ts
@@ -11,13 +11,14 @@ import {
   SampleZOwnableWitnesses,
 } from '../fixtures/sample-contracts/witnesses/SampleZOwnableWitnesses';
 
-/**
- * Type constructor args
- */
+/** Type constructor args */
 type SampleZOwnableArgs = readonly [
   owner: Uint8Array,
   instanceSalt: Uint8Array,
 ];
+
+/** Concrete ledger type extracted from the generated artifact */
+type SampleZOwnableLedger = ReturnType<typeof ledger>;
 
 /**
  * Base simulator
@@ -36,7 +37,7 @@ const SampleZOwnableSimulatorBase = createSimulator<
     return [owner, instanceSalt];
   },
   ledgerExtractor: (state) => ledger(state),
-  witnessesFactory: () => SampleZOwnableWitnesses(),
+  witnessesFactory: () => SampleZOwnableWitnesses<SampleZOwnableLedger>(),
 });
 
 /**

--- a/packages/simulator/test/integration/WitnessSimulator.ts
+++ b/packages/simulator/test/integration/WitnessSimulator.ts
@@ -8,10 +8,11 @@ import {
   WitnessWitnesses,
 } from '../fixtures/sample-contracts/witnesses/WitnessWitnesses';
 
-/**
- * Type constructor args
- */
+/** Type constructor args */
 type WitnessArgs = readonly [];
+
+/** Concrete ledger type extracted from the generated artifact */
+type WitnessLedger = ReturnType<typeof ledger>;
 
 /**
  * Base simulator
@@ -30,7 +31,7 @@ const WitnessSimulatorBase = createSimulator<
     return [];
   },
   ledgerExtractor: (state) => ledger(state),
-  witnessesFactory: () => WitnessWitnesses(),
+  witnessesFactory: () => WitnessWitnesses<WitnessLedger>(),
 });
 
 /**


### PR DESCRIPTION
This PR proposes to use a generic ledger in the ZOwnablePK witnesses file. This removes the witness dependence on the generated artifact (which is from the mock contract). Updating the simulator is relatively straightforward bc it already has access to the ledger

This PR also updates the simulator package accordingly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated simulator documentation and examples with improved type patterns and workflow guidance.

* **Refactor**
  * Enhanced type system for witness factories and interfaces to support better ledger type inference across the simulator framework.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->