### PR TITLE
AccessControl: replace ownPublicKey with witness-derived id scheme

### DIFF
--- a/contracts/src/access/AccessControl.compact
+++ b/contracts/src/access/AccessControl.compact
@@ -84,6 +84,14 @@ pragma language_version >= 0.21.0;
  *   Any DApp may provide any implementation. The ZK proof system constrains what values
  *   can produce valid proofs.
  *
+ * @dev Canonicalization
+ * All `Either<Bytes<32>, ContractAddress>` values used as map keys in `_operatorRoles`
+ * are canonicalized before reads and writes. Canonicalization zeroes out the inactive
+ * branch of the Either, ensuring that two values with the same active branch always
+ * resolve to the same map key regardless of what data the inactive branch carries.
+ * `hasRole` canonicalizes on read. `_unsafeGrantRole` and `_revokeRole` canonicalize
+ * on write. Internal circuits use `_hasRole` which assumes pre-canonicalized inputs.
+ *
  * @notice Missing Features and Improvements:
  *
  * - Role events

--- a/contracts/src/access/AccessControl.compact
+++ b/contracts/src/access/AccessControl.compact
@@ -9,13 +9,24 @@ pragma language_version >= 0.21.0;
  * This module provides a role-based access control mechanism, where roles can be used to
  * represent a set of permissions.
  *
+ * Authorization is based on a witness-derived identity scheme. Each caller proves knowledge
+ * of a secret key by injecting it via the `wit_AccessControlSK` witness. The module computes
+ * an account identifier as `persistentHash(secretKey)` which is a commitment that hides the key
+ * while providing a stable, pseudonymous on-chain identity.
+ *
+ * Because the account identifier is `H(secretKey)` with no per-deployment salt or domain
+ * separator, the same secret key produces the same identity across all contracts. This is
+ * intentional. It provides a linkable pseudonymous identity analogous to Solidity's
+ * `msg.sender`. Users who desire cross-contract unlinkability can use different secret keys
+ * per contract at the wallet layer.
+ *
  * Roles are referred to by their `Bytes<32>` identifier. These should be exposed
  * in the top-level contract and be unique. One way to achieve this is by
  * using `export sealed ledger` hash digests that are initialized in the top-level contract:
  *
- * ```typescript
+ * ```compact
  * import CompactStandardLibrary;
- * import "./node_modules/@openzeppelin-compact/accessControl/src/AccessControl" prefix AccessControl_;
+ * import "./node_modules/@myProject/accessControl/src/AccessControl" prefix AccessControl_;
  *
  * export sealed ledger MY_ROLE: Bytes<32>;
  *
@@ -26,10 +37,10 @@ pragma language_version >= 0.21.0;
  *
  * To restrict access to a circuit, use {assertOnlyRole}:
  *
- * ```typescript
+ * ```compact
  * circuit foo(): [] {
- *  assertOnlyRole(MY_ROLE);
- *  ...
+ *  AccessControl_assertOnlyRole(MY_ROLE);
+ *  // ... rest of circuit logic
  * }
  * ```
  *
@@ -47,7 +58,7 @@ pragma language_version >= 0.21.0;
  * grant and revoke this role. Extra precautions should be taken to secure
  * accounts that have been granted it.
  *
- * @notice Roles can only be granted to ZswapCoinPublicKeys
+ * @notice Roles can only be granted to Bytes<32> identifiers
  * through the main role approval circuits (`grantRole` and `_grantRole`).
  * In other words, role approvals to contract addresses are disallowed through these
  * circuits.
@@ -64,6 +75,16 @@ pragma language_version >= 0.21.0;
  * @notice The unsafe circuits are planned to become deprecated once contract-to-contract calls
  * are supported.
  *
+ * @dev Security Considerations:
+ * - The `secretKey` must be kept private. Loss of the key prevents role holders
+ *   from proving access. Key exposure allows impersonation.
+ * - It is strongly recommended to use cryptographically secure random values for the secret key
+ *   (e.g., `crypto.getRandomValues()`). Weak or predictable keys can be brute-forced.
+ * - The `secretKey` is provided via the `wit_AccessControlSK` witness. As with all witnesses,
+ *   the contract must not assume that the witness implementation matches the developer's code.
+ *   Any DApp may provide any implementation. The ZK proof system constrains what values
+ *   can produce valid proofs.
+ *
  * @notice Missing Features and Improvements:
  *
  * - Role events
@@ -71,18 +92,17 @@ pragma language_version >= 0.21.0;
  */
 module AccessControl {
   import CompactStandardLibrary;
-  import "../utils/Utils" prefix Utils_;
 
   /**
    * @description Mapping from a role identifier -> account -> its permissions.
    * @type {Bytes<32>} roleId - A hash representing a role identifier.
-   * @type {Map<Either<ZswapCoinPublicKey, ContractAddress>, Boolean>} hasRole - A mapping from an account to a
+   * @type {Map<Either<Bytes<32>, ContractAddress>, Boolean>} hasRole - A mapping from an account to a
    * Boolean determining if the account is approved for a role.
    * @type {Map<roleId, hasRole>}
-   * @type {Map<Bytes<32>, Map<Either<ZswapCoinPublicKey, ContractAddress>, Boolean>} _operatorRoles
-   */
+   * @type {Map<Bytes<32>, Map<Either<Bytes<32>, ContractAddress>, Boolean>>} _operatorRoles
+   */
   export ledger _operatorRoles: Map<Bytes<32>,
-                                    Map<Either<ZswapCoinPublicKey, ContractAddress>, Boolean>>;
+                                    Map<Either<Bytes<32>, ContractAddress>, Boolean>>;
 
   /**
    * @description Mapping from a role identifier to an admin role identifier.
@@ -90,22 +110,33 @@ module AccessControl {
    * @type {Bytes<32>} adminId - A hash representing an admin identifier.
    * @type {Map<roleId, adminId>}
    * @type {Map<Bytes<32>, Bytes<32>>} _adminRoles
-   */
+   */
   export ledger _adminRoles: Map<Bytes<32>, Bytes<32>>;
 
   export ledger DEFAULT_ADMIN_ROLE: Bytes<32>;
 
   /**
+   * @witness wit_AccessControlSK
+   * @description Returns the caller's secret key used in deriving the account identifier.
+   *
+   * The same key produces the same account identifier across all contracts. Users who
+   * desire cross-contract unlinkability should use different keys per contract.
+   *
+   * @returns {Bytes<32>} secretKey - A 32-byte cryptographically secure random value.
+   */
+  witness wit_AccessControlSK(): Bytes<32>;
+
+  /**
    * @description Returns `true` if `account` has been granted `roleId`.
    *
-   * @circuitInfo k=10, rows=487
+   * @circuitInfo k=10, rows=1007
    *
    * @param {Bytes<32>} roleId - The role identifier.
-   * @param {Either<ZswapCoinPublicKey, ContractAddress>} account - The account to query.
+   * @param {Either<Bytes<32>, ContractAddress>} account - The account to query.
    * @return {Boolean} - Whether the account has the specified role.
-    */
+    */
   export circuit hasRole(roleId: Bytes<32>,
-                         account: Either<ZswapCoinPublicKey, ContractAddress>
+                         account: Either<Bytes<32>, ContractAddress>
                          ): Boolean {
     if (_operatorRoles.member(disclose(roleId)) &&
         _operatorRoles.lookup(roleId).member(disclose(account))) {
@@ -116,38 +147,39 @@ module AccessControl {
   }
 
   /**
-   * @description Reverts if `ownPublicKey()` is missing `roleId`.
+   * @description Reverts if the caller cannot prove ownership of `roleId`.
+   * The caller's identity is derived from the `wit_AccessControlSK` witness as
+   * `persistentHash(secretKey)`.
    *
-   * @circuitInfo k=10, rows=345
+   * @circuitInfo k=13, rows=2669
    *
    * Requirements:
    *
    * - The caller must have `roleId`.
-   * - The caller must not be a ContractAddress
    *
    * @param {Bytes<32>} roleId - The role identifier.
    * @return {[]} - Empty tuple.
    */
   export circuit assertOnlyRole(roleId: Bytes<32>): [] {
-    _checkRole(roleId, left<ZswapCoinPublicKey, ContractAddress>(ownPublicKey()));
+    _checkRole(roleId, left<Bytes<32>, ContractAddress>(_computeAccountId()));
   }
 
   /**
    * @description Reverts if `account` is missing `roleId`.
    *
-   * @circuitInfo k=10, rows=467
+   * @circuitInfo k=10, rows=987
    *
    * Requirements:
    *
    * - `account` must have `roleId`.
    *
    * @param {Bytes<32>} roleId - The role identifier.
-   * @param {Either<ZswapCoinPublicKey, ContractAddress>} account - The account to query.
+   * @param {Either<Bytes<32>, ContractAddress>} account - The account to query.
    * @return {[]} - Empty tuple.
    */
   export circuit _checkRole(
                    roleId: Bytes<32>,
-                   account: Either<ZswapCoinPublicKey, ContractAddress>
+                   account: Either<Bytes<32>, ContractAddress>
                    ): [] {
     assert(hasRole(roleId, account), "AccessControl: unauthorized account");
   }
@@ -156,9 +188,9 @@ module AccessControl {
    * @description Returns the admin role that controls `roleId` or
    * a byte array with all zero bytes if `roleId` doesn't exist. See {grantRole} and {revokeRole}.
    *
-   * To change a role’s admin use {_setRoleAdmin}.
+   * To change a role's admin use {_setRoleAdmin}.
    *
-   * @circuitInfo k=10, rows=207
+   * @circuitInfo k=9, rows=373
    *
    * @param {Bytes<32>} roleId - The role identifier.
    * @return {Bytes<32>} roleAdmin - The admin role that controls `roleId`.
@@ -173,7 +205,7 @@ module AccessControl {
   /**
    * @description Grants `roleId` to `account`.
    *
-   * @circuitInfo k=10, rows=994
+   * @circuitInfo k=13, rows=3578
    *
    * Requirements:
    *
@@ -181,12 +213,12 @@ module AccessControl {
    * - The caller must have `roleId`'s admin role.
    *
    * @param {Bytes<32>} roleId - The role identifier.
-   * @param {Either<ZswapCoinPublicKey, ContractAddress>} account - A ZswapCoinPublicKey or ContractAddress.
+   * @param {Either<Bytes<32>, ContractAddress>} account - A Bytes<32> or ContractAddress.
    * @return {[]} - Empty tuple.
    */
   export circuit grantRole(
                    roleId: Bytes<32>,
-                   account: Either<ZswapCoinPublicKey, ContractAddress>
+                   account: Either<Bytes<32>, ContractAddress>
                    ): [] {
     assertOnlyRole(getRoleAdmin(roleId));
     _grantRole(roleId, account);
@@ -195,19 +227,19 @@ module AccessControl {
   /**
    * @description Revokes `roleId` from `account`.
    *
-   * @circuitInfo k=10, rows=827
+   * @circuitInfo k=13, rows=3454
    *
    * Requirements:
    *
    * - The caller must have `roleId`'s admin role.
    *
    * @param {Bytes<32>} roleId - The role identifier.
-   * @param {Either<ZswapCoinPublicKey, ContractAddress>} account - A ZswapCoinPublicKey or ContractAddress.
+   * @param {Either<Bytes<32>, ContractAddress>} account - A Bytes<32> or ContractAddress.
    * @return {[]} - Empty tuple.
    */
   export circuit revokeRole(
                    roleId: Bytes<32>,
-                   account: Either<ZswapCoinPublicKey, ContractAddress>
+                   account: Either<Bytes<32>, ContractAddress>
                    ): [] {
     assertOnlyRole(getRoleAdmin(roleId));
     _revokeRole(roleId, account);
@@ -220,22 +252,25 @@ module AccessControl {
    * purpose is to provide a mechanism for accounts to lose their privileges
    * if they are compromised (such as when a trusted device is misplaced).
    *
-   * @circuitInfo k=10, rows=640
+   * The caller's identity is derived from the `wit_AccessControlSK` witness as
+   * `persistentHash(secretKey)`. The `callerConfirmation` parameter must match
+   * the caller's computed account identifier to prevent accidental renunciation.
+   *
+   * @circuitInfo k=13, rows=3310
    *
    * Requirements:
    *
-   * - The caller must be `callerConfirmation`.
-   * - The caller must not be a `ContractAddress`.
+   * - The caller's computed account identifier must match `callerConfirmation`.
    *
    * @param {Bytes<32>} roleId - The role identifier.
-   * @param {Either<ZswapCoinPublicKey, ContractAddress>} callerConfirmation - A ZswapCoinPublicKey or ContractAddress.
+   * @param {Either<Bytes<32>, ContractAddress>} callerConfirmation - The caller's account identifier, must match the internally computed value.
    * @return {[]} - Empty tuple.
    */
   export circuit renounceRole(
                    roleId: Bytes<32>,
-                   callerConfirmation: Either<ZswapCoinPublicKey, ContractAddress>
+                   callerConfirmation: Either<Bytes<32>, ContractAddress>
                    ): [] {
-    assert(callerConfirmation == left<ZswapCoinPublicKey, ContractAddress>(ownPublicKey()),
+    assert(callerConfirmation == left<Bytes<32>, ContractAddress>(_computeAccountId()),
            "AccessControl: bad confirmation"
            );
 
@@ -245,7 +280,7 @@ module AccessControl {
   /**
    * @description Sets `adminRole` as `roleId`'s admin role.
    *
-   * @circuitInfo k=10, rows=209
+   * @circuitInfo k=10, rows=581
    *
    * @param {Bytes<32>} roleId - The role identifier.
    * @param {Bytes<32>} adminRole - The admin role identifier.
@@ -259,21 +294,22 @@ module AccessControl {
    * @description Attempts to grant `roleId` to `account` and returns a boolean indicating if `roleId` was granted.
    * Internal circuit without access restriction.
    *
-   * @circuitInfo k=10, rows=734
+   * @circuitInfo k=11, rows=1185
    *
    * Requirements:
    *
    * - `account` must not be a ContractAddress.
    *
    * @param {Bytes<32>} roleId - The role identifier.
-   * @param {Either<ZswapCoinPublicKey, ContractAddress>} account - A ZswapCoinPublicKey or ContractAddress.
+   * @param {Either<Bytes<32>, ContractAddress>} account - A Bytes<32> or ContractAddress.
    * @return {Boolean} roleGranted - A boolean indicating if `roleId` was granted.
    */
   export circuit _grantRole(
                    roleId: Bytes<32>,
-                   account: Either<ZswapCoinPublicKey, ContractAddress>
+                   account: Either<Bytes<32>, ContractAddress>
                    ): Boolean {
-    assert(!Utils_isContractAddress(account), "AccessControl: unsafe role approval");
+    const isCommitment = account.is_left;
+    assert(isCommitment, "AccessControl: unsafe role approval");
     return _unsafeGrantRole(roleId, account);
   }
 
@@ -281,18 +317,18 @@ module AccessControl {
    * @description Attempts to grant `roleId` to `account` and returns a boolean indicating if `roleId` was granted.
    * Internal circuit without access restriction. It does NOT check if the role is granted to a ContractAddress.
    *
-   * @circuitInfo k=10, rows=733
+   * @circuitInfo k=11, rows=1184
    *
-   * @notice External smart contracts cannot call the token contract at this time, so granting a role to an ContractAddress may
+   * @notice External smart contracts cannot call the token contract at this time, so granting a role to a ContractAddress may
    * render a circuit permanently inaccessible.
    *
    * @param {Bytes<32>} roleId - The role identifier.
-   * @param {Either<ZswapCoinPublicKey, ContractAddress>} account - A ZswapCoinPublicKey or ContractAddress.
+   * @param {Either<Bytes<32>, ContractAddress>} account - A Bytes<32> or ContractAddress.
    * @return {Boolean} roleGranted - A boolean indicating if `role` was granted.
    */
   export circuit _unsafeGrantRole(
                    roleId: Bytes<32>,
-                   account: Either<ZswapCoinPublicKey, ContractAddress>
+                   account: Either<Bytes<32>, ContractAddress>
                    ): Boolean {
     if (hasRole(roleId, account)) {
       return false;
@@ -301,7 +337,7 @@ module AccessControl {
     if (!_operatorRoles.member(disclose(roleId))) {
       _operatorRoles.insert(
         disclose(roleId),
-        default<Map<Either<ZswapCoinPublicKey, ContractAddress>, Boolean>>
+        default<Map<Either<Bytes<32>, ContractAddress>, Boolean>>
         );
       _operatorRoles.lookup(roleId).insert(disclose(account), true);
       return true;
@@ -315,15 +351,15 @@ module AccessControl {
    * @description Attempts to revoke `roleId` from `account` and returns a boolean indicating if `roleId` was revoked.
    * Internal circuit without access restriction.
    *
-   * @circuitInfo k=10, rows=563
+   * @circuitInfo k=11, rows=1061
    *
    * @param {Bytes<32>} roleId - The role identifier.
-   * @param {Bytes<32>} adminRole - The admin role identifier.
+   * @param {Either<Bytes<32>, ContractAddress>} account - A Bytes<32> or ContractAddress.
    * @return {Boolean} roleRevoked - A boolean indicating if `roleId` was revoked.
    */
   export circuit _revokeRole(
                    roleId: Bytes<32>,
-                   account: Either<ZswapCoinPublicKey, ContractAddress>
+                   account: Either<Bytes<32>, ContractAddress>
                    ): Boolean {
     if (!hasRole(roleId, account)) {
       return false;
@@ -331,5 +367,53 @@ module AccessControl {
 
     _operatorRoles.lookup(roleId).insert(disclose(account), false);
     return true;
+  }
+
+  /**
+   * @description Computes the caller's account identifier from the `wit_AccessControlSK` witness.
+   *
+   * ## ID Derivation
+   * `accountId = persistentHash(secretKey)`
+   *
+   * The result is a 32-byte commitment that uniquely identifies the caller.
+   *
+   * @circuitInfo k=13, rows=2294
+   *
+   * @returns {Bytes<32>} accountId - The computed account identifier.
+   */
+  circuit _computeAccountId(): Bytes<32> {
+    return computeAccountId(wit_AccessControlSK());
+  }
+
+  /**
+   * @description Computes an account identifier without on-chain state, allowing a user to derive
+   * their identity commitment before submitting it in a grant or revoke operation.
+   * This is the off-chain counterpart to {_computeAccountId} and produces an identical result
+   * given the same inputs.
+   *
+   * @warning OpSec: The `secretKey` parameter is a sensitive secret. Mishandling it can
+   * permanently compromise the privacy guarantees of this system:
+   *
+   * - **Never log or persist** the `secretKey` in plaintext — avoid browser devtools,
+   *   application logs, analytics pipelines, or any observable side-channel.
+   * - **Store offline or in secure enclaves** — hardware security modules (HSMs),
+   *   air-gapped devices, or encrypted vaults are strongly preferred over hot storage.
+   * - **Use cryptographically secure randomness** — generate keys with `crypto.getRandomValues()`
+   *   or equivalent; weak or predictable keys can be brute-forced to reveal your identity.
+   * - **Treat key loss as identity loss** — a lost key cannot be recovered. Back up
+   *   keys securely before using them in role commitments.
+   * - **Avoid calling this circuit in untrusted environments** — executing this in an
+   *   unverified browser extension, compromised runtime, or shared machine may expose
+   *   the key to a malicious observer.
+   *
+   * ## ID Derivation
+   * `accountId = persistentHash(secretKey)`
+   *
+   * @param {Bytes<32>} secretKey - A 32-byte cryptographically secure random value.
+   *
+   * @returns {Bytes<32>} accountId - The computed account identifier.
+   */
+  export pure circuit computeAccountId(secretKey: Bytes<32>): Bytes<32> {
+    return persistentHash<Vector<1, Bytes<32>>>([secretKey]);
   }
 }

--- a/contracts/src/access/AccessControl.compact
+++ b/contracts/src/access/AccessControl.compact
@@ -355,7 +355,7 @@ module AccessControl {
    *
    * @circuitInfo k=11, rows=1142
    *
-   * @notice External smart contracts cannot call the token contract at this time, so granting a role to a ContractAddress may
+   * @notice External smart contracts cannot call the access control contract at this time, so granting a role to a ContractAddress may
    * render a circuit permanently inaccessible.
    *
    * @param {Bytes<32>} roleId - The role identifier.

--- a/contracts/src/access/AccessControl.compact
+++ b/contracts/src/access/AccessControl.compact
@@ -296,6 +296,7 @@ module AccessControl {
    * Requirements:
    *
    * - The caller's computed account identifier must match `callerConfirmation`.
+   * - The caller must not be a `ContractAddress`.
    *
    * @param {Bytes<32>} roleId - The role identifier.
    * @param {Either<Bytes<32>, ContractAddress>} callerConfirmation - The caller's account identifier, must match the internally computed value.

--- a/contracts/src/access/AccessControl.compact
+++ b/contracts/src/access/AccessControl.compact
@@ -26,7 +26,7 @@ pragma language_version >= 0.21.0;
  *
  * ```compact
  * import CompactStandardLibrary;
- * import "./node_modules/@myProject/accessControl/src/AccessControl" prefix AccessControl_;
+ * import "./node_modules/@openzeppelin-compact/accessControl/src/AccessControl" prefix AccessControl_;
  *
  * export sealed ledger MY_ROLE: Bytes<32>;
  *

--- a/contracts/src/access/AccessControl.compact
+++ b/contracts/src/access/AccessControl.compact
@@ -137,7 +137,7 @@ module AccessControl {
   /**
    * @description Returns `true` if `account` has been granted `roleId`.
    *
-   * @circuitInfo k=10, rows=1007
+   * @circuitInfo k=10, rows=1019
    *
    * @param {Bytes<32>} roleId - The role identifier.
    * @param {Either<Bytes<32>, ContractAddress>} account - The account to query.
@@ -232,7 +232,7 @@ module AccessControl {
   /**
    * @description Grants `roleId` to `account`.
    *
-   * @circuitInfo k=13, rows=3578
+   * @circuitInfo k=13, rows=3536
    *
    * Requirements:
    *
@@ -254,7 +254,7 @@ module AccessControl {
   /**
    * @description Revokes `roleId` from `account`.
    *
-   * @circuitInfo k=13, rows=3454
+   * @circuitInfo k=13, rows=3466
    *
    * Requirements:
    *
@@ -283,7 +283,7 @@ module AccessControl {
    * `persistentHash(secretKey)`. The `callerConfirmation` parameter must match
    * the caller's computed account identifier to prevent accidental renunciation.
    *
-   * @circuitInfo k=13, rows=3310
+   * @circuitInfo k=13, rows=3322
    *
    * Requirements:
    *
@@ -321,7 +321,7 @@ module AccessControl {
    * @description Attempts to grant `roleId` to `account` and returns a boolean indicating if `roleId` was granted.
    * Internal circuit without access restriction.
    *
-   * @circuitInfo k=11, rows=1185
+   * @circuitInfo k=11, rows=1143
    *
    * Requirements:
    *
@@ -344,7 +344,7 @@ module AccessControl {
    * @description Attempts to grant `roleId` to `account` and returns a boolean indicating if `roleId` was granted.
    * Internal circuit without access restriction. It does NOT check if the role is granted to a ContractAddress.
    *
-   * @circuitInfo k=11, rows=1184
+   * @circuitInfo k=11, rows=1142
    *
    * @notice External smart contracts cannot call the token contract at this time, so granting a role to a ContractAddress may
    * render a circuit permanently inaccessible.
@@ -377,7 +377,7 @@ module AccessControl {
    * @description Attempts to revoke `roleId` from `account` and returns a boolean indicating if `roleId` was revoked.
    * Internal circuit without access restriction.
    *
-   * @circuitInfo k=11, rows=1061
+   * @circuitInfo k=11, rows=1073
    *
    * @param {Bytes<32>} roleId - The role identifier.
    * @param {Either<Bytes<32>, ContractAddress>} account - A Bytes<32> or ContractAddress.

--- a/contracts/src/access/AccessControl.compact
+++ b/contracts/src/access/AccessControl.compact
@@ -91,6 +91,7 @@ pragma language_version >= 0.21.0;
  */
 module AccessControl {
   import CompactStandardLibrary;
+  import "../utils/Utils" prefix Utils_;
 
   /**
    * @description Mapping from a role identifier -> account -> its permissions.
@@ -145,6 +146,22 @@ module AccessControl {
   export circuit hasRole(roleId: Bytes<32>,
                          account: Either<Bytes<32>, ContractAddress>
                          ): Boolean {
+    const canonAcct = Utils_canonicalize<Bytes<32>, ContractAddress>(account);
+    return _hasRole(roleId, canonAcct);
+  }
+
+  /**
+   * @description Returns `true` if `account` has been granted `roleId`. Internal variant
+   * that assumes `account` has already been canonicalized by the caller. External consumers
+   * should use {hasRole} which canonicalizes the input automatically.
+   *
+   * @param {Bytes<32>} roleId - The role identifier.
+   * @param {Either<Bytes<32>, ContractAddress>} account - The canonicalized account to query.
+   * @return {Boolean} - Whether the account has the specified role.
+   */
+  circuit _hasRole(roleId: Bytes<32>,
+                         account: Either<Bytes<32>, ContractAddress>
+                         ): Boolean {
     if (_operatorRoles.member(disclose(roleId)) &&
         _operatorRoles.lookup(roleId).member(disclose(account))) {
       return _operatorRoles.lookup(roleId).lookup(disclose(account));
@@ -168,6 +185,9 @@ module AccessControl {
    * @return {[]} - Empty tuple.
    */
   export circuit assertOnlyRole(roleId: Bytes<32>): [] {
+    // The account constructed via left<...>() is already canonical,
+    // but we route through _checkRole -> hasRole for consistency.
+    // The redundant canonicalization is negligible.
     _checkRole(roleId, left<Bytes<32>, ContractAddress>(_computeAccountId()));
   }
 
@@ -337,7 +357,8 @@ module AccessControl {
                    roleId: Bytes<32>,
                    account: Either<Bytes<32>, ContractAddress>
                    ): Boolean {
-    if (hasRole(roleId, account)) {
+    const canonAcct = Utils_canonicalize<Bytes<32>, ContractAddress>(account);
+    if (_hasRole(roleId, canonAcct)) {
       return false;
     }
 
@@ -348,7 +369,7 @@ module AccessControl {
         );
     }
 
-    _operatorRoles.lookup(roleId).insert(disclose(account), true);
+    _operatorRoles.lookup(roleId).insert(disclose(canonAcct), true);
     return true;
   }
 
@@ -366,11 +387,13 @@ module AccessControl {
                    roleId: Bytes<32>,
                    account: Either<Bytes<32>, ContractAddress>
                    ): Boolean {
-    if (!hasRole(roleId, account)) {
+    const canonAcct = Utils_canonicalize<Bytes<32>, ContractAddress>(account);
+
+    if (!_hasRole(roleId, canonAcct)) {
       return false;
     }
 
-    _operatorRoles.lookup(roleId).insert(disclose(account), false);
+    _operatorRoles.lookup(roleId).insert(disclose(canonAcct), false);
     return true;
   }
 

--- a/contracts/src/access/AccessControl.compact
+++ b/contracts/src/access/AccessControl.compact
@@ -172,8 +172,8 @@ module AccessControl {
 
   /**
    * @description Reverts if the caller cannot prove ownership of `roleId`.
-   * The caller's identity is derived from the `wit_AccessControlSK` witness as
-   * `persistentHash(secretKey)`.
+   * In the case of an external (non-contract) caller, the caller’s identity is
+   * derived from the `wit_AccessControlSK` witness as `persistentHash(secretKey)`.
    *
    * @circuitInfo k=13, rows=2669
    *

--- a/contracts/src/access/test/AccessControl.test.ts
+++ b/contracts/src/access/test/AccessControl.test.ts
@@ -151,6 +151,25 @@ describe('AccessControl', () => {
         'AccessControl: unauthorized account',
       );
     });
+
+    it('should fail when contract address matches accountId bytes but is right variant', () => {
+      // Grant role to a contract address whose bytes match ADMIN's accountId
+      const contractWithSameBytes = {
+        is_left: false,
+        left: zeroBytes,
+        right: { bytes: ADMIN.accountId },
+      };
+
+      accessControl._unsafeGrantRole(OPERATOR_ROLE_1, contractWithSameBytes);
+      expect(accessControl.hasRole(OPERATOR_ROLE_1, contractWithSameBytes)).toBe(true);
+
+      // ADMIN's witness produces left(H(sk)) which has the same bytes
+      // but is a different Either variant than the granted role
+      accessControl.privateState.injectSecretKey(ADMIN.secretKey);
+      expect(() => {
+        accessControl.assertOnlyRole(OPERATOR_ROLE_1);
+      }).toThrow('AccessControl: unauthorized account');
+    });
   });
 
   describe('_checkRole', () => {

--- a/contracts/src/access/test/AccessControl.test.ts
+++ b/contracts/src/access/test/AccessControl.test.ts
@@ -1,21 +1,56 @@
-import { convertFieldToBytes } from '@midnight-ntwrk/compact-runtime';
+import {
+  CompactTypeBytes,
+  CompactTypeVector,
+  convertFieldToBytes,
+  persistentHash,
+} from '@midnight-ntwrk/compact-runtime';
 import { beforeEach, describe, expect, it } from 'vitest';
 import * as utils from '#test-utils/address.js';
 import { AccessControlSimulator } from './simulators/AccessControlSimulator.js';
 
-// PKs
-const [OPERATOR_1, Z_OPERATOR_1] = utils.generateEitherPubKeyPair('OPERATOR_1');
-const [_, Z_OPERATOR_2] = utils.generateEitherPubKeyPair('OPERATOR_2');
-const [ADMIN, Z_ADMIN] = utils.generateEitherPubKeyPair('ADMIN');
-const [CUSTOM_ADMIN, Z_CUSTOM_ADMIN] =
-  utils.generateEitherPubKeyPair('CUSTOM_ADMIN');
-const [UNAUTHORIZED, Z_UNAUTHORIZED] =
-  utils.generateEitherPubKeyPair('UNAUTHORIZED');
+// Helpers
+const buildAccountIdHash = (sk: Uint8Array): Uint8Array => {
+  const rt_type = new CompactTypeVector(1, new CompactTypeBytes(32));
+  return persistentHash(rt_type, [sk]);
+};
 
-// Encoded contract addresses
-const OPERATOR_CONTRACT = utils.toHexPadded('OPERATOR_CONTRACT');
-const Z_OPERATOR_CONTRACT =
-  utils.createEitherTestContractAddress('OPERATOR_CONTRACT');
+const zeroBytes = utils.zeroUint8Array();
+
+const eitherCommitment = (commitment: Uint8Array) => {
+  return {
+    is_left: true,
+    left: commitment,
+    right: { bytes: zeroBytes },
+  };
+};
+
+const eitherContract = (address: string) => {
+  return {
+    is_left: false,
+    left: zeroBytes,
+    right: utils.encodeToAddress(address),
+  };
+};
+
+const createTestSK = (label: string): Buffer => Buffer.alloc(32, label);
+
+const makeUser = (label: string) => {
+  const secretKey = createTestSK(label);
+  const accountId = buildAccountIdHash(secretKey);
+  const either = eitherCommitment(accountId);
+  return { secretKey, accountId, either };
+};
+
+// Users
+const ADMIN = makeUser('ADMIN');
+const CUSTOM_ADMIN = makeUser('CUSTOM_ADMIN');
+const OP1 = makeUser('OP1');
+const OP2 = makeUser('OP2');
+const OP3 = makeUser('OP3');
+const UNAUTHORIZED = makeUser('UNAUTHORIZED');
+
+// Contract addresses
+const OP1_CONTRACT = eitherContract('CONTRACT_ADDRESS');
 
 // Roles
 const DEFAULT_ADMIN_ROLE = utils.zeroUint8Array();
@@ -25,20 +60,17 @@ const OPERATOR_ROLE_3 = convertFieldToBytes(32, 3n, '');
 const CUSTOM_ADMIN_ROLE = convertFieldToBytes(32, 4n, '');
 const UNINITIALIZED_ROLE = convertFieldToBytes(32, 5n, '');
 
+// Lists
+const operatorRolesList = [OPERATOR_ROLE_1, OPERATOR_ROLE_2];
+const commitmentOperators = [OP1.either, OP2.either, OP3.either];
+const allOperators = [...commitmentOperators, OP1_CONTRACT];
+
 let accessControl: AccessControlSimulator;
 
-const callerTypes = {
-  contract: OPERATOR_CONTRACT,
-  pubkey: OPERATOR_1,
-};
-
 const operatorTypes = [
-  ['contract', Z_OPERATOR_CONTRACT],
-  ['pubkey', Z_OPERATOR_1],
+  ['contract', OP1_CONTRACT],
+  ['commitment', OP1.either],
 ] as const;
-
-const operatorRoles = [OPERATOR_ROLE_1, OPERATOR_ROLE_2];
-const operatorPKs = [Z_OPERATOR_1, Z_OPERATOR_2, Z_OPERATOR_CONTRACT];
 
 describe('AccessControl', () => {
   beforeEach(() => {
@@ -47,71 +79,71 @@ describe('AccessControl', () => {
 
   describe('hasRole', () => {
     beforeEach(() => {
-      accessControl._grantRole(OPERATOR_ROLE_1, Z_OPERATOR_1);
+      accessControl._grantRole(OPERATOR_ROLE_1, OP1.either);
     });
 
     it('should return true when operator has a role', () => {
-      expect(accessControl.hasRole(OPERATOR_ROLE_1, Z_OPERATOR_1)).toBe(true);
+      expect(accessControl.hasRole(OPERATOR_ROLE_1, OP1.either)).toBe(true);
     });
 
     it('should return false when unauthorized', () => {
-      expect(accessControl.hasRole(OPERATOR_ROLE_1, Z_UNAUTHORIZED)).toBe(
+      expect(accessControl.hasRole(OPERATOR_ROLE_1, UNAUTHORIZED.either)).toBe(
         false,
       );
     });
 
     it('should return false when role does not exist', () => {
-      expect(accessControl.hasRole(UNINITIALIZED_ROLE, Z_OPERATOR_1)).toBe(
-        false,
-      );
+      expect(accessControl.hasRole(UNINITIALIZED_ROLE, OP1.either)).toBe(false);
     });
   });
 
   describe('assertOnlyRole', () => {
     beforeEach(() => {
-      accessControl._grantRole(OPERATOR_ROLE_1, Z_OPERATOR_1);
+      accessControl._grantRole(OPERATOR_ROLE_1, OP1.either);
     });
 
     it('should allow operator with role to call', () => {
-      expect(() =>
-        accessControl.as(OPERATOR_1).assertOnlyRole(OPERATOR_ROLE_1),
-      ).not.toThrow();
+      // Set secret key for OP1
+      accessControl.privateState.injectSecretKey(OP1.secretKey);
+
+      expect(() => accessControl.assertOnlyRole(OPERATOR_ROLE_1)).not.toThrow();
     });
 
-    it('should throw if caller is unauthorized', () => {
-      expect(() =>
-        accessControl.as(UNAUTHORIZED).assertOnlyRole(OPERATOR_ROLE_1),
-      ).toThrow('AccessControl: unauthorized account');
-    });
+    it('should fail if caller is unauthorized', () => {
+      // Set bad secret key
+      accessControl.privateState.injectSecretKey(UNAUTHORIZED.secretKey);
 
-    it('should throw if ContractAddress with role is caller', () => {
-      accessControl._unsafeGrantRole(OPERATOR_ROLE_1, Z_OPERATOR_CONTRACT);
-
-      expect(() =>
-        accessControl.as(OPERATOR_CONTRACT).assertOnlyRole(OPERATOR_ROLE_1),
-      ).toThrow('AccessControl: unauthorized account');
+      expect(() => accessControl.assertOnlyRole(OPERATOR_ROLE_1)).toThrow(
+        'AccessControl: unauthorized account',
+      );
     });
   });
 
   describe('_checkRole', () => {
     beforeEach(() => {
-      accessControl._grantRole(OPERATOR_ROLE_1, Z_OPERATOR_1);
-      accessControl._unsafeGrantRole(OPERATOR_ROLE_1, Z_OPERATOR_CONTRACT);
+      accessControl._grantRole(OPERATOR_ROLE_1, OP1.either);
+      accessControl._unsafeGrantRole(OPERATOR_ROLE_1, OP1_CONTRACT);
     });
 
-    describe.each(
-      operatorTypes,
-    )('when the operator is a %s', (_operatorType, _operator) => {
-      it(`should not throw if ${_operatorType} has role`, () => {
-        expect(() =>
-          accessControl._checkRole(OPERATOR_ROLE_1, _operator),
-        ).not.toThrow();
-      });
-    });
+    it('should not fail if user has role', () => {
+      expect(accessControl.hasRole(OPERATOR_ROLE_1, OP1.either)).toBe(true);
 
-    it('should throw if operator is unauthorized', () => {
       expect(() =>
-        accessControl._checkRole(OPERATOR_ROLE_1, Z_UNAUTHORIZED),
+        accessControl._checkRole(OPERATOR_ROLE_1, OP1.either),
+      ).not.toThrow();
+    });
+
+    it('should not fail if contract has role', () => {
+      expect(accessControl.hasRole(OPERATOR_ROLE_1, OP1_CONTRACT)).toBe(true);
+
+      expect(() =>
+        accessControl._checkRole(OPERATOR_ROLE_1, OP1_CONTRACT),
+      ).not.toThrow();
+    });
+
+    it('should fail if operator is unauthorized', () => {
+      expect(() =>
+        accessControl._checkRole(OPERATOR_ROLE_1, UNAUTHORIZED.either),
       ).toThrow('AccessControl: unauthorized account');
     });
   });
@@ -133,73 +165,108 @@ describe('AccessControl', () => {
 
   describe('grantRole', () => {
     beforeEach(() => {
-      accessControl._grantRole(DEFAULT_ADMIN_ROLE, Z_ADMIN);
+      accessControl._grantRole(DEFAULT_ADMIN_ROLE, ADMIN.either);
     });
 
     it('admin should grant role', () => {
-      accessControl.as(ADMIN).grantRole(OPERATOR_ROLE_1, Z_OPERATOR_1);
-      expect(accessControl.hasRole(OPERATOR_ROLE_1, Z_OPERATOR_1)).toBe(true);
+      // Set admin SK
+      accessControl.privateState.injectSecretKey(ADMIN.secretKey);
+
+      accessControl.grantRole(OPERATOR_ROLE_1, OP1.either);
+      expect(accessControl.hasRole(OPERATOR_ROLE_1, OP1.either)).toBe(true);
     });
 
     it('admin should grant multiple roles', () => {
-      for (let i = 0; i < operatorRoles.length; i++) {
-        // length - 1 because we test ContractAddress separately
-        for (let j = 0; j < operatorPKs.length - 1; j++) {
-          accessControl.as(ADMIN).grantRole(operatorRoles[i], operatorPKs[j]);
-          expect(accessControl.hasRole(operatorRoles[i], operatorPKs[j])).toBe(
-            true,
-          );
+      // Set admin SK
+      accessControl.privateState.injectSecretKey(ADMIN.secretKey);
+
+      for (let i = 0; i < operatorRolesList.length; i++) {
+        for (let j = 0; j < commitmentOperators.length; j++) {
+          accessControl.grantRole(operatorRolesList[i], commitmentOperators[j]);
+          expect(
+            accessControl.hasRole(operatorRolesList[i], commitmentOperators[j]),
+          ).toBe(true);
         }
       }
     });
 
-    it('should throw if operator grants role', () => {
-      accessControl.as(ADMIN).grantRole(OPERATOR_ROLE_1, Z_OPERATOR_1);
+    it('should fail if unauthorized grants role', () => {
+      // Set unauthorized SK
+      accessControl.privateState.injectSecretKey(UNAUTHORIZED.secretKey);
 
       expect(() => {
-        accessControl.as(OPERATOR_1).grantRole(OPERATOR_ROLE_1, Z_UNAUTHORIZED);
+        accessControl.grantRole(OPERATOR_ROLE_1, OP1.either);
       }).toThrow('AccessControl: unauthorized account');
     });
 
-    it('should throw if admin grants role to ContractAddress', () => {
+    it('should fail if operator grants role', () => {
+      // Set admin SK
+      accessControl.privateState.injectSecretKey(ADMIN.secretKey);
+      accessControl.grantRole(OPERATOR_ROLE_1, OP1.either);
+
+      // Set OP1 SK
+      accessControl.privateState.injectSecretKey(OP1.secretKey);
+
       expect(() => {
-        accessControl.as(ADMIN).grantRole(OPERATOR_ROLE_1, Z_OPERATOR_CONTRACT);
+        accessControl.grantRole(OPERATOR_ROLE_1, OP2.either);
+      }).toThrow('AccessControl: unauthorized account');
+    });
+
+    it('should fail if admin grants role to ContractAddress', () => {
+      // Set admin SK
+      accessControl.privateState.injectSecretKey(ADMIN.secretKey);
+
+      expect(() => {
+        accessControl.grantRole(OPERATOR_ROLE_1, OP1_CONTRACT);
       }).toThrow('AccessControl: unsafe role approval');
     });
   });
 
   describe('revokeRole', () => {
     beforeEach(() => {
-      accessControl._grantRole(DEFAULT_ADMIN_ROLE, Z_ADMIN);
-      accessControl._grantRole(OPERATOR_ROLE_1, Z_OPERATOR_1);
-      accessControl._unsafeGrantRole(OPERATOR_ROLE_1, Z_OPERATOR_CONTRACT);
+      accessControl._grantRole(DEFAULT_ADMIN_ROLE, ADMIN.either);
+      accessControl._grantRole(OPERATOR_ROLE_1, OP1.either);
+      accessControl._unsafeGrantRole(OPERATOR_ROLE_1, OP1_CONTRACT);
     });
 
     describe.each(
       operatorTypes,
     )('when the operator is a %s', (_operatorType, _operator) => {
       it('admin should revoke role', () => {
-        accessControl.as(ADMIN).revokeRole(OPERATOR_ROLE_1, _operator);
+        // Set admin SK
+        accessControl.privateState.injectSecretKey(ADMIN.secretKey);
+
+        accessControl.revokeRole(OPERATOR_ROLE_1, _operator);
         expect(accessControl.hasRole(OPERATOR_ROLE_1, _operator)).toBe(false);
-      });
-
-      it('should throw if operator revokes role', () => {
-        const caller = callerTypes[_operatorType];
-
-        expect(() => {
-          accessControl.as(caller).revokeRole(OPERATOR_ROLE_1, Z_UNAUTHORIZED);
-        }).toThrow('AccessControl: unauthorized account');
       });
     });
 
+    it('should fail if unauthorized revokes role', () => {
+      accessControl.privateState.injectSecretKey(UNAUTHORIZED.secretKey);
+
+      expect(() => {
+        accessControl.revokeRole(OPERATOR_ROLE_1, OP1.either);
+      }).toThrow('AccessControl: unauthorized account');
+    });
+
+    it('should fail if operator revokes role', () => {
+      accessControl.privateState.injectSecretKey(OP1.secretKey);
+
+      expect(() => {
+        accessControl.revokeRole(OPERATOR_ROLE_1, OP2.either);
+      }).toThrow('AccessControl: unauthorized account');
+    });
+
     it('admin should revoke multiple roles', () => {
-      for (let i = 0; i < operatorRoles.length; i++) {
-        for (let j = 0; j < operatorPKs.length; j++) {
-          accessControl._unsafeGrantRole(operatorRoles[i], operatorPKs[j]);
-          accessControl.as(ADMIN).revokeRole(operatorRoles[i], operatorPKs[j]);
-          expect(accessControl.hasRole(operatorRoles[i], operatorPKs[j])).toBe(
-            false,
-          );
+      accessControl.privateState.injectSecretKey(ADMIN.secretKey);
+
+      for (let i = 0; i < operatorRolesList.length; i++) {
+        for (let j = 0; j < allOperators.length; j++) {
+          accessControl._unsafeGrantRole(operatorRolesList[i], allOperators[j]);
+          accessControl.revokeRole(operatorRolesList[i], allOperators[j]);
+          expect(
+            accessControl.hasRole(operatorRolesList[i], allOperators[j]),
+          ).toBe(false);
         }
       }
     });
@@ -207,29 +274,32 @@ describe('AccessControl', () => {
 
   describe('renounceRole', () => {
     beforeEach(() => {
-      accessControl._grantRole(OPERATOR_ROLE_1, Z_OPERATOR_1);
+      accessControl._grantRole(OPERATOR_ROLE_1, OP1.either);
     });
 
     it('should allow operator to renounce own role', () => {
-      accessControl.as(OPERATOR_1).renounceRole(OPERATOR_ROLE_1, Z_OPERATOR_1);
-      expect(accessControl.hasRole(OPERATOR_ROLE_1, Z_OPERATOR_1)).toBe(false);
+      accessControl.privateState.injectSecretKey(OP1.secretKey);
+
+      accessControl.renounceRole(OPERATOR_ROLE_1, OP1.either);
+      expect(accessControl.hasRole(OPERATOR_ROLE_1, OP1.either)).toBe(false);
     });
 
-    it('ContractAddress renounce should throw', () => {
-      accessControl._unsafeGrantRole(OPERATOR_ROLE_1, Z_OPERATOR_CONTRACT);
+    // Should be refactored with c2c
+    it('should fail when renouncing as a ContractAddress', () => {
+      accessControl._unsafeGrantRole(OPERATOR_ROLE_1, OP1_CONTRACT);
+
+      accessControl.privateState.injectSecretKey(ADMIN.secretKey);
 
       expect(() => {
-        accessControl
-          .as(OPERATOR_CONTRACT)
-          .renounceRole(OPERATOR_ROLE_1, Z_OPERATOR_CONTRACT);
+        accessControl.renounceRole(OPERATOR_ROLE_1, OP1_CONTRACT);
       }).toThrow('AccessControl: bad confirmation');
     });
 
-    it('unauthorized renounce should throw', () => {
+    it('should fail when unauthorized renounces role', () => {
+      accessControl.privateState.injectSecretKey(UNAUTHORIZED.secretKey);
+
       expect(() => {
-        accessControl
-          .as(UNAUTHORIZED)
-          .renounceRole(OPERATOR_ROLE_1, Z_OPERATOR_1);
+        accessControl.renounceRole(OPERATOR_ROLE_1, OP1.either);
       }).toThrow('AccessControl: bad confirmation');
     });
   });
@@ -261,67 +331,74 @@ describe('AccessControl', () => {
     });
 
     it('should authorize new admin to grant / revoke roles', () => {
-      accessControl._grantRole(CUSTOM_ADMIN_ROLE, Z_CUSTOM_ADMIN);
+      accessControl._grantRole(CUSTOM_ADMIN_ROLE, CUSTOM_ADMIN.either);
       accessControl._setRoleAdmin(OPERATOR_ROLE_1, CUSTOM_ADMIN_ROLE);
 
+      // Set custom admin SK
+      accessControl.privateState.injectSecretKey(CUSTOM_ADMIN.secretKey);
+
+      // Grant role and check it's been granted
       expect(() =>
-        accessControl.as(CUSTOM_ADMIN).grantRole(OPERATOR_ROLE_1, Z_OPERATOR_1),
+        accessControl.grantRole(OPERATOR_ROLE_1, OP1.either),
       ).not.toThrow();
+      expect(accessControl.hasRole(OPERATOR_ROLE_1, OP1.either)).toBe(true);
+
+      // Revoke role and check it's been revoked
       expect(() =>
-        accessControl
-          .as(CUSTOM_ADMIN)
-          .revokeRole(OPERATOR_ROLE_1, Z_OPERATOR_1),
+        accessControl.revokeRole(OPERATOR_ROLE_1, OP1.either),
       ).not.toThrow();
+      expect(accessControl.hasRole(OPERATOR_ROLE_1, OP1.either)).toBe(false);
     });
 
     it('should disallow previous admin from granting / revoking roles', () => {
-      accessControl._grantRole(DEFAULT_ADMIN_ROLE, Z_ADMIN);
-      accessControl._grantRole(CUSTOM_ADMIN_ROLE, Z_CUSTOM_ADMIN);
+      accessControl._grantRole(DEFAULT_ADMIN_ROLE, ADMIN.either);
+      accessControl._grantRole(CUSTOM_ADMIN_ROLE, CUSTOM_ADMIN.either);
       accessControl._setRoleAdmin(OPERATOR_ROLE_1, CUSTOM_ADMIN_ROLE);
 
-      expect(() =>
-        accessControl.as(ADMIN).grantRole(OPERATOR_ROLE_1, Z_OPERATOR_1),
-      ).toThrow('AccessControl: unauthorized account');
-      expect(() =>
-        accessControl.as(ADMIN).revokeRole(OPERATOR_ROLE_1, Z_OPERATOR_1),
-      ).toThrow('AccessControl: unauthorized account');
+      // Set init admin
+      accessControl.privateState.injectSecretKey(ADMIN.secretKey);
+
+      expect(() => {
+        accessControl.grantRole(OPERATOR_ROLE_1, OP1.either);
+      }).toThrow('AccessControl: unauthorized account');
+
+      expect(() => {
+        accessControl.revokeRole(OPERATOR_ROLE_1, OP1.either);
+      }).toThrow('AccessControl: unauthorized account');
     });
   });
 
   describe('_grantRole', () => {
     it('should grant role', () => {
-      expect(accessControl._grantRole(OPERATOR_ROLE_1, Z_OPERATOR_1)).toBe(
-        true,
-      );
-      expect(accessControl.hasRole(OPERATOR_ROLE_1, Z_OPERATOR_1)).toBe(true);
+      expect(accessControl._grantRole(OPERATOR_ROLE_1, OP1.either)).toBe(true);
+      expect(accessControl.hasRole(OPERATOR_ROLE_1, OP1.either)).toBe(true);
     });
 
     it('should return false if hasRole already', () => {
-      expect(accessControl._grantRole(OPERATOR_ROLE_1, Z_OPERATOR_1)).toBe(
-        true,
-      );
-      expect(accessControl.hasRole(OPERATOR_ROLE_1, Z_OPERATOR_1)).toBe(true);
+      expect(accessControl._grantRole(OPERATOR_ROLE_1, OP1.either)).toBe(true);
+      expect(accessControl.hasRole(OPERATOR_ROLE_1, OP1.either)).toBe(true);
 
-      expect(accessControl._grantRole(OPERATOR_ROLE_1, Z_OPERATOR_1)).toBe(
-        false,
-      );
-      expect(accessControl.hasRole(OPERATOR_ROLE_1, Z_OPERATOR_1)).toBe(true);
+      expect(accessControl._grantRole(OPERATOR_ROLE_1, OP1.either)).toBe(false);
+      expect(accessControl.hasRole(OPERATOR_ROLE_1, OP1.either)).toBe(true);
     });
 
+    // Should be refactored with c2c
     it('should fail to grant role to a ContractAddress', () => {
       expect(() => {
-        accessControl._grantRole(OPERATOR_ROLE_1, Z_OPERATOR_CONTRACT);
+        accessControl._grantRole(OPERATOR_ROLE_1, OP1_CONTRACT);
       }).toThrow('AccessControl: unsafe role approval');
     });
 
     it('should grant multiple roles', () => {
-      for (let i = 0; i < operatorRoles.length; i++) {
-        // length - 1 because we test ContractAddress in the above test
-        for (let j = 0; j < operatorPKs.length - 1; j++) {
-          accessControl._grantRole(operatorRoles[i], operatorPKs[j]);
-          expect(accessControl.hasRole(operatorRoles[i], operatorPKs[j])).toBe(
-            true,
+      for (let i = 0; i < operatorRolesList.length; i++) {
+        for (let j = 0; j < commitmentOperators.length; j++) {
+          accessControl._grantRole(
+            operatorRolesList[i],
+            commitmentOperators[j],
           );
+          expect(
+            accessControl.hasRole(operatorRolesList[i], commitmentOperators[j]),
+          ).toBe(true);
         }
       }
     });
@@ -329,42 +406,44 @@ describe('AccessControl', () => {
 
   describe('_unsafeGrantRole', () => {
     it('should grant role', () => {
-      expect(
-        accessControl._unsafeGrantRole(OPERATOR_ROLE_1, Z_OPERATOR_1),
-      ).toBe(true);
-      expect(accessControl.hasRole(OPERATOR_ROLE_1, Z_OPERATOR_1)).toBe(true);
+      expect(accessControl._unsafeGrantRole(OPERATOR_ROLE_1, OP1.either)).toBe(
+        true,
+      );
+      expect(accessControl.hasRole(OPERATOR_ROLE_1, OP1.either)).toBe(true);
     });
 
     it('should return false if hasRole already', () => {
-      expect(
-        accessControl._unsafeGrantRole(OPERATOR_ROLE_1, Z_OPERATOR_1),
-      ).toBe(true);
-      expect(accessControl.hasRole(OPERATOR_ROLE_1, Z_OPERATOR_1)).toBe(true);
-
-      expect(
-        accessControl._unsafeGrantRole(OPERATOR_ROLE_1, Z_OPERATOR_1),
-      ).toBe(false);
-      expect(accessControl.hasRole(OPERATOR_ROLE_1, Z_OPERATOR_1)).toBe(true);
-    });
-
-    it('should grant role to a ContractAddress', () => {
-      expect(
-        accessControl._unsafeGrantRole(OPERATOR_ROLE_1, Z_OPERATOR_CONTRACT),
-      ).toBe(true);
-      expect(accessControl.hasRole(OPERATOR_ROLE_1, Z_OPERATOR_CONTRACT)).toBe(
+      expect(accessControl._unsafeGrantRole(OPERATOR_ROLE_1, OP1.either)).toBe(
         true,
       );
+      expect(accessControl.hasRole(OPERATOR_ROLE_1, OP1.either)).toBe(true);
+
+      expect(accessControl._unsafeGrantRole(OPERATOR_ROLE_1, OP1.either)).toBe(
+        false,
+      );
+      expect(accessControl.hasRole(OPERATOR_ROLE_1, OP1.either)).toBe(true);
+    });
+
+    // Should be refactored with c2c
+    it('should grant role to a ContractAddress', () => {
+      expect(
+        accessControl._unsafeGrantRole(OPERATOR_ROLE_1, OP1_CONTRACT),
+      ).toBe(true);
+      expect(accessControl.hasRole(OPERATOR_ROLE_1, OP1_CONTRACT)).toBe(true);
     });
 
     it('should grant multiple roles', () => {
-      for (let i = 0; i < operatorRoles.length; i++) {
-        for (let j = 0; j < operatorPKs.length; j++) {
+      for (let i = 0; i < operatorRolesList.length; i++) {
+        for (let j = 0; j < allOperators.length; j++) {
           expect(
-            accessControl._unsafeGrantRole(operatorRoles[i], operatorPKs[j]),
+            accessControl._unsafeGrantRole(
+              operatorRolesList[i],
+              allOperators[j],
+            ),
           ).toBe(true);
-          expect(accessControl.hasRole(operatorRoles[i], operatorPKs[j])).toBe(
-            true,
-          );
+          expect(
+            accessControl.hasRole(operatorRolesList[i], allOperators[j]),
+          ).toBe(true);
         }
       }
     });
@@ -384,22 +463,34 @@ describe('AccessControl', () => {
     });
 
     it('should return false if account does not have role', () => {
-      expect(accessControl._revokeRole(OPERATOR_ROLE_1, Z_OPERATOR_1)).toBe(
+      expect(accessControl._revokeRole(OPERATOR_ROLE_1, OP1.either)).toBe(
         false,
       );
     });
 
     it('should revoke multiple roles', () => {
-      for (let i = 0; i < operatorRoles.length; i++) {
-        for (let j = 0; j < operatorPKs.length; j++) {
-          accessControl._unsafeGrantRole(operatorRoles[i], operatorPKs[j]);
+      for (let i = 0; i < operatorRolesList.length; i++) {
+        for (let j = 0; j < allOperators.length; j++) {
+          accessControl._unsafeGrantRole(operatorRolesList[i], allOperators[j]);
           expect(
-            accessControl._revokeRole(operatorRoles[i], operatorPKs[j]),
+            accessControl._revokeRole(operatorRolesList[i], allOperators[j]),
           ).toBe(true);
-          expect(accessControl.hasRole(operatorRoles[i], operatorPKs[j])).toBe(
-            false,
-          );
+          expect(
+            accessControl.hasRole(operatorRolesList[i], allOperators[j]),
+          ).toBe(false);
         }
+      }
+    });
+  });
+
+  describe('computeAccountId', () => {
+    it('should match the test helper derivation', () => {
+      const users = [OP1, OP2, OP3];
+
+      for (let i = 0; i < users.length; i++) {
+        expect(accessControl.computeAccountId(users[i].secretKey)).toEqual(
+          users[i].accountId,
+        );
       }
     });
   });

--- a/contracts/src/access/test/AccessControl.test.ts
+++ b/contracts/src/access/test/AccessControl.test.ts
@@ -161,7 +161,9 @@ describe('AccessControl', () => {
       };
 
       accessControl._unsafeGrantRole(OPERATOR_ROLE_1, contractWithSameBytes);
-      expect(accessControl.hasRole(OPERATOR_ROLE_1, contractWithSameBytes)).toBe(true);
+      expect(
+        accessControl.hasRole(OPERATOR_ROLE_1, contractWithSameBytes),
+      ).toBe(true);
 
       // ADMIN's witness produces left(H(sk)) which has the same bytes
       // but is a different Either variant than the granted role

--- a/contracts/src/access/test/AccessControl.test.ts
+++ b/contracts/src/access/test/AccessControl.test.ts
@@ -32,7 +32,12 @@ const eitherContract = (address: string) => {
   };
 };
 
-const createTestSK = (label: string): Buffer => Buffer.alloc(32, label);
+const createTestSK = (label: string): Uint8Array => {
+  const sk = new Uint8Array(32);
+  const encoded = new TextEncoder().encode(label);
+  sk.set(encoded.slice(0, 32));
+  return sk;
+};
 
 const makeUser = (label: string) => {
   const secretKey = createTestSK(label);

--- a/contracts/src/access/test/AccessControl.test.ts
+++ b/contracts/src/access/test/AccessControl.test.ts
@@ -100,6 +100,35 @@ describe('AccessControl', () => {
     it('should return false when role does not exist', () => {
       expect(accessControl.hasRole(UNINITIALIZED_ROLE, OP1.either)).toBe(false);
     });
+
+    it('should return true when queried with dirty Either (canonicalization)', () => {
+      const dirtyEither = {
+        is_left: true,
+        left: OP1.accountId,
+        right: { bytes: new Uint8Array(32).fill(0xff) },
+      };
+      expect(accessControl.hasRole(OPERATOR_ROLE_1, dirtyEither)).toBe(true);
+    });
+
+    it('should return false when dirty Either has wrong accountId', () => {
+      const dirtyEither = {
+        is_left: true,
+        left: UNAUTHORIZED.accountId,
+        right: { bytes: new Uint8Array(32).fill(0xff) },
+      };
+      expect(accessControl.hasRole(OPERATOR_ROLE_1, dirtyEither)).toBe(false);
+    });
+
+    it('should match hasRole with dirty left side on contract address', () => {
+      accessControl._unsafeGrantRole(OPERATOR_ROLE_1, OP1_CONTRACT);
+
+      const dirtyContract = {
+        is_left: false,
+        left: new Uint8Array(32).fill(0xff),
+        right: OP1_CONTRACT.right,
+      };
+      expect(accessControl.hasRole(OPERATOR_ROLE_1, dirtyContract)).toBe(true);
+    });
   });
 
   describe('assertOnlyRole', () => {
@@ -271,6 +300,36 @@ describe('AccessControl', () => {
         accessControl.grantRole(OPERATOR_ROLE_2, OP2.either),
       ).not.toThrow();
     });
+
+    it('admin should re-grant a role after revoking it', () => {
+      accessControl.privateState.injectSecretKey(ADMIN.secretKey);
+
+      accessControl.grantRole(OPERATOR_ROLE_1, OP1.either);
+      expect(accessControl.hasRole(OPERATOR_ROLE_1, OP1.either)).toBe(true);
+
+      accessControl.revokeRole(OPERATOR_ROLE_1, OP1.either);
+      expect(accessControl.hasRole(OPERATOR_ROLE_1, OP1.either)).toBe(false);
+
+      accessControl.grantRole(OPERATOR_ROLE_1, OP1.either);
+      expect(accessControl.hasRole(OPERATOR_ROLE_1, OP1.either)).toBe(true);
+    });
+
+    it('should be idempotent when granting an already-held role', () => {
+      accessControl.privateState.injectSecretKey(ADMIN.secretKey);
+
+      accessControl.grantRole(OPERATOR_ROLE_1, OP1.either);
+      expect(accessControl.hasRole(OPERATOR_ROLE_1, OP1.either)).toBe(true);
+
+      // Second grant should not throw or corrupt state
+      expect(() =>
+        accessControl.grantRole(OPERATOR_ROLE_1, OP1.either),
+      ).not.toThrow();
+      expect(accessControl.hasRole(OPERATOR_ROLE_1, OP1.either)).toBe(true);
+
+      // Revoke should still work normally after double-grant
+      accessControl.revokeRole(OPERATOR_ROLE_1, OP1.either);
+      expect(accessControl.hasRole(OPERATOR_ROLE_1, OP1.either)).toBe(false);
+    });
   });
 
   describe('revokeRole', () => {
@@ -320,6 +379,18 @@ describe('AccessControl', () => {
           ).toBe(false);
         }
       }
+    });
+
+    it('should not corrupt state when revoking a never-granted role', () => {
+      accessControl.privateState.injectSecretKey(ADMIN.secretKey);
+
+      // Revoke a role that was never granted to OP2
+      accessControl.revokeRole(OPERATOR_ROLE_2, OP2.either);
+      expect(accessControl.hasRole(OPERATOR_ROLE_2, OP2.either)).toBe(false);
+
+      // Subsequent grant should still work
+      accessControl.grantRole(OPERATOR_ROLE_2, OP2.either);
+      expect(accessControl.hasRole(OPERATOR_ROLE_2, OP2.either)).toBe(true);
     });
   });
 
@@ -426,6 +497,35 @@ describe('AccessControl', () => {
         accessControl.revokeRole(OPERATOR_ROLE_1, OP1.either);
       }).toThrow('AccessControl: unauthorized account');
     });
+
+    it('should allow overwriting admin role and transfer authority', () => {
+      const NEW_ADMIN_ROLE = convertFieldToBytes(32, 99n, '');
+      const NEW_ADMIN = makeUser('NEW_ADMIN');
+
+      accessControl._grantRole(CUSTOM_ADMIN_ROLE, CUSTOM_ADMIN.either);
+      accessControl._grantRole(NEW_ADMIN_ROLE, NEW_ADMIN.either);
+      accessControl._setRoleAdmin(OPERATOR_ROLE_1, CUSTOM_ADMIN_ROLE);
+
+      // CUSTOM_ADMIN can grant
+      accessControl.privateState.injectSecretKey(CUSTOM_ADMIN.secretKey);
+      expect(() =>
+        accessControl.grantRole(OPERATOR_ROLE_1, OP1.either),
+      ).not.toThrow();
+
+      // Overwrite admin role
+      accessControl._setRoleAdmin(OPERATOR_ROLE_1, NEW_ADMIN_ROLE);
+
+      // CUSTOM_ADMIN should lose authority
+      expect(() =>
+        accessControl.grantRole(OPERATOR_ROLE_1, OP2.either),
+      ).toThrow('AccessControl: unauthorized account');
+
+      // NEW_ADMIN should gain authority
+      accessControl.privateState.injectSecretKey(NEW_ADMIN.secretKey);
+      expect(() =>
+        accessControl.grantRole(OPERATOR_ROLE_1, OP2.either),
+      ).not.toThrow();
+    });
   });
 
   describe('_grantRole', () => {
@@ -516,6 +616,43 @@ describe('AccessControl', () => {
         }
       }
     });
+
+    it('should match on subsequent hasRole with clean Either after dirty grant', () => {
+      const dirtyEither = {
+        is_left: true,
+        left: OP2.accountId,
+        right: { bytes: new Uint8Array(32).fill(0xff) },
+      };
+      accessControl._unsafeGrantRole(OPERATOR_ROLE_1, dirtyEither);
+
+      // Clean Either should find the role
+      expect(accessControl.hasRole(OPERATOR_ROLE_1, OP2.either)).toBe(true);
+    });
+
+    it('should match on subsequent hasRole with dirty Either after clean grant', () => {
+      accessControl._unsafeGrantRole(OPERATOR_ROLE_1, OP2.either);
+
+      const dirtyEither = {
+        is_left: true,
+        left: OP2.accountId,
+        right: { bytes: new Uint8Array(32).fill(0xff) },
+      };
+      expect(accessControl.hasRole(OPERATOR_ROLE_1, dirtyEither)).toBe(true);
+    });
+
+    it('should return false for duplicate grant with dirty Either', () => {
+      // Init granted role
+      accessControl._unsafeGrantRole(OPERATOR_ROLE_1, OP1.either);
+
+      const dirtyEither = {
+        is_left: true,
+        left: OP1.accountId,
+        right: { bytes: new Uint8Array(32).fill(0xff) },
+      };
+
+      // Dirty Either should still detect the existing grant
+      expect(accessControl._unsafeGrantRole(OPERATOR_ROLE_1, dirtyEither)).toBe(false);
+    });
   });
 
   describe('_revokeRole', () => {
@@ -550,6 +687,40 @@ describe('AccessControl', () => {
         }
       }
     });
+
+    it('should revoke with dirty Either after clean grant', () => {
+      accessControl._unsafeGrantRole(OPERATOR_ROLE_1, OP1.either);
+
+      const dirtyEither = {
+        is_left: true,
+        left: OP1.accountId,
+        right: { bytes: new Uint8Array(32).fill(0xff) },
+      };
+
+      expect(accessControl._revokeRole(OPERATOR_ROLE_1, dirtyEither)).toBe(true);
+      expect(accessControl.hasRole(OPERATOR_ROLE_1, OP1.either)).toBe(false);
+    });
+
+    it('should return false when revoking ungranted role with dirty Either', () => {
+      const dirtyEither = {
+        is_left: true,
+        left: OP2.accountId,
+        right: { bytes: new Uint8Array(32).fill(0xff) },
+      };
+      expect(accessControl._revokeRole(OPERATOR_ROLE_1, dirtyEither)).toBe(false);
+    });
+
+    it('should revoke with dirty left side on contract address', () => {
+      accessControl._unsafeGrantRole(OPERATOR_ROLE_1, OP1_CONTRACT);
+
+      const dirtyContract = {
+        is_left: false,
+        left: new Uint8Array(32).fill(0xff),
+        right: OP1_CONTRACT.right,
+      };
+      expect(accessControl._revokeRole(OPERATOR_ROLE_1, dirtyContract)).toBe(true);
+      expect(accessControl.hasRole(OPERATOR_ROLE_1, OP1_CONTRACT)).toBe(false);
+    });
   });
 
   describe('computeAccountId', () => {
@@ -560,6 +731,17 @@ describe('AccessControl', () => {
         expect(accessControl.computeAccountId(users[i].secretKey)).toEqual(
           users[i].accountId,
         );
+      }
+    });
+
+    it('should produce distinct identifiers for distinct keys', () => {
+      const users = [ADMIN, CUSTOM_ADMIN, OP1, OP2, OP3, UNAUTHORIZED];
+      const ids = users.map((u) => accessControl.computeAccountId(u.secretKey));
+
+      for (let i = 0; i < ids.length; i++) {
+        for (let j = i + 1; j < ids.length; j++) {
+          expect(ids[i]).not.toEqual(ids[j]);
+        }
       }
     });
   });

--- a/contracts/src/access/test/AccessControl.test.ts
+++ b/contracts/src/access/test/AccessControl.test.ts
@@ -225,6 +225,44 @@ describe('AccessControl', () => {
         accessControl.grantRole(OPERATOR_ROLE_1, OP1_CONTRACT);
       }).toThrow('AccessControl: unsafe role approval');
     });
+
+    it('admin should not be able to grant after self-revocation', () => {
+      // Set admin SK
+      accessControl.privateState.injectSecretKey(ADMIN.secretKey);
+
+      accessControl.revokeRole(DEFAULT_ADMIN_ROLE, ADMIN.either);
+
+      expect(() => accessControl.grantRole(OPERATOR_ROLE_1, OP1.either)).toThrow(
+        'AccessControl: unauthorized account',
+      );
+    });
+
+    it('admin should not be able to grant after renouncing role', () => {
+      // Set admin SK
+      accessControl.privateState.injectSecretKey(ADMIN.secretKey);
+
+      accessControl.renounceRole(DEFAULT_ADMIN_ROLE, ADMIN.either);
+
+      expect(() => accessControl.grantRole(OPERATOR_ROLE_1, OP1.either)).toThrow(
+        'AccessControl: unauthorized account',
+      );
+    });
+
+    it('admin authority should not be transitive across role hierarchies', () => {
+      accessControl._setRoleAdmin(OPERATOR_ROLE_2, OPERATOR_ROLE_1);
+      accessControl._grantRole(OPERATOR_ROLE_1, OP1.either);
+
+      accessControl.privateState.injectSecretKey(ADMIN.secretKey);
+
+      // ADMIN holds DEFAULT_ADMIN_ROLE but not OPERATOR_ROLE_1
+      expect(() => accessControl.grantRole(OPERATOR_ROLE_2, OP2.either)).toThrow(
+        'AccessControl: unauthorized account',
+      );
+
+      // OP1 holds OPERATOR_ROLE_1 which is admin of OPERATOR_ROLE_2
+      accessControl.privateState.injectSecretKey(OP1.secretKey);
+      expect(() => accessControl.grantRole(OPERATOR_ROLE_2, OP2.either)).not.toThrow();
+    });
   });
 
   describe('revokeRole', () => {
@@ -306,6 +344,15 @@ describe('AccessControl', () => {
       expect(() => {
         accessControl.renounceRole(OPERATOR_ROLE_1, OP1.either);
       }).toThrow('AccessControl: bad confirmation');
+    });
+
+    it('should not fail when renouncing a role not held', () => {
+      accessControl.privateState.injectSecretKey(OP1.secretKey);
+      // Confirm role not already held
+      expect(accessControl.hasRole(OPERATOR_ROLE_3, OP1.either)).toBe(false);
+
+      accessControl.renounceRole(OPERATOR_ROLE_3, OP1.either);
+      expect(accessControl.hasRole(OPERATOR_ROLE_3, OP1.either)).toBe(false);
     });
   });
 
@@ -406,6 +453,15 @@ describe('AccessControl', () => {
           ).toBe(true);
         }
       }
+    });
+
+    it('should allow regranting a revoked role', () => {
+      accessControl._grantRole(OPERATOR_ROLE_1, OP1.either);
+      accessControl._revokeRole(OPERATOR_ROLE_1, OP1.either);
+      expect(accessControl.hasRole(OPERATOR_ROLE_1, OP1.either)).toBe(false);
+
+      expect(accessControl._grantRole(OPERATOR_ROLE_1, OP1.either)).toBe(true);
+      expect(accessControl.hasRole(OPERATOR_ROLE_1, OP1.either)).toBe(true);
     });
   });
 

--- a/contracts/src/access/test/AccessControl.test.ts
+++ b/contracts/src/access/test/AccessControl.test.ts
@@ -232,9 +232,9 @@ describe('AccessControl', () => {
 
       accessControl.revokeRole(DEFAULT_ADMIN_ROLE, ADMIN.either);
 
-      expect(() => accessControl.grantRole(OPERATOR_ROLE_1, OP1.either)).toThrow(
-        'AccessControl: unauthorized account',
-      );
+      expect(() =>
+        accessControl.grantRole(OPERATOR_ROLE_1, OP1.either),
+      ).toThrow('AccessControl: unauthorized account');
     });
 
     it('admin should not be able to grant after renouncing role', () => {
@@ -243,9 +243,9 @@ describe('AccessControl', () => {
 
       accessControl.renounceRole(DEFAULT_ADMIN_ROLE, ADMIN.either);
 
-      expect(() => accessControl.grantRole(OPERATOR_ROLE_1, OP1.either)).toThrow(
-        'AccessControl: unauthorized account',
-      );
+      expect(() =>
+        accessControl.grantRole(OPERATOR_ROLE_1, OP1.either),
+      ).toThrow('AccessControl: unauthorized account');
     });
 
     it('admin authority should not be transitive across role hierarchies', () => {
@@ -255,13 +255,15 @@ describe('AccessControl', () => {
       accessControl.privateState.injectSecretKey(ADMIN.secretKey);
 
       // ADMIN holds DEFAULT_ADMIN_ROLE but not OPERATOR_ROLE_1
-      expect(() => accessControl.grantRole(OPERATOR_ROLE_2, OP2.either)).toThrow(
-        'AccessControl: unauthorized account',
-      );
+      expect(() =>
+        accessControl.grantRole(OPERATOR_ROLE_2, OP2.either),
+      ).toThrow('AccessControl: unauthorized account');
 
       // OP1 holds OPERATOR_ROLE_1 which is admin of OPERATOR_ROLE_2
       accessControl.privateState.injectSecretKey(OP1.secretKey);
-      expect(() => accessControl.grantRole(OPERATOR_ROLE_2, OP2.either)).not.toThrow();
+      expect(() =>
+        accessControl.grantRole(OPERATOR_ROLE_2, OP2.either),
+      ).not.toThrow();
     });
   });
 

--- a/contracts/src/access/test/AccessControl.test.ts
+++ b/contracts/src/access/test/AccessControl.test.ts
@@ -651,7 +651,9 @@ describe('AccessControl', () => {
       };
 
       // Dirty Either should still detect the existing grant
-      expect(accessControl._unsafeGrantRole(OPERATOR_ROLE_1, dirtyEither)).toBe(false);
+      expect(accessControl._unsafeGrantRole(OPERATOR_ROLE_1, dirtyEither)).toBe(
+        false,
+      );
     });
   });
 
@@ -697,7 +699,9 @@ describe('AccessControl', () => {
         right: { bytes: new Uint8Array(32).fill(0xff) },
       };
 
-      expect(accessControl._revokeRole(OPERATOR_ROLE_1, dirtyEither)).toBe(true);
+      expect(accessControl._revokeRole(OPERATOR_ROLE_1, dirtyEither)).toBe(
+        true,
+      );
       expect(accessControl.hasRole(OPERATOR_ROLE_1, OP1.either)).toBe(false);
     });
 
@@ -707,7 +711,9 @@ describe('AccessControl', () => {
         left: OP2.accountId,
         right: { bytes: new Uint8Array(32).fill(0xff) },
       };
-      expect(accessControl._revokeRole(OPERATOR_ROLE_1, dirtyEither)).toBe(false);
+      expect(accessControl._revokeRole(OPERATOR_ROLE_1, dirtyEither)).toBe(
+        false,
+      );
     });
 
     it('should revoke with dirty left side on contract address', () => {
@@ -718,7 +724,9 @@ describe('AccessControl', () => {
         left: new Uint8Array(32).fill(0xff),
         right: OP1_CONTRACT.right,
       };
-      expect(accessControl._revokeRole(OPERATOR_ROLE_1, dirtyContract)).toBe(true);
+      expect(accessControl._revokeRole(OPERATOR_ROLE_1, dirtyContract)).toBe(
+        true,
+      );
       expect(accessControl.hasRole(OPERATOR_ROLE_1, OP1_CONTRACT)).toBe(false);
     });
   });

--- a/contracts/src/access/test/mocks/MockAccessControl.compact
+++ b/contracts/src/access/test/mocks/MockAccessControl.compact
@@ -6,9 +6,9 @@ import CompactStandardLibrary;
 
 import "../../AccessControl" prefix AccessControl_;
 
-export { ZswapCoinPublicKey, ContractAddress, Either, Maybe, AccessControl_DEFAULT_ADMIN_ROLE };
+export { ContractAddress, Either, Maybe, AccessControl_DEFAULT_ADMIN_ROLE };
 
-export circuit hasRole(roleId: Bytes<32>, account: Either<ZswapCoinPublicKey, ContractAddress>): Boolean {
+export circuit hasRole(roleId: Bytes<32>, account: Either<Bytes<32>, ContractAddress>): Boolean {
   return AccessControl_hasRole(roleId, account);
 }
 
@@ -16,7 +16,7 @@ export circuit assertOnlyRole(roleId: Bytes<32>): [] {
   AccessControl_assertOnlyRole(roleId);
 }
 
-export circuit _checkRole(roleId: Bytes<32>, account: Either<ZswapCoinPublicKey, ContractAddress>): [] {
+export circuit _checkRole(roleId: Bytes<32>, account: Either<Bytes<32>, ContractAddress>): [] {
   AccessControl__checkRole(roleId, account);
 }
 
@@ -24,15 +24,15 @@ export circuit getRoleAdmin(roleId: Bytes<32>): Bytes<32> {
   return AccessControl_getRoleAdmin(roleId);
 }
 
-export circuit grantRole(roleId: Bytes<32>, account: Either<ZswapCoinPublicKey, ContractAddress>): [] {
+export circuit grantRole(roleId: Bytes<32>, account: Either<Bytes<32>, ContractAddress>): [] {
   AccessControl_grantRole(roleId, account);
 }
 
-export circuit revokeRole(roleId: Bytes<32>, account: Either<ZswapCoinPublicKey, ContractAddress>): [] {
+export circuit revokeRole(roleId: Bytes<32>, account: Either<Bytes<32>, ContractAddress>): [] {
   AccessControl_revokeRole(roleId, account);
 }
 
-export circuit renounceRole(roleId: Bytes<32>, callerConfirmation: Either<ZswapCoinPublicKey, ContractAddress>): [] {
+export circuit renounceRole(roleId: Bytes<32>, callerConfirmation: Either<Bytes<32>, ContractAddress>): [] {
   AccessControl_renounceRole(roleId, callerConfirmation);
 }
 
@@ -40,14 +40,18 @@ export circuit _setRoleAdmin(roleId: Bytes<32>, adminRole: Bytes<32>): [] {
   AccessControl__setRoleAdmin(roleId, adminRole);
 }
 
-export circuit _grantRole(roleId: Bytes<32>, account: Either<ZswapCoinPublicKey, ContractAddress>): Boolean {
+export circuit _grantRole(roleId: Bytes<32>, account: Either<Bytes<32>, ContractAddress>): Boolean {
   return AccessControl__grantRole(roleId, account);
 }
 
-export circuit _unsafeGrantRole(roleId: Bytes<32>, account: Either<ZswapCoinPublicKey, ContractAddress>): Boolean {
+export circuit _unsafeGrantRole(roleId: Bytes<32>, account: Either<Bytes<32>, ContractAddress>): Boolean {
   return AccessControl__unsafeGrantRole(roleId, account);
 }
 
-export circuit _revokeRole(roleId: Bytes<32>, account: Either<ZswapCoinPublicKey, ContractAddress>): Boolean {
+export circuit _revokeRole(roleId: Bytes<32>, account: Either<Bytes<32>, ContractAddress>): Boolean {
   return AccessControl__revokeRole(roleId, account);
+}
+
+export pure circuit computeAccountId(secretKey: Bytes<32>): Bytes<32> {
+  return AccessControl_computeAccountId(secretKey);
 }

--- a/contracts/src/access/test/simulators/AccessControlSimulator.ts
+++ b/contracts/src/access/test/simulators/AccessControlSimulator.ts
@@ -57,7 +57,7 @@ export class AccessControlSimulator extends AccessControlSimulatorBase {
   /**
    * @description Retrieves an account's permission for `roleId`.
    * @param roleId - The role identifier.
-   * @param account - A ZswapCoinPublicKey or a ContractAddress.
+   * @param account - A Bytes<32> accountId or a ContractAddress.
    * @returns Whether an account has a specified role.
    */
   public hasRole(
@@ -78,7 +78,7 @@ export class AccessControlSimulator extends AccessControlSimulatorBase {
   /**
    * @description Retrieves an account's permission for `roleId`.
    * @param roleId - The role identifier.
-   * @param account - A ZswapCoinPublicKey or a ContractAddress.
+   * @param account - A Bytes<32> accountId or a ContractAddress.
    */
   public _checkRole(
     roleId: Uint8Array,
@@ -99,7 +99,7 @@ export class AccessControlSimulator extends AccessControlSimulatorBase {
   /**
    * @description Grants an account permissions to use `roleId`.
    * @param roleId - The role identifier.
-   * @param account - A ZswapCoinPublicKey or a ContractAddress.
+   * @param account - A Bytes<32> accountId or a ContractAddress.
    */
   public grantRole(
     roleId: Uint8Array,
@@ -111,7 +111,7 @@ export class AccessControlSimulator extends AccessControlSimulatorBase {
   /**
    * @description Revokes an account's permission to use `roleId`.
    * @param roleId - The role identifier.
-   * @param account - A ZswapCoinPublicKey or a ContractAddress.
+   * @param account - A Bytes<32> accountId or a ContractAddress.
    */
   public revokeRole(
     roleId: Uint8Array,
@@ -123,7 +123,7 @@ export class AccessControlSimulator extends AccessControlSimulatorBase {
   /**
    * @description Revokes `roleId` from the calling account.
    * @param roleId - The role identifier.
-   * @param account - A ZswapCoinPublicKey or a ContractAddress.
+   * @param account - A Bytes<32> accountId or a ContractAddress.
    */
   public renounceRole(
     roleId: Uint8Array,
@@ -144,7 +144,7 @@ export class AccessControlSimulator extends AccessControlSimulatorBase {
   /**
    * @description Grants an account permissions to use `roleId`. Internal function without access restriction.
    * @param roleId - The role identifier.
-   * @param account - A ZswapCoinPublicKey or a ContractAddress.
+   * @param account - A Bytes<32> accountId or a ContractAddress.
    */
   public _grantRole(
     roleId: Uint8Array,
@@ -157,7 +157,7 @@ export class AccessControlSimulator extends AccessControlSimulatorBase {
    * @description Grants an account permissions to use `roleId`. Internal function without access restriction.
    * DOES NOT restrict sending to a ContractAddress.
    * @param roleId - The role identifier.
-   * @param account - A ZswapCoinPublicKey or a ContractAddress.
+   * @param account - A Bytes<32> accountId or a ContractAddress.
    */
   public _unsafeGrantRole(
     roleId: Uint8Array,
@@ -169,7 +169,7 @@ export class AccessControlSimulator extends AccessControlSimulatorBase {
   /**
    * @description Revokes an account's permission to use `roleId`. Internal function without access restriction.
    * @param roleId - The role identifier.
-   * @param account - A ZswapCoinPublicKey or a ContractAddress.
+   * @param account - A Bytes<32> accountId or a ContractAddress.
    */
   public _revokeRole(
     roleId: Uint8Array,

--- a/contracts/src/access/test/simulators/AccessControlSimulator.ts
+++ b/contracts/src/access/test/simulators/AccessControlSimulator.ts
@@ -7,7 +7,6 @@ import {
   type Either,
   ledger,
   Contract as MockAccessControl,
-  type ZswapCoinPublicKey,
 } from '../../../../artifacts/MockAccessControl/contract/index.js';
 import {
   AccessControlPrivateState,
@@ -28,7 +27,7 @@ const AccessControlSimulatorBase = createSimulator<
 >({
   contractFactory: (witnesses) =>
     new MockAccessControl<AccessControlPrivateState>(witnesses),
-  defaultPrivateState: () => AccessControlPrivateState,
+  defaultPrivateState: () => AccessControlPrivateState.generate(),
   contractArgs: () => [],
   ledgerExtractor: (state) => ledger(state),
   witnessesFactory: () => AccessControlWitnesses(),
@@ -55,7 +54,7 @@ export class AccessControlSimulator extends AccessControlSimulatorBase {
    */
   public hasRole(
     roleId: Uint8Array,
-    account: Either<ZswapCoinPublicKey, ContractAddress>,
+    account: Either<Uint8Array, ContractAddress>,
   ): boolean {
     return this.circuits.impure.hasRole(roleId, account);
   }
@@ -75,7 +74,7 @@ export class AccessControlSimulator extends AccessControlSimulatorBase {
    */
   public _checkRole(
     roleId: Uint8Array,
-    account: Either<ZswapCoinPublicKey, ContractAddress>,
+    account: Either<Uint8Array, ContractAddress>,
   ) {
     this.circuits.impure._checkRole(roleId, account);
   }
@@ -96,7 +95,7 @@ export class AccessControlSimulator extends AccessControlSimulatorBase {
    */
   public grantRole(
     roleId: Uint8Array,
-    account: Either<ZswapCoinPublicKey, ContractAddress>,
+    account: Either<Uint8Array, ContractAddress>,
   ) {
     this.circuits.impure.grantRole(roleId, account);
   }
@@ -108,7 +107,7 @@ export class AccessControlSimulator extends AccessControlSimulatorBase {
    */
   public revokeRole(
     roleId: Uint8Array,
-    account: Either<ZswapCoinPublicKey, ContractAddress>,
+    account: Either<Uint8Array, ContractAddress>,
   ) {
     this.circuits.impure.revokeRole(roleId, account);
   }
@@ -120,7 +119,7 @@ export class AccessControlSimulator extends AccessControlSimulatorBase {
    */
   public renounceRole(
     roleId: Uint8Array,
-    account: Either<ZswapCoinPublicKey, ContractAddress>,
+    account: Either<Uint8Array, ContractAddress>,
   ) {
     this.circuits.impure.renounceRole(roleId, account);
   }
@@ -141,7 +140,7 @@ export class AccessControlSimulator extends AccessControlSimulatorBase {
    */
   public _grantRole(
     roleId: Uint8Array,
-    account: Either<ZswapCoinPublicKey, ContractAddress>,
+    account: Either<Uint8Array, ContractAddress>,
   ): boolean {
     return this.circuits.impure._grantRole(roleId, account);
   }
@@ -154,7 +153,7 @@ export class AccessControlSimulator extends AccessControlSimulatorBase {
    */
   public _unsafeGrantRole(
     roleId: Uint8Array,
-    account: Either<ZswapCoinPublicKey, ContractAddress>,
+    account: Either<Uint8Array, ContractAddress>,
   ): boolean {
     return this.circuits.impure._unsafeGrantRole(roleId, account);
   }
@@ -166,8 +165,48 @@ export class AccessControlSimulator extends AccessControlSimulatorBase {
    */
   public _revokeRole(
     roleId: Uint8Array,
-    account: Either<ZswapCoinPublicKey, ContractAddress>,
+    account: Either<Uint8Array, ContractAddress>,
   ): boolean {
     return this.circuits.impure._revokeRole(roleId, account);
   }
+
+  /**
+   * @description Computes an account identifier without on-chain state, allowing a user to derive
+   * their identity commitment before submitting it in a grant or revoke operation.
+   * @param {Bytes<32>} secretKey - A 32-byte cryptographically secure random value.
+   * @returns {Bytes<32>} accountId - The computed account identifier.
+   */
+  public computeAccountId(secretKey: Uint8Array): Uint8Array {
+    return this.circuits.pure.computeAccountId(secretKey);
+  }
+
+  public readonly privateState = {
+    /**
+     * @description Replaces the secret key in the private state. Used in tests to
+     * simulate switching between different user identities or injecting incorrect
+     * keys to test failure paths.
+     * @param newSK - The new secret key to set.
+     * @returns The updated private state.
+     */
+    injectSecretKey: (
+      newSK: Buffer<ArrayBufferLike>,
+    ): AccessControlPrivateState => {
+      const updatedState = { secretKey: newSK };
+      this.circuitContextManager.updatePrivateState(updatedState);
+      return updatedState;
+    },
+
+    /**
+     * @description Returns the current secret key from the private state.
+     * @returns The secret key.
+     * @throws If the secret key is undefined.
+     */
+    getCurrentSecretKey: (): Uint8Array => {
+      const sk = this.getPrivateState().secretKey;
+      if (typeof sk === 'undefined') {
+        throw new Error('Missing secret key');
+      }
+      return sk;
+    },
+  };
 }

--- a/contracts/src/access/test/simulators/AccessControlSimulator.ts
+++ b/contracts/src/access/test/simulators/AccessControlSimulator.ts
@@ -189,7 +189,7 @@ export class AccessControlSimulator extends AccessControlSimulatorBase {
      * @returns The updated private state.
      */
     injectSecretKey: (
-      newSK: Buffer<ArrayBufferLike>,
+      newSK: Uint8Array,
     ): AccessControlPrivateState => {
       const updatedState = { secretKey: newSK };
       this.circuitContextManager.updatePrivateState(updatedState);

--- a/contracts/src/access/test/simulators/AccessControlSimulator.ts
+++ b/contracts/src/access/test/simulators/AccessControlSimulator.ts
@@ -189,7 +189,11 @@ export class AccessControlSimulator extends AccessControlSimulatorBase {
      * @returns The updated private state.
      */
     injectSecretKey: (newSK: Uint8Array): AccessControlPrivateState => {
-      const updatedState = { secretKey: newSK };
+      const currentState = this.getPrivateState();
+      const updatedState = {
+        ...currentState,
+        ...AccessControlPrivateState.withSecretKey(newSK),
+      };
       this.circuitContextManager.updatePrivateState(updatedState);
       return updatedState;
     },

--- a/contracts/src/access/test/simulators/AccessControlSimulator.ts
+++ b/contracts/src/access/test/simulators/AccessControlSimulator.ts
@@ -57,7 +57,7 @@ export class AccessControlSimulator extends AccessControlSimulatorBase {
   /**
    * @description Retrieves an account's permission for `roleId`.
    * @param roleId - The role identifier.
-   * @param account - A Bytes<32> accountId or a ContractAddress.
+   * @param account - An Either wrapping a Bytes<32> identity commitment (left) or a ContractAddress (right).
    * @returns Whether an account has a specified role.
    */
   public hasRole(
@@ -78,7 +78,7 @@ export class AccessControlSimulator extends AccessControlSimulatorBase {
   /**
    * @description Retrieves an account's permission for `roleId`.
    * @param roleId - The role identifier.
-   * @param account - A Bytes<32> accountId or a ContractAddress.
+   * @param account - An Either wrapping a Bytes<32> identity commitment (left) or a ContractAddress (right).
    */
   public _checkRole(
     roleId: Uint8Array,
@@ -99,7 +99,7 @@ export class AccessControlSimulator extends AccessControlSimulatorBase {
   /**
    * @description Grants an account permissions to use `roleId`.
    * @param roleId - The role identifier.
-   * @param account - A Bytes<32> accountId or a ContractAddress.
+   * @param account - An Either wrapping a Bytes<32> identity commitment (left) or a ContractAddress (right).
    */
   public grantRole(
     roleId: Uint8Array,
@@ -111,7 +111,7 @@ export class AccessControlSimulator extends AccessControlSimulatorBase {
   /**
    * @description Revokes an account's permission to use `roleId`.
    * @param roleId - The role identifier.
-   * @param account - A Bytes<32> accountId or a ContractAddress.
+   * @param account - An Either wrapping a Bytes<32> identity commitment (left) or a ContractAddress (right).
    */
   public revokeRole(
     roleId: Uint8Array,
@@ -123,7 +123,7 @@ export class AccessControlSimulator extends AccessControlSimulatorBase {
   /**
    * @description Revokes `roleId` from the calling account.
    * @param roleId - The role identifier.
-   * @param account - A Bytes<32> accountId or a ContractAddress.
+   * @param account - An Either wrapping a Bytes<32> identity commitment (left) or a ContractAddress (right).
    */
   public renounceRole(
     roleId: Uint8Array,
@@ -144,7 +144,7 @@ export class AccessControlSimulator extends AccessControlSimulatorBase {
   /**
    * @description Grants an account permissions to use `roleId`. Internal function without access restriction.
    * @param roleId - The role identifier.
-   * @param account - A Bytes<32> accountId or a ContractAddress.
+   * @param account - An Either wrapping a Bytes<32> identity commitment (left) or a ContractAddress (right).
    */
   public _grantRole(
     roleId: Uint8Array,
@@ -157,7 +157,7 @@ export class AccessControlSimulator extends AccessControlSimulatorBase {
    * @description Grants an account permissions to use `roleId`. Internal function without access restriction.
    * DOES NOT restrict sending to a ContractAddress.
    * @param roleId - The role identifier.
-   * @param account - A Bytes<32> accountId or a ContractAddress.
+   * @param account - An Either wrapping a Bytes<32> identity commitment (left) or a ContractAddress (right).
    */
   public _unsafeGrantRole(
     roleId: Uint8Array,
@@ -169,7 +169,7 @@ export class AccessControlSimulator extends AccessControlSimulatorBase {
   /**
    * @description Revokes an account's permission to use `roleId`. Internal function without access restriction.
    * @param roleId - The role identifier.
-   * @param account - A Bytes<32> accountId or a ContractAddress.
+   * @param account - An Either wrapping a Bytes<32> identity commitment (left) or a ContractAddress (right).
    */
   public _revokeRole(
     roleId: Uint8Array,

--- a/contracts/src/access/test/simulators/AccessControlSimulator.ts
+++ b/contracts/src/access/test/simulators/AccessControlSimulator.ts
@@ -188,9 +188,7 @@ export class AccessControlSimulator extends AccessControlSimulatorBase {
      * @param newSK - The new secret key to set.
      * @returns The updated private state.
      */
-    injectSecretKey: (
-      newSK: Uint8Array,
-    ): AccessControlPrivateState => {
+    injectSecretKey: (newSK: Uint8Array): AccessControlPrivateState => {
       const updatedState = { secretKey: newSK };
       this.circuitContextManager.updatePrivateState(updatedState);
       return updatedState;

--- a/contracts/src/access/witnesses/AccessControlWitnesses.ts
+++ b/contracts/src/access/witnesses/AccessControlWitnesses.ts
@@ -1,6 +1,73 @@
-// SPDX-License-Identifier: MIT
-// OpenZeppelin Compact Contracts v0.0.1-alpha.1 (access/witnesses/AccessControlWitnesses.ts)
+import { getRandomValues } from 'node:crypto';
+import type { WitnessContext } from '@midnight-ntwrk/compact-runtime';
+import type { Ledger } from '../../../artifacts/MockAccessControl/contract/index.js';
 
-export type AccessControlPrivateState = Record<string, never>;
-export const AccessControlPrivateState: AccessControlPrivateState = {};
-export const AccessControlWitnesses = () => ({});
+/**
+ * @description Interface defining the witness methods for AccessControl operations.
+ * @template P - The private state type.
+ */
+export interface IAccessControlWitnesses<P> {
+  /**
+   * Retrieves the secret key from the private state.
+   * @param context - The witness context containing the private state.
+   * @returns A tuple of the private state and the secret key as a Uint8Array.
+   */
+  wit_AccessControlSK(context: WitnessContext<Ledger, P>): [P, Uint8Array];
+}
+
+/**
+ * @description Represents the private state of an AccessControl contract, storing a secret key.
+ */
+export type AccessControlPrivateState = {
+  /** @description A 32-byte secret key used for creating a public user identifier. */
+  secretKey: Buffer;
+};
+
+/**
+ * @description Utility object for managing the private state of an AccessControl contract.
+ */
+export const AccessControlPrivateState = {
+  /**
+   * @description Generates a new private state with a random secret key.
+   * @returns A fresh AccessControlPrivateState instance.
+   */
+  generate: (): AccessControlPrivateState => {
+    return { secretKey: getRandomValues(Buffer.alloc(32)) };
+  },
+
+  /**
+   * @description Generates a new private state with a user-defined secret key.
+   * Useful for deterministic nonce generation or advanced use cases.
+   *
+   * @param sk - The 32-byte secret nonce to use.
+   * @returns A fresh AccessControlPrivateState instance with the provided nonce.
+   *
+   * @example
+   * ```typescript
+   * // For deterministic keys (user-defined scheme)
+   * const deterministicKey = myDeterministicScheme(...);
+   * const privateState = AccessControlPrivateState.withSecretKey(deterministicKey);
+   * ```
+   */
+  withSecretKey: (sk: Buffer): AccessControlPrivateState => {
+    if (sk.length !== 32) {
+      throw new Error(
+        `withSecretKey: expected 32-byte secret key, received ${sk.length} bytes`,
+      );
+    }
+    return { secretKey: Buffer.from(sk) };
+  },
+};
+
+/**
+ * @description Factory function creating witness implementations for Ownable operations.
+ * @returns An object implementing the Witnesses interface for AccessControlPrivateState.
+ */
+export const AccessControlWitnesses =
+  (): IAccessControlWitnesses<AccessControlPrivateState> => ({
+    wit_AccessControlSK(
+      context: WitnessContext<Ledger, AccessControlPrivateState>,
+    ): [AccessControlPrivateState, Uint8Array] {
+      return [context.privateState, context.privateState.secretKey];
+    },
+  });

--- a/contracts/src/access/witnesses/AccessControlWitnesses.ts
+++ b/contracts/src/access/witnesses/AccessControlWitnesses.ts
@@ -36,10 +36,10 @@ export const AccessControlPrivateState = {
 
   /**
    * @description Generates a new private state with a user-defined secret key.
-   * Useful for deterministic nonce generation or advanced use cases.
+   * Useful for deterministic key generation or advanced use cases.
    *
-   * @param sk - The 32-byte secret nonce to use.
-   * @returns A fresh AccessControlPrivateState instance with the provided nonce.
+   * @param sk - The 32-byte secret key to use.
+   * @returns A fresh AccessControlPrivateState instance with the provided key.
    *
    * @example
    * ```typescript
@@ -59,7 +59,7 @@ export const AccessControlPrivateState = {
 };
 
 /**
- * @description Factory function creating witness implementations for Ownable operations.
+ * @description Factory function creating witness implementations for AccessControl operations.
  * @returns An object implementing the Witnesses interface for AccessControlPrivateState.
  */
 export const AccessControlWitnesses = <L>(): IAccessControlWitnesses<

--- a/contracts/src/access/witnesses/AccessControlWitnesses.ts
+++ b/contracts/src/access/witnesses/AccessControlWitnesses.ts
@@ -20,7 +20,7 @@ export interface IAccessControlWitnesses<P> {
  */
 export type AccessControlPrivateState = {
   /** @description A 32-byte secret key used for creating a public user identifier. */
-  secretKey: Buffer;
+  secretKey: Uint8Array;
 };
 
 /**
@@ -32,7 +32,7 @@ export const AccessControlPrivateState = {
    * @returns A fresh AccessControlPrivateState instance.
    */
   generate: (): AccessControlPrivateState => {
-    return { secretKey: getRandomValues(Buffer.alloc(32)) };
+    return { secretKey: getRandomValues(new Uint8Array(32)) };
   },
 
   /**
@@ -49,13 +49,13 @@ export const AccessControlPrivateState = {
    * const privateState = AccessControlPrivateState.withSecretKey(deterministicKey);
    * ```
    */
-  withSecretKey: (sk: Buffer): AccessControlPrivateState => {
+  withSecretKey: (sk: Uint8Array): AccessControlPrivateState => {
     if (sk.length !== 32) {
       throw new Error(
         `withSecretKey: expected 32-byte secret key, received ${sk.length} bytes`,
       );
     }
-    return { secretKey: Buffer.from(sk) };
+    return { secretKey: Uint8Array.from(sk) };
   },
 };
 

--- a/contracts/src/access/witnesses/AccessControlWitnesses.ts
+++ b/contracts/src/access/witnesses/AccessControlWitnesses.ts
@@ -1,18 +1,17 @@
 import { getRandomValues } from 'node:crypto';
 import type { WitnessContext } from '@midnight-ntwrk/compact-runtime';
-import type { Ledger } from '../../../artifacts/MockAccessControl/contract/index.js';
 
 /**
  * @description Interface defining the witness methods for AccessControl operations.
  * @template P - The private state type.
  */
-export interface IAccessControlWitnesses<P> {
+export interface IAccessControlWitnesses<L, P> {
   /**
    * Retrieves the secret key from the private state.
    * @param context - The witness context containing the private state.
    * @returns A tuple of the private state and the secret key as a Uint8Array.
    */
-  wit_AccessControlSK(context: WitnessContext<Ledger, P>): [P, Uint8Array];
+  wit_AccessControlSK(context: WitnessContext<L, P>): [P, Uint8Array];
 }
 
 /**
@@ -63,10 +62,9 @@ export const AccessControlPrivateState = {
  * @description Factory function creating witness implementations for Ownable operations.
  * @returns An object implementing the Witnesses interface for AccessControlPrivateState.
  */
-export const AccessControlWitnesses =
-  (): IAccessControlWitnesses<AccessControlPrivateState> => ({
+export const AccessControlWitnesses = <L>(): IAccessControlWitnesses<L, AccessControlPrivateState> => ({
     wit_AccessControlSK(
-      context: WitnessContext<Ledger, AccessControlPrivateState>,
+      context: WitnessContext<L, AccessControlPrivateState>,
     ): [AccessControlPrivateState, Uint8Array] {
       return [context.privateState, context.privateState.secretKey];
     },

--- a/contracts/src/access/witnesses/AccessControlWitnesses.ts
+++ b/contracts/src/access/witnesses/AccessControlWitnesses.ts
@@ -69,6 +69,9 @@ export const AccessControlWitnesses = <L>(): IAccessControlWitnesses<
   wit_AccessControlSK(
     context: WitnessContext<L, AccessControlPrivateState>,
   ): [AccessControlPrivateState, Uint8Array] {
-    return [context.privateState, context.privateState.secretKey];
+    return [
+      context.privateState,
+      Uint8Array.from(context.privateState.secretKey),
+    ];
   },
 });

--- a/contracts/src/access/witnesses/AccessControlWitnesses.ts
+++ b/contracts/src/access/witnesses/AccessControlWitnesses.ts
@@ -62,10 +62,13 @@ export const AccessControlPrivateState = {
  * @description Factory function creating witness implementations for Ownable operations.
  * @returns An object implementing the Witnesses interface for AccessControlPrivateState.
  */
-export const AccessControlWitnesses = <L>(): IAccessControlWitnesses<L, AccessControlPrivateState> => ({
-    wit_AccessControlSK(
-      context: WitnessContext<L, AccessControlPrivateState>,
-    ): [AccessControlPrivateState, Uint8Array] {
-      return [context.privateState, context.privateState.secretKey];
-    },
-  });
+export const AccessControlWitnesses = <L>(): IAccessControlWitnesses<
+  L,
+  AccessControlPrivateState
+> => ({
+  wit_AccessControlSK(
+    context: WitnessContext<L, AccessControlPrivateState>,
+  ): [AccessControlPrivateState, Uint8Array] {
+    return [context.privateState, context.privateState.secretKey];
+  },
+});

--- a/contracts/src/access/witnesses/AccessControlWitnesses.ts
+++ b/contracts/src/access/witnesses/AccessControlWitnesses.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Compact Contracts v0.0.1-alpha.1 (access/witnesses/AccessControlWitnesses.ts)
+
 import { getRandomValues } from 'node:crypto';
 import type { WitnessContext } from '@midnight-ntwrk/compact-runtime';
 

--- a/contracts/src/access/witnesses/test/AccessControlWitnesses.test.ts
+++ b/contracts/src/access/witnesses/test/AccessControlWitnesses.test.ts
@@ -54,7 +54,9 @@ describe('AccessControlPrivateState', () => {
     it('should throw for an empty array', () => {
       expect(() =>
         AccessControlPrivateState.withSecretKey(new Uint8Array(0)),
-      ).toThrowError('withSecretKey: expected 32-byte secret key, received 0 bytes');
+      ).toThrowError(
+        'withSecretKey: expected 32-byte secret key, received 0 bytes',
+      );
     });
   });
 });
@@ -65,7 +67,10 @@ describe('AccessControlWitnesses', () => {
   function makeContext(
     privateState: AccessControlPrivateState,
   ): WitnessContext<Ledger, AccessControlPrivateState> {
-    return { privateState } as WitnessContext<Ledger, AccessControlPrivateState>;
+    return { privateState } as WitnessContext<
+      Ledger,
+      AccessControlPrivateState
+    >;
   }
 
   describe('wit_AccessControlSK', () => {

--- a/contracts/src/access/witnesses/test/AccessControlWitnesses.test.ts
+++ b/contracts/src/access/witnesses/test/AccessControlWitnesses.test.ts
@@ -1,0 +1,133 @@
+import type { WitnessContext } from '@midnight-ntwrk/compact-runtime';
+import { describe, expect, it } from 'vitest';
+import type { Ledger } from '../../../../artifacts/MockAccessControl/contract/index.js';
+import {
+  AccessControlPrivateState,
+  AccessControlWitnesses,
+} from '../AccessControlWitnesses.js';
+
+const SECRET_KEY = Buffer.alloc(32, 0x34);
+
+describe('AccessControlPrivateState', () => {
+  describe('generate', () => {
+    it('should return a state with a 32-byte secretKey', () => {
+      const state = AccessControlPrivateState.generate();
+      expect(state.secretKey).toBeInstanceOf(Buffer);
+      expect(state.secretKey.length).toBe(32);
+    });
+
+    it('should produce unique secret key on successive calls', () => {
+      const a = AccessControlPrivateState.generate();
+      const b = AccessControlPrivateState.generate();
+      expect(a.secretKey.equals(b.secretKey)).toBe(false);
+    });
+  });
+
+  describe('withSecretKey', () => {
+    it('should accept a valid 32-byte secret key', () => {
+      const state = AccessControlPrivateState.withSecretKey(SECRET_KEY);
+      expect(state.secretKey).toEqual(SECRET_KEY);
+    });
+
+    it('should create a defensive copy of the input secret key', () => {
+      const sk = Buffer.alloc(32, 0xcc);
+      const state = AccessControlPrivateState.withSecretKey(sk);
+
+      sk.fill(0xff);
+      expect(state.secretKey).toEqual(Buffer.alloc(32, 0xcc));
+    });
+
+    it('should throw for a secret key shorter than 32 bytes', () => {
+      const short = Buffer.alloc(16);
+      expect(() => AccessControlPrivateState.withSecretKey(short)).toThrowError(
+        'withSecretKey: expected 32-byte secret key, received 16 bytes',
+      );
+    });
+
+    it('should throw for a secret key longer than 32 bytes', () => {
+      const long = Buffer.alloc(64);
+      expect(() => AccessControlPrivateState.withSecretKey(long)).toThrowError(
+        'withSecretKey: expected 32-byte secret key, received 64 bytes',
+      );
+    });
+
+    it('should throw for an empty buffer', () => {
+      expect(() =>
+        AccessControlPrivateState.withSecretKey(Buffer.alloc(0)),
+      ).toThrowError('withSecretKey: expected 32-byte secret key, received 0 bytes');
+    });
+  });
+});
+
+describe('AccessControlWitnesses', () => {
+  const witnesses = AccessControlWitnesses();
+
+  function makeContext(
+    privateState: AccessControlPrivateState,
+  ): WitnessContext<Ledger, AccessControlPrivateState> {
+    return { privateState } as WitnessContext<Ledger, AccessControlPrivateState>;
+  }
+
+  describe('wit_AccessControlSK', () => {
+    it('should return a tuple of [privateState, secretKey]', () => {
+      const state = AccessControlPrivateState.withSecretKey(SECRET_KEY);
+      const ctx = makeContext(state);
+
+      const [returnedState, returnedSK] = witnesses.wit_AccessControlSK(ctx);
+
+      expect(returnedState).toBe(state);
+      expect(returnedSK).toEqual(SECRET_KEY);
+    });
+
+    it('should return the exact same privateState reference', () => {
+      const state = AccessControlPrivateState.generate();
+      const ctx = makeContext(state);
+
+      const [returnedState] = witnesses.wit_AccessControlSK(ctx);
+      expect(returnedState).toBe(state);
+    });
+
+    it('should return the secretKey as a Uint8Array', () => {
+      const state = AccessControlPrivateState.generate();
+      const ctx = makeContext(state);
+
+      const [, returnedSK] = witnesses.wit_AccessControlSK(ctx);
+      expect(returnedSK).toBeInstanceOf(Uint8Array);
+      expect(returnedSK.length).toBe(32);
+    });
+
+    it('should work with a randomly generated state', () => {
+      const state = AccessControlPrivateState.generate();
+      const ctx = makeContext(state);
+
+      const [returnedState, returnedSK] = witnesses.wit_AccessControlSK(ctx);
+
+      expect(returnedState).toBe(state);
+      expect(Buffer.from(returnedSK).equals(state.secretKey)).toBe(true);
+    });
+  });
+});
+
+describe('AccessControlWitnesses factory', () => {
+  it('should return a fresh witnesses object on each call', () => {
+    const a = AccessControlWitnesses();
+    const b = AccessControlWitnesses();
+    expect(a).not.toBe(b);
+  });
+
+  it('should produce witnesses with identical behaviour', () => {
+    const a = AccessControlWitnesses();
+    const b = AccessControlWitnesses();
+    const state = AccessControlPrivateState.generate();
+    const ctx = { privateState: state } as WitnessContext<
+      Ledger,
+      AccessControlPrivateState
+    >;
+
+    const [stateA, skA] = a.wit_AccessControlSK(ctx);
+    const [stateB, skB] = b.wit_AccessControlSK(ctx);
+
+    expect(stateA).toBe(stateB);
+    expect(Buffer.from(skA).equals(Buffer.from(skB))).toBe(true);
+  });
+});

--- a/contracts/src/access/witnesses/test/AccessControlWitnesses.test.ts
+++ b/contracts/src/access/witnesses/test/AccessControlWitnesses.test.ts
@@ -6,20 +6,20 @@ import {
   AccessControlWitnesses,
 } from '../AccessControlWitnesses.js';
 
-const SECRET_KEY = Buffer.alloc(32, 0x34);
+const SECRET_KEY = new Uint8Array(32).fill(0x34);
 
 describe('AccessControlPrivateState', () => {
   describe('generate', () => {
     it('should return a state with a 32-byte secretKey', () => {
       const state = AccessControlPrivateState.generate();
-      expect(state.secretKey).toBeInstanceOf(Buffer);
+      expect(state.secretKey).toBeInstanceOf(Uint8Array);
       expect(state.secretKey.length).toBe(32);
     });
 
     it('should produce unique secret key on successive calls', () => {
       const a = AccessControlPrivateState.generate();
       const b = AccessControlPrivateState.generate();
-      expect(a.secretKey.equals(b.secretKey)).toBe(false);
+      expect(a.secretKey).not.toEqual(b.secretKey);
     });
   });
 
@@ -30,30 +30,30 @@ describe('AccessControlPrivateState', () => {
     });
 
     it('should create a defensive copy of the input secret key', () => {
-      const sk = Buffer.alloc(32, 0xcc);
+      const sk = new Uint8Array(32).fill(0xcc);
       const state = AccessControlPrivateState.withSecretKey(sk);
 
       sk.fill(0xff);
-      expect(state.secretKey).toEqual(Buffer.alloc(32, 0xcc));
+      expect(state.secretKey).toEqual(new Uint8Array(32).fill(0xcc));
     });
 
     it('should throw for a secret key shorter than 32 bytes', () => {
-      const short = Buffer.alloc(16);
+      const short = new Uint8Array(16);
       expect(() => AccessControlPrivateState.withSecretKey(short)).toThrowError(
         'withSecretKey: expected 32-byte secret key, received 16 bytes',
       );
     });
 
     it('should throw for a secret key longer than 32 bytes', () => {
-      const long = Buffer.alloc(64);
+      const long = new Uint8Array(64);
       expect(() => AccessControlPrivateState.withSecretKey(long)).toThrowError(
         'withSecretKey: expected 32-byte secret key, received 64 bytes',
       );
     });
 
-    it('should throw for an empty buffer', () => {
+    it('should throw for an empty array', () => {
       expect(() =>
-        AccessControlPrivateState.withSecretKey(Buffer.alloc(0)),
+        AccessControlPrivateState.withSecretKey(new Uint8Array(0)),
       ).toThrowError('withSecretKey: expected 32-byte secret key, received 0 bytes');
     });
   });
@@ -103,7 +103,7 @@ describe('AccessControlWitnesses', () => {
       const [returnedState, returnedSK] = witnesses.wit_AccessControlSK(ctx);
 
       expect(returnedState).toBe(state);
-      expect(Buffer.from(returnedSK).equals(state.secretKey)).toBe(true);
+      expect(returnedSK).toEqual(state.secretKey);
     });
   });
 });
@@ -128,6 +128,6 @@ describe('AccessControlWitnesses factory', () => {
     const [stateB, skB] = b.wit_AccessControlSK(ctx);
 
     expect(stateA).toBe(stateB);
-    expect(Buffer.from(skA).equals(Buffer.from(skB))).toBe(true);
+    expect(skA).toEqual(skB);
   });
 });


### PR DESCRIPTION
This PR proposes to replace `ownPublicKey()` with a witness-derived identity scheme. The module defines a `wit_AccessControlSK` witness that returns a secret key, and identity is derived as `accountId = persistentHash(secretKey)`. Only the holder of the secret key can produce the corresponding `accountId`. This intentionally mirrors Solidity's `msg.sender` which provides a stable, pseudonymous identity that persists across contracts. The hash uses no per-deployment salt or domain separator by design. If a user uses the same secret key across multiple contracts (e.g., a USDC and USDT deployment both using the FungibleToken module), their `accountId` will be identical in all of them. This is opt-in linkability: users who want cross-contract unlinkability use different keys per contract at the wallet layer.

Note that shielded variants (ShieldedAccessControl) use a more complex commitment/nullifier scheme with per-deployment salts and domain separators to provide stronger privacy guarantees. Users should choose the appropriate module variant based on their privacy requirements.

Fix: https://github.com/OpenZeppelin/compact-contracts/issues/452

### Changes

- `assertOnlyRole` now derives caller identity from `H(wit_AccessControlSK())` instead of `ownPublicKey()`
- Change account type from `Either<ZswapCoinPublicKey, ContractAddress>` to `Either<Bytes<32>, ContractAddress>` across all circuit signatures and ledger types
- Add `wit_AccessControlSK` witness returning the caller's secret key
  - The witness is namespaced to the module so that circuits calling into multiple modules within a single transaction can use independent keys for each. A shared witness name would return the same key for both calls within the same proof, preventing the user from maintaining separate identities per module
- Add `computeAccountId` (pure) circuit for off-chain identity derivation
- Add `_computeAccountId` (internal) circuit using the witness

### Witnesses

- Add AccessControlWitnesses with `wit_AccessControlSK` implementation

### Effects

- Only the holder of the secret key can produce the corresponding `accountId`
- All circuit signatures and ledger types that referenced `Either<ZswapCoinPublicKey, ContractAddress>` are updated to `Either<Bytes<32>, ContractAddress>`. The account identifier is now a hash-derived commitment rather than a public key. This propagates through circuit parameters, return types, and ledger state
- Subsequent PRs will apply the same witness-derived id pattern to enable opt-in linkability between contract deployments

### Trade-offs

- Users are responsible for generating, storing, and backing up their secret keys. Key loss means identity loss. There is no on-chain recovery mechanism. The secret key must be available as raw bytes to the local proving environment during proof gen, as it is used as a hash preimage inside the circuit. The key does not require a specific cryptographic format. Any 32 bytes of sufficient entropy will work. Users may derive the key from an HSM-held master secret or store it in an encrypted vault, but the raw value must ultimately reach the prover
- The same secret key produces the same `accountId` across all unshielded contracts. Users who require unlinkability must manage separate keys per contract. This is an intentional design choice mirroring `msg.sender` semantics
- The `H(sk)` authentication mechanism is currently baked into each module rather than provided as a pluggable abstraction. When in-circuit EC signature verification becomes available in Compact, a more general authentication layer could decouple identity verification from authorization logic which would allow modules to accept identities proven by a hash preimage, ECDSA signature, or other mechanisms without modifying the authorization or business logic modules
- Signing-only HSMs that refuse to export any derived key material are incompatible with this scheme, as the secret key must reach the prover as raw bytes. KDF-capable HSMs and hardware wallets, however, can derive a purpose-specific key internally and export the derived value, keeping root key material inside the secure boundary. This follows the same pattern as BIP-32 HD key derivation used by existing wallet infrastructure

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added `computeAccountId` function for off-chain identity commitment derivation
- **Refactor**
  - Access control now uses secret-key-based identities instead of public-key-based identities
  - Updated role management to support the new identity model
- **Tests**
  - Expanded test coverage for the new identity mechanism and role operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->



