### PR TITLE
fix(tokens): l-03 tokens uris presist accross burn and remint

### DIFF
--- a/contracts/src/token/NonFungibleToken.compact
+++ b/contracts/src/token/NonFungibleToken.compact
@@ -629,6 +629,7 @@ module NonFungibleToken {
     Initializable_assertInitialized();
     const previousOwner = _update(shieldedBurnAddress(), tokenId, shieldedBurnAddress());
     assert(!Utils_isKeyOrAddressZero(previousOwner), "NonFungibleToken: Invalid Sender");
+    _tokenURIs.remove(disclose(tokenId));
   }
 
   /**

--- a/contracts/src/token/test/nonFungibleToken.test.ts
+++ b/contracts/src/token/test/nonFungibleToken.test.ts
@@ -785,6 +785,16 @@ describe('NonFungibleToken', () => {
       expect(token._ownerOf(TOKENID_1)).toEqual(ZERO_KEY);
       expect(token._getApproved(TOKENID_1)).toEqual(ZERO_KEY);
     });
+
+    it('should clear tokenURI on burn', () => {
+      token._setTokenURI(TOKENID_1, SOME_URI);
+      expect(token.tokenURI(TOKENID_1)).toEqual(SOME_URI);
+
+      token._burn(TOKENID_1);
+
+      token._mint(Z_OWNER, TOKENID_1);
+      expect(token.tokenURI(TOKENID_1)).toEqual(EMPTY_URI);
+    });
   });
 
   describe('_transfer', () => {


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

## Types of changes

What types of changes does your code introduce to OpenZeppelin Midnight Contracts?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

Fixes #427 

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->

## PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md#your-first-code-contribution)
- [ ] I have added tests that prove my fix is effective or that my feature works. See [GUIDELINES.md#testing](../GUIDELINES.md#testing) for more information.
- [ ] I have added documentation for new methods or changes to existing method behavior. See [GUIDELINES.md#documentation](../GUIDELINES.md#documentation) for more information.
- [ ] CI Workflows Are Passing

#### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Token burning now properly removes associated metadata, ensuring complete cleanup when tokens are destroyed.

* **Tests**
  * Added test validation confirming that stored metadata is correctly cleared when tokens are burned and reminted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->