### PR TITLE
refactor(multisig): fix requested changes

### DIFF
--- a/contracts/src/multisig/ProposalManager.compact
+++ b/contracts/src/multisig/ProposalManager.compact
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Compact Contracts v0.0.1-alpha.1 (access/ProposalManager.compact)
+// OpenZeppelin Compact Contracts v0.0.1-alpha.1 (multisig/ProposalManager.compact)
 
 pragma language_version >= 0.21.0;
 

--- a/contracts/src/multisig/ProposalManager.compact
+++ b/contracts/src/multisig/ProposalManager.compact
@@ -45,8 +45,8 @@ module ProposalManager {
 
   // ─── State ──────────────────────────────────────────────────────
 
-  ledger _nextProposalId: Counter;
-  ledger _proposals: Map<Uint<64>, Proposal>;
+  export ledger _nextProposalId: Counter;
+  export ledger _proposals: Map<Uint<64>, Proposal>;
 
   // ─── Recipient Helpers ──────────────────────────────────────────
 
@@ -54,6 +54,7 @@ module ProposalManager {
    * @description Constructs a shielded user recipient.
    *
    * @param {ZswapCoinPublicKey} key - The shielded recipient's public key.
+   *
    * @returns {Recipient} The typed recipient.
    */
   export circuit shieldedUserRecipient(key: ZswapCoinPublicKey): Recipient {
@@ -64,6 +65,7 @@ module ProposalManager {
    * @description Constructs an unshielded user recipient.
    *
    * @param {UserAddress} addr - The unshielded recipient's address.
+   *
    * @returns {Recipient} The typed recipient.
    */
   export circuit unshieldedUserRecipient(addr: UserAddress): Recipient {
@@ -74,6 +76,7 @@ module ProposalManager {
    * @description Constructs a contract recipient.
    *
    * @param {ContractAddress} addr - The contract address.
+   *
    * @returns {Recipient} The typed recipient.
    */
   export circuit contractRecipient(addr: ContractAddress): Recipient {
@@ -89,6 +92,7 @@ module ProposalManager {
    * - Recipient kind must be ShieldedUser or Contract.
    *
    * @param {Recipient} r - The recipient.
+   *
    * @returns {Either<ZswapCoinPublicKey, ContractAddress>} The shielded recipient.
    */
   export circuit toShieldedRecipient(r: Recipient): Either<ZswapCoinPublicKey, ContractAddress> {
@@ -112,6 +116,7 @@ module ProposalManager {
    * - Recipient kind must be UnshieldedUser or Contract.
    *
    * @param {Recipient} r - The recipient.
+   *
    * @returns {Either<ContractAddress, UserAddress>} The unshielded recipient.
    */
   export circuit toUnshieldedRecipient(r: Recipient): Either<ContractAddress, UserAddress> {
@@ -136,6 +141,7 @@ module ProposalManager {
    * - Proposal with `id` must have been created.
    *
    * @param {Uint<64>} id - The proposal ID.
+   *
    * @returns {[]} Empty tuple.
    */
   export circuit assertProposalExists(id: Uint<64>): [] {
@@ -154,6 +160,7 @@ module ProposalManager {
    * - Proposal status must be Active.
    *
    * @param {Uint<64>} id - The proposal ID.
+   *
    * @returns {[]} Empty tuple.
    */
   export circuit assertProposalActive(id: Uint<64>): [] {
@@ -180,6 +187,7 @@ module ProposalManager {
    * @param {Recipient} to - The recipient (constructed via helper circuits).
    * @param {Bytes<32>} color - The token color.
    * @param {Uint<128>} amount - The amount to transfer.
+   *
    * @returns {Uint<64>} The new proposal ID.
    */
   export circuit _createProposal(
@@ -192,7 +200,7 @@ module ProposalManager {
     _nextProposalId.increment(1);
     const id = _nextProposalId;
 
-    _proposals.insert(disclose(id), disclose(Proposal {
+    _proposals.insert(id, disclose(Proposal {
       to: to,
       color: color,
       amount: amount,
@@ -214,18 +222,19 @@ module ProposalManager {
    * - Proposal must be active.
    *
    * @param {Uint<64>} id - The proposal ID.
+   *
    * @returns {[]} Empty tuple.
    */
   export circuit _cancelProposal(id: Uint<64>): [] {
     assertProposalActive(id);
 
     const proposal = _proposals.lookup(disclose(id));
-    _proposals.insert(disclose(id), disclose(Proposal {
+    _proposals.insert(disclose(id), Proposal {
       to: proposal.to,
       color: proposal.color,
       amount: proposal.amount,
       status: ProposalStatus.Cancelled
-    }));
+    });
   }
 
   /**
@@ -240,18 +249,19 @@ module ProposalManager {
    * - Proposal must be active.
    *
    * @param {Uint<64>} id - The proposal ID.
+   *
    * @returns {[]} Empty tuple.
    */
   export circuit _markExecuted(id: Uint<64>): [] {
     assertProposalActive(id);
 
     const proposal = _proposals.lookup(disclose(id));
-    _proposals.insert(disclose(id), disclose(Proposal {
+    _proposals.insert(disclose(id), Proposal {
       to: proposal.to,
       color: proposal.color,
       amount: proposal.amount,
       status: ProposalStatus.Executed
-    }));
+    });
   }
 
   // ─── View ───────────────────────────────────────────────────────
@@ -260,6 +270,7 @@ module ProposalManager {
    * @description Returns the full proposal data.
    *
    * @param {Uint<64>} id - The proposal ID.
+   *
    * @returns {Proposal} The proposal.
    */
   export circuit getProposal(id: Uint<64>): Proposal {
@@ -271,6 +282,7 @@ module ProposalManager {
    * @description Returns the recipient of a proposal.
    *
    * @param {Uint<64>} id - The proposal ID.
+   *
    * @returns {Recipient} The recipient.
    */
   export circuit getProposalRecipient(id: Uint<64>): Recipient {
@@ -282,6 +294,7 @@ module ProposalManager {
    * @description Returns the amount of a proposal.
    *
    * @param {Uint<64>} id - The proposal ID.
+   *
    * @returns {Uint<128>} The amount.
    */
   export circuit getProposalAmount(id: Uint<64>): Uint<128> {
@@ -293,6 +306,7 @@ module ProposalManager {
    * @description Returns the token color of a proposal.
    *
    * @param {Uint<64>} id - The proposal ID.
+   *
    * @returns {Bytes<32>} The token color.
    */
   export circuit getProposalColor(id: Uint<64>): Bytes<32> {
@@ -304,6 +318,7 @@ module ProposalManager {
    * @description Returns the status of a proposal.
    *
    * @param {Uint<64>} id - The proposal ID.
+   *
    * @returns {ProposalStatus} The proposal status.
    */
   export circuit getProposalStatus(id: Uint<64>): ProposalStatus {

--- a/contracts/src/multisig/ShieldedTreasury.compact
+++ b/contracts/src/multisig/ShieldedTreasury.compact
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Compact Contracts v0.0.1-alpha.1 (multisig/ShieldedTreasury.compact)
+
 pragma language_version >= 0.21.0;
 
 /**

--- a/contracts/src/multisig/ShieldedTreasury.compact
+++ b/contracts/src/multisig/ShieldedTreasury.compact
@@ -24,18 +24,13 @@ pragma language_version >= 0.21.0;
  */
 module ShieldedTreasury {
   import CompactStandardLibrary;
+  import { selfAsRecipient, UINT128_MAX } from "../utils/Utils" prefix Utils_;
 
   // ─── State ──────────────────────────────────────────────────────
 
-  ledger _coins: Map<Bytes<32>, QualifiedShieldedCoinInfo>;
-  ledger _shieldedReceived: Map<Bytes<32>, Uint<128>>;
-  ledger _shieldedSent: Map<Bytes<32>, Uint<128>>;
-
-  // ─── Constant ───────────────────────────────────────────────────
-
-  export circuit UINT128_MAX(): Uint<128> {
-    return 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF;
-  }
+  export ledger _coins: Map<Bytes<32>, QualifiedShieldedCoinInfo>;
+  export ledger _received: Map<Bytes<32>, Uint<128>>;
+  export ledger _sent: Map<Bytes<32>, Uint<128>>;
 
   // ─── Deposit ────────────────────────────────────────────────────
 
@@ -60,11 +55,12 @@ module ShieldedTreasury {
    * - Deposit must not cause received total overflow.
    *
    * @param {ShieldedCoinInfo} coin - The incoming shielded coin descriptor.
+   *
    * @returns {[]} Empty tuple.
    */
   export circuit _deposit(coin: ShieldedCoinInfo): [] {
     const currentReceived = getReceivedTotal(coin.color);
-    assert(currentReceived <= UINT128_MAX() - coin.value, "ShieldedTreasury: overflow");
+    assert(currentReceived <= Utils_UINT128_MAX() - coin.value, "ShieldedTreasury: overflow");
 
     receiveShielded(disclose(coin));
 
@@ -72,12 +68,12 @@ module ShieldedTreasury {
 
     if (_coins.member(coinColor)) {
       const merged = mergeCoinImmediate(_coins.lookup(coinColor), disclose(coin));
-      _coins.insertCoin(coinColor, disclose(merged), selfAsRecipient());
+      _coins.insertCoin(coinColor, merged, Utils_selfAsRecipient());
     } else {
-      _coins.insertCoin(coinColor, disclose(coin), selfAsRecipient());
+      _coins.insertCoin(coinColor, disclose(coin), Utils_selfAsRecipient());
     }
 
-    _shieldedReceived.insert(
+    _received.insert(
       coinColor,
       disclose(currentReceived + coin.value as Uint<128>)
     );
@@ -105,6 +101,7 @@ module ShieldedTreasury {
    * @param {Either<ZswapCoinPublicKey, ContractAddress>} recipient - The recipient.
    * @param {Bytes<32>} color - The token color.
    * @param {Uint<128>} amount - The amount to send.
+   *
    * @returns {ShieldedSendResult} The result containing sent coin and any change.
    */
   export circuit _send(
@@ -117,23 +114,24 @@ module ShieldedTreasury {
     const coin = _coins.lookup(disclose(color));
     assert(coin.value >= amount, "ShieldedTreasury: coin value insufficient");
 
-    const result = sendShielded(disclose(coin), disclose(recipient), disclose(amount));
+    const currentSent = getSentTotal(color);
+    assert(currentSent <= Utils_UINT128_MAX() - amount, "ShieldedTreasury: overflow");
+
+    const result = sendShielded(coin, disclose(recipient), disclose(amount));
 
     if (disclose(result.change.is_some)) {
+      const changeCoin = result.change.value;
       sendImmediateShielded(
-        disclose(result.change.value),
-        selfAsRecipient(),
-        disclose(result.change.value.value)
+        changeCoin,
+        Utils_selfAsRecipient(),
+        changeCoin.value
       );
-      _coins.insertCoin(disclose(color), result.change.value, selfAsRecipient());
+      _coins.insertCoin(disclose(color), changeCoin, Utils_selfAsRecipient());
     } else {
       _coins.remove(disclose(color));
     }
 
-    const currentSent = getSentTotal(color);
-    assert(currentSent <= UINT128_MAX() - amount, "ShieldedTreasury: overflow");
-
-    _shieldedSent.insert(
+    _sent.insert(
       disclose(color),
       disclose(currentSent + amount as Uint<128>)
     );
@@ -148,6 +146,7 @@ module ShieldedTreasury {
    * Reads the actual coin value from the UTXO map.
    *
    * @param {Bytes<32>} color - The token color.
+   *
    * @returns {Uint<128>} The current balance.
    */
   export circuit getTokenBalance(color: Bytes<32>): Uint<128> {
@@ -163,26 +162,28 @@ module ShieldedTreasury {
    * @description Returns the cumulative received total for a color.
    *
    * @param {Bytes<32>} color - The token color.
+   *
    * @returns {Uint<128>} Total received.
    */
   export circuit getReceivedTotal(color: Bytes<32>): Uint<128> {
-    if (!_shieldedReceived.member(disclose(color))) {
+    if (!_received.member(disclose(color))) {
       return 0;
     }
-    return _shieldedReceived.lookup(disclose(color));
+    return _received.lookup(disclose(color));
   }
 
   /**
    * @description Returns the cumulative sent total for a color.
    *
    * @param {Bytes<32>} color - The token color.
+   *
    * @returns {Uint<128>} Total sent.
    */
   export circuit getSentTotal(color: Bytes<32>): Uint<128> {
-    if (!_shieldedSent.member(disclose(color))) {
+    if (!_sent.member(disclose(color))) {
       return 0;
     }
-    return _shieldedSent.lookup(disclose(color));
+    return _sent.lookup(disclose(color));
   }
 
   /**
@@ -191,20 +192,10 @@ module ShieldedTreasury {
    * `getTokenBalance` if accounting is consistent.
    *
    * @param {Bytes<32>} color - The token color.
+   *
    * @returns {Uint<128>} Received minus sent.
    */
   export circuit getReceivedMinusSent(color: Bytes<32>): Uint<128> {
     return getReceivedTotal(color) - getSentTotal(color) as Uint<128>;
-  }
-
-  /**
-   * @description Returns the current contract's address as an
-   * `Either<ZswapCoinPublicKey, ContractAddress>` for use as a
-   * recipient in shielded send operations (deposits and receiving change).
-   *
-   * @returns {Either<ZswapCoinPublicKey, ContractAddress>} The contract's address as a recipient.
-   */
-  circuit selfAsRecipient(): Either<ZswapCoinPublicKey, ContractAddress> {
-    return right<ZswapCoinPublicKey, ContractAddress>(kernel.self());
   }
 }

--- a/contracts/src/multisig/ShieldedTreasuryStateless.compact
+++ b/contracts/src/multisig/ShieldedTreasuryStateless.compact
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Compact Contracts v0.0.1-alpha.1 (multisig/ShieldedTreasuryStateless.compact)
+
 pragma language_version >= 0.21.0;
 
 /**

--- a/contracts/src/multisig/ShieldedTreasuryStateless.compact
+++ b/contracts/src/multisig/ShieldedTreasuryStateless.compact
@@ -20,6 +20,7 @@ pragma language_version >= 0.21.0;
  */
 module ShieldedTreasuryStateless {
   import CompactStandardLibrary;
+  import { selfAsRecipient } from "../utils/Utils" prefix Utils_;
 
   // ─── Deposit ────────────────────────────────────────────────────
 
@@ -52,6 +53,7 @@ module ShieldedTreasuryStateless {
    * @param {Either<ZswapCoinPublicKey, ContractAddress>} recipient - The recipient.
    * @param {Bytes<32>} color - The token color.
    * @param {Uint<128>} amount - The amount to send.
+   *
    * @returns {ShieldedSendResult} The result containing sent coin and any change.
    */
   export circuit _send(
@@ -64,22 +66,11 @@ module ShieldedTreasuryStateless {
     if (disclose(result.change.is_some)) {
       sendImmediateShielded(
         disclose(result.change.value),
-        selfAsRecipient(),
+        Utils_selfAsRecipient(),
         disclose(result.change.value.value)
       );
     }
 
     return result;
-  }
-
-  /**
-   * @description Returns the current contract's address as an
-   * `Either<ZswapCoinPublicKey, ContractAddress>` for use as a
-   * recipient in shielded send operations (deposits and receiving change).
-   *
-   * @returns {Either<ZswapCoinPublicKey, ContractAddress>} The contract's address as a recipient.
-   */
-  circuit selfAsRecipient(): Either<ZswapCoinPublicKey, ContractAddress> {
-    return right<ZswapCoinPublicKey, ContractAddress>(kernel.self());
   }
 }

--- a/contracts/src/multisig/ShieldedTreasuryStateless.compact
+++ b/contracts/src/multisig/ShieldedTreasuryStateless.compact
@@ -34,11 +34,13 @@ module ShieldedTreasuryStateless {
   // ─── Send ───────────────────────────────────────────────────────
 
   /**
-   * @description Sends shielded tokens from the treasury.
+   * @description Sends shielded tokens using a caller-provided coin.
    *
-   * Looks up the stored coin by color, verifies sufficient value,
-   * and executes the shielded send. If the send produces change,
-   * it is sent back to the contract via `sendImmediateShielded`.
+   * The coin is supplied by the caller rather than looked up from
+   * on-chain state; the token color is derived from `coin.color`.
+   * Executes the shielded send and, if change is produced, returns it
+   * to the contract via `sendImmediateShielded`. No balance or
+   * received/sent accounting is tracked on the ledger.
    *
    * @notice Access control is NOT enforced here.
    * The consuming contract must gate this behind its own
@@ -46,12 +48,10 @@ module ShieldedTreasuryStateless {
    *
    * Requirements:
    *
-   * - A coin of the given `color` must exist in the treasury.
-   * - The coin's value must be >= `amount`.
-   * - Send must not cause sent total overflow.
+   * - `coin.value` must be >= `amount`.
    *
+   * @param {QualifiedShieldedCoinInfo} coin - The coin to spend (provided by the caller).
    * @param {Either<ZswapCoinPublicKey, ContractAddress>} recipient - The recipient.
-   * @param {Bytes<32>} color - The token color.
    * @param {Uint<128>} amount - The amount to send.
    *
    * @returns {ShieldedSendResult} The result containing sent coin and any change.

--- a/contracts/src/multisig/SignerManager.compact
+++ b/contracts/src/multisig/SignerManager.compact
@@ -30,9 +30,9 @@ module SignerManager<T> {
 
   // ─── State ──────────────────────────────────────────────────────────────────
 
-  ledger _signers: Map<T, Boolean>;
-  ledger _signerCount: Uint<8>;
-  ledger _threshold: Uint<8>;
+  export ledger _signers: Set<T>;
+  export ledger _signerCount: Uint<8>;
+  export ledger _threshold: Uint<8>;
 
   // ─── Initialization ─────────────────────────────────────────────────────────
 
@@ -48,6 +48,7 @@ module SignerManager<T> {
    *
    * @param {Vector<n, T>} signers - The initial signer set.
    * @param {Uint<8>} thresh - The minimum number of approvals required.
+   *
    * @returns {[]} Empty tuple.
    */
   export circuit initialize<#n>(
@@ -74,6 +75,7 @@ module SignerManager<T> {
    * - `caller` must be a member of the signers registry.
    *
    * @param {T} caller - The identity to validate.
+   *
    * @returns {[]} Empty tuple.
    */
   export circuit assertSigner(caller: T): [] {
@@ -88,6 +90,7 @@ module SignerManager<T> {
    * - `approvalCount` must be >= threshold.
    *
    * @param {Uint<8>} approvalCount - The current number of approvals.
+   *
    * @returns {[]} Empty tuple.
    */
   export circuit assertThresholdMet(approvalCount: Uint<8>): [] {
@@ -118,6 +121,7 @@ module SignerManager<T> {
    * @description Returns whether the given account is an active signer.
    *
    * @param {T} account - The account to check.
+   *
    * @returns {Boolean} True if the account is an active signer.
    */
   export circuit isSigner(account: T): Boolean {
@@ -138,6 +142,7 @@ module SignerManager<T> {
    * - `signer` must not already be an active signer.
    *
    * @param {T} signer - The signer to add.
+   *
    * @returns {[]} Empty tuple.
    */
   export circuit _addSigner(signer: T): [] {
@@ -146,7 +151,7 @@ module SignerManager<T> {
       "SignerManager: signer already active"
     );
 
-    _signers.insert(disclose(signer), true);
+    _signers.insert(disclose(signer));
     _signerCount = _signerCount + 1 as Uint<8>;
   }
 
@@ -163,6 +168,7 @@ module SignerManager<T> {
    * - Removal must not drop signer count below threshold.
    *
    * @param {T} signer - The signer to remove.
+   *
    * @returns {[]} Empty tuple.
    */
   export circuit _removeSigner(signer: T): [] {
@@ -188,6 +194,7 @@ module SignerManager<T> {
    * - `newThreshold` must not exceed the current signer count.
    *
    * @param {Uint<8>} newThreshold - The new minimum number of approvals required.
+   *
    * @returns {[]} Empty tuple.
    */
   export circuit _changeThreshold(newThreshold: Uint<8>): [] {

--- a/contracts/src/multisig/SignerManager.compact
+++ b/contracts/src/multisig/SignerManager.compact
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Compact Contracts v0.0.1-alpha.1 (multisig/SignerManager.compact)
+
 pragma language_version >= 0.21.0;
 
 /**

--- a/contracts/src/multisig/UnshieldedTreasury.compact
+++ b/contracts/src/multisig/UnshieldedTreasury.compact
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Compact Contracts v0.0.1-alpha.1 (multisig/UnshieldedTreasury.compact)
+
 pragma language_version >= 0.21.0;
 
 /**

--- a/contracts/src/multisig/UnshieldedTreasury.compact
+++ b/contracts/src/multisig/UnshieldedTreasury.compact
@@ -19,16 +19,11 @@ pragma language_version >= 0.21.0;
  */
 module UnshieldedTreasury {
   import CompactStandardLibrary;
+  import { UINT128_MAX } from "../utils/Utils" prefix Utils_;
 
   // ─── State ──────────────────────────────────────────────────────
 
-  ledger _balances: Map<Bytes<32>, Uint<128>>;
-
-  // ─── Constant ───────────────────────────────────────────────────
-
-  export circuit UINT128_MAX(): Uint<128> {
-    return 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF;
-  }
+  export ledger _balances: Map<Bytes<32>, Uint<128>>;
 
   // ─── Deposit ────────────────────────────────────────────────────
 
@@ -52,11 +47,12 @@ module UnshieldedTreasury {
    *
    * @param {Bytes<32>} color - The token type identifier.
    * @param {Uint<128>} amount - The amount to deposit.
+   *
    * @returns {[]} Empty tuple.
    */
   export circuit _deposit(color: Bytes<32>, amount: Uint<128>): [] {
     assert(
-      unshieldedBalanceLte(disclose(color), UINT128_MAX() - disclose(amount)),
+      unshieldedBalanceLte(disclose(color), Utils_UINT128_MAX() - disclose(amount)),
       "UnshieldedTreasury: overflow"
     );
 
@@ -82,6 +78,7 @@ module UnshieldedTreasury {
    * @param {Either<ContractAddress, UserAddress>} recipient - The recipient address.
    * @param {Bytes<32>} color - The token type identifier.
    * @param {Uint<128>} amount - The amount to send.
+   *
    * @returns {[]} Empty tuple.
    */
   export circuit _send(
@@ -105,6 +102,7 @@ module UnshieldedTreasury {
    * @description Returns the balance for a given token color.
    *
    * @param {Bytes<32>} color - The token type identifier.
+   *
    * @returns {Uint<128>} The current balance.
    */
   export circuit getTokenBalance(color: Bytes<32>): Uint<128> {

--- a/contracts/src/multisig/presets/ShieldedMultiSig.compact
+++ b/contracts/src/multisig/presets/ShieldedMultiSig.compact
@@ -3,6 +3,28 @@
 
 pragma language_version >= 0.21.0;
 
+/**
+ * @module ShieldedMultiSig
+ * @description A shielded multisig preset composing `SignerManager`,
+ * `ProposalManager`, and `ShieldedTreasury`. Signers approve proposals that
+ * transfer shielded tokens out of the treasury once the configured threshold
+ * is met.
+ *
+ * @notice Signer identity uses `Either<ZswapCoinPublicKey, ContractAddress>`
+ * in state for forward compatibility. In the current protocol, only
+ * `left(ZswapCoinPublicKey)` callers can authenticate — `getCaller()` resolves
+ * via `ownPublicKey()` and has no way to produce a right-variant today.
+ * Registering contract-address signers is permitted but those signers cannot
+ * exercise governance (create/approve/revoke) until contract-to-contract calls
+ * are supported. Choose your signer set accordingly.
+ *
+ * @notice The state shape is deliberately kept broad so that, once
+ * contract-to-contract calls are supported, `getCaller()` can be swapped via
+ * a CMA (Contract Maintenance Authorities) circuit upgrade without a state
+ * migration. Existing deployments would then gain working contract-signer
+ * authentication.
+ */
+
 import CompactStandardLibrary;
 
 import "../ProposalManager" prefix Proposal_;
@@ -115,6 +137,19 @@ circuit _revokeApproval(id: Uint<64>, signer: Either<ZswapCoinPublicKey, Contrac
   _approvalCount.insert(disclose(id), disclose(newCount));
 }
 
+/**
+ * @description Returns the caller identity used for signer authentication.
+ *
+ * @warning Currently resolves callers via `ownPublicKey()` only, so any signer
+ * registered as a `right(ContractAddress)` variant cannot authenticate through
+ * this circuit today. Ledger fields keep the `Either<ZswapCoinPublicKey, ContractAddress>`
+ * shape so that, once contract-to-contract calls are supported, `getCaller()`
+ * can be replaced via a CMA (Contract Maintenance Authorities) circuit upgrade
+ * to detect the contract-call context and return the appropriate variant —
+ * without a state migration.
+ *
+ * @returns {Either<ZswapCoinPublicKey, ContractAddress>} The caller wrapped as a left-variant.
+ */
 circuit getCaller(): Either<ZswapCoinPublicKey, ContractAddress> {
   return left<ZswapCoinPublicKey, ContractAddress>(ownPublicKey());
 }

--- a/contracts/src/multisig/presets/ShieldedMultiSig.compact
+++ b/contracts/src/multisig/presets/ShieldedMultiSig.compact
@@ -61,6 +61,12 @@ export circuit createShieldedProposal(
   const callerPK = getCaller();
   Signer_assertSigner(callerPK);
 
+  assert(
+    to.kind == Proposal_RecipientKind.ShieldedUser
+      || to.kind == Proposal_RecipientKind.Contract,
+    "ShieldedMultiSig: recipient must be a shielded user or contract"
+  );
+
   return Proposal__createProposal(to, color, amount);
 }
 

--- a/contracts/src/multisig/presets/ShieldedMultiSig.compact
+++ b/contracts/src/multisig/presets/ShieldedMultiSig.compact
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Compact Contracts v0.0.1-alpha.1 (multisig/presets/ShieldedMultiSig.compact)
+
 pragma language_version >= 0.21.0;
 
 import CompactStandardLibrary;

--- a/contracts/src/multisig/presets/ShieldedMultiSigV2.compact
+++ b/contracts/src/multisig/presets/ShieldedMultiSigV2.compact
@@ -71,7 +71,7 @@ ledger _instanceSalt: Bytes<32>;
  *
  * Requirements:
  *
- * - `thresh` must be > 0 and <= 3.
+ * - `thresh` must be > 0 and <= 2 (matches the 2-signature `execute` surface).
  * - `signerCommitments` must not contain duplicates.
  * - `instanceSalt` should be cryptographically random.
  *
@@ -84,6 +84,10 @@ constructor(
   signerCommitments: Vector<3, Bytes<32>>,
   thresh: Uint<8>,
 ) {
+  assert(
+    thresh <= 2,
+    "ShieldedMultiSigV2: threshold cannot exceed 2 (execute verifies at most 2 signatures)"
+  );
   _instanceSalt = disclose(instanceSalt);
   Signer_initialize<3>(signerCommitments, thresh);
 }

--- a/contracts/src/multisig/presets/ShieldedMultiSigV2.compact
+++ b/contracts/src/multisig/presets/ShieldedMultiSigV2.compact
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Compact Contracts v0.0.1-alpha.1 (multisig/presets/ShieldedMultiSigV2.compact)
+
 pragma language_version >= 0.21.0;
 
 /**

--- a/contracts/src/multisig/presets/ShieldedMultiSigV2.compact
+++ b/contracts/src/multisig/presets/ShieldedMultiSigV2.compact
@@ -33,7 +33,7 @@ import "../SignerManager"<Bytes<32>> prefix Signer_;
  * Threads the valid count, previous commitment (for duplicate
  * detection), and message hash through each iteration.
  */
-struct VerificationState {
+export struct VerificationState {
   validCount: Uint<8>,
   prevCommitment: Bytes<32>,
   msgHash: Bytes<32>
@@ -44,7 +44,7 @@ struct VerificationState {
  * Combines the ECDSA public key with an instance-specific salt and
  * domain separator to produce a unique, unlinkable commitment.
  */
-struct SignerCommitmentInput {
+export struct SignerCommitmentInput {
   pk: Bytes<64>,
   salt: Bytes<32>,
   domain: Bytes<32>

--- a/contracts/src/multisig/presets/ShieldedMultiSigV2.compact
+++ b/contracts/src/multisig/presets/ShieldedMultiSigV2.compact
@@ -142,6 +142,7 @@ export circuit deposit(coin: ShieldedCoinInfo): [] {
  * @param {QualifiedShieldedCoinInfo} coin - The coin to spend (from operator's pool).
  * @param {Vector<2, Bytes<64>>} pubkeys - ECDSA public keys of approving signers.
  * @param {Vector<2, Bytes<64>>} signatures - ECDSA signatures over the operation.
+ *
  * @returns {ShieldedSendResult} The send result including any change.
  */
 export circuit execute(
@@ -190,6 +191,7 @@ export circuit execute(
  * @param {VerificationState} state - Accumulator threaded through fold.
  * @param {Bytes<64>} pubkey - The signer's ECDSA public key.
  * @param {Bytes<64>} signature - The signer's signature over msgHash.
+ *
  * @returns {VerificationState} Updated accumulator.
  */
 circuit verifySignature(
@@ -229,6 +231,7 @@ circuit verifySignature(
  *
  * @param {Bytes<64>} pk - The ECDSA public key.
  * @param {Bytes<32>} salt - The instance salt.
+ *
  * @returns {Bytes<32>} The signer commitment.
  */
 export pure circuit _calculateSignerId(

--- a/contracts/src/multisig/test/ShieldedMultiSig.test.ts
+++ b/contracts/src/multisig/test/ShieldedMultiSig.test.ts
@@ -131,6 +131,34 @@ describe('ShieldedMultiSig', () => {
           multisig.as(SIGNER1).createShieldedProposal(to, COLOR, 0n);
         }).toThrow('ProposalManager: zero amount');
       });
+
+      it('should reject UnshieldedUser recipient kind', () => {
+        const to = {
+          kind: RecipientKind.UnshieldedUser,
+          address: Z_RECIPIENT_PK.bytes,
+        };
+        expect(() => {
+          multisig
+            .as(SIGNER1)
+            .createShieldedProposal(to, COLOR, PROPOSAL_AMOUNT);
+        }).toThrow(
+          'ShieldedMultiSig: recipient must be a shielded user or contract',
+        );
+      });
+
+      it('should accept Contract recipient kind', () => {
+        const to = {
+          kind: RecipientKind.Contract,
+          address: new Uint8Array(32).fill(7),
+        };
+        const id = multisig
+          .as(SIGNER1)
+          .createShieldedProposal(to, COLOR, PROPOSAL_AMOUNT);
+        expect(id).toEqual(1n);
+        expect(multisig.getProposalRecipient(id).kind).toEqual(
+          RecipientKind.Contract,
+        );
+      });
     });
 
     describe('approveProposal', () => {

--- a/contracts/src/multisig/test/ShieldedMultiSigV2.test.ts
+++ b/contracts/src/multisig/test/ShieldedMultiSigV2.test.ts
@@ -164,13 +164,7 @@ describe('ShieldedMultiSigV2', () => {
         const to = makeRecipient(new Uint8Array(32).fill(7));
         const coin = makeQualifiedCoin(COLOR, AMOUNT, 0n);
         expect(() => {
-          multisig.execute(
-            to,
-            100n,
-            coin,
-            [PK1, PK1],
-            [DUMMY_SIG, DUMMY_SIG],
-          );
+          multisig.execute(to, 100n, coin, [PK1, PK1], [DUMMY_SIG, DUMMY_SIG]);
         }).toThrow('Multisig: duplicate signer');
       });
 

--- a/contracts/src/multisig/test/ShieldedMultiSigV2.test.ts
+++ b/contracts/src/multisig/test/ShieldedMultiSigV2.test.ts
@@ -1,0 +1,192 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { ShieldedMultiSigV2Simulator } from './simulators/ShieldedMultiSigV2Simulator.js';
+
+const RecipientKind = { ShieldedUser: 0, UnshieldedUser: 1, Contract: 2 };
+
+const INSTANCE_SALT = new Uint8Array(32).fill(0xaa);
+const COLOR = new Uint8Array(32).fill(1);
+const AMOUNT = 1000n;
+
+const PK1 = new Uint8Array(64).fill(0x11);
+const PK2 = new Uint8Array(64).fill(0x22);
+const PK3 = new Uint8Array(64).fill(0x33);
+const NON_SIGNER_PK = new Uint8Array(64).fill(0x99);
+
+const COMMITMENT1 = ShieldedMultiSigV2Simulator.calculateSignerId(
+  PK1,
+  INSTANCE_SALT,
+);
+const COMMITMENT2 = ShieldedMultiSigV2Simulator.calculateSignerId(
+  PK2,
+  INSTANCE_SALT,
+);
+const COMMITMENT3 = ShieldedMultiSigV2Simulator.calculateSignerId(
+  PK3,
+  INSTANCE_SALT,
+);
+const SIGNER_COMMITMENTS = [COMMITMENT1, COMMITMENT2, COMMITMENT3];
+
+const DUMMY_SIG = new Uint8Array(64).fill(0xff);
+
+function makeRecipient(address: Uint8Array): {
+  kind: number;
+  address: Uint8Array;
+} {
+  return { kind: RecipientKind.ShieldedUser, address };
+}
+
+function makeCoin(
+  color: Uint8Array,
+  value: bigint,
+  nonce?: Uint8Array,
+): { nonce: Uint8Array; color: Uint8Array; value: bigint } {
+  return {
+    nonce: nonce ?? new Uint8Array(32).fill(0),
+    color,
+    value,
+  };
+}
+
+function makeQualifiedCoin(
+  color: Uint8Array,
+  value: bigint,
+  mtIndex: bigint,
+  nonce?: Uint8Array,
+): {
+  nonce: Uint8Array;
+  color: Uint8Array;
+  value: bigint;
+  mt_index: bigint;
+} {
+  return {
+    nonce: nonce ?? new Uint8Array(32).fill(0),
+    color,
+    value,
+    mt_index: mtIndex,
+  };
+}
+
+let multisig: ShieldedMultiSigV2Simulator;
+
+describe('ShieldedMultiSigV2', () => {
+  describe('constructor', () => {
+    it('should initialize with 2-of-3 threshold', () => {
+      multisig = new ShieldedMultiSigV2Simulator(
+        INSTANCE_SALT,
+        SIGNER_COMMITMENTS,
+        2n,
+      );
+      expect(multisig.getSignerCount()).toEqual(3n);
+      expect(multisig.getThreshold()).toEqual(2n);
+    });
+
+    it('should initialize with 1-of-3 threshold', () => {
+      multisig = new ShieldedMultiSigV2Simulator(
+        INSTANCE_SALT,
+        SIGNER_COMMITMENTS,
+        1n,
+      );
+      expect(multisig.getThreshold()).toEqual(1n);
+    });
+
+    it('should fail with zero threshold', () => {
+      expect(() => {
+        new ShieldedMultiSigV2Simulator(INSTANCE_SALT, SIGNER_COMMITMENTS, 0n);
+      }).toThrow('SignerManager: threshold must be > 0');
+    });
+
+    it('should fail with threshold greater than 2', () => {
+      expect(() => {
+        new ShieldedMultiSigV2Simulator(INSTANCE_SALT, SIGNER_COMMITMENTS, 3n);
+      }).toThrow(
+        'ShieldedMultiSigV2: threshold cannot exceed 2 (execute verifies at most 2 signatures)',
+      );
+    });
+
+    it('should register all signer commitments', () => {
+      multisig = new ShieldedMultiSigV2Simulator(
+        INSTANCE_SALT,
+        SIGNER_COMMITMENTS,
+        2n,
+      );
+      for (const commitment of SIGNER_COMMITMENTS) {
+        expect(multisig.isSigner(commitment)).toEqual(true);
+      }
+    });
+
+    it('should reject a non-signer commitment', () => {
+      multisig = new ShieldedMultiSigV2Simulator(
+        INSTANCE_SALT,
+        SIGNER_COMMITMENTS,
+        2n,
+      );
+      const unknown = ShieldedMultiSigV2Simulator.calculateSignerId(
+        NON_SIGNER_PK,
+        INSTANCE_SALT,
+      );
+      expect(multisig.isSigner(unknown)).toEqual(false);
+    });
+  });
+
+  describe('when initialized', () => {
+    beforeEach(() => {
+      multisig = new ShieldedMultiSigV2Simulator(
+        INSTANCE_SALT,
+        SIGNER_COMMITMENTS,
+        2n,
+      );
+    });
+
+    describe('view', () => {
+      it('getNonce should start at 0', () => {
+        expect(multisig.getNonce()).toEqual(0n);
+      });
+
+      it('getSignerCount should return 3', () => {
+        expect(multisig.getSignerCount()).toEqual(3n);
+      });
+
+      it('getThreshold should match constructor arg', () => {
+        expect(multisig.getThreshold()).toEqual(2n);
+      });
+    });
+
+    describe('deposit', () => {
+      it('should accept deposits without reverting', () => {
+        expect(() => {
+          multisig.deposit(makeCoin(COLOR, AMOUNT));
+        }).not.toThrow();
+      });
+    });
+
+    describe('execute', () => {
+      it('should reject duplicate signer', () => {
+        const to = makeRecipient(new Uint8Array(32).fill(7));
+        const coin = makeQualifiedCoin(COLOR, AMOUNT, 0n);
+        expect(() => {
+          multisig.execute(
+            to,
+            100n,
+            coin,
+            [PK1, PK1],
+            [DUMMY_SIG, DUMMY_SIG],
+          );
+        }).toThrow('Multisig: duplicate signer');
+      });
+
+      it('should reject a non-signer pubkey', () => {
+        const to = makeRecipient(new Uint8Array(32).fill(7));
+        const coin = makeQualifiedCoin(COLOR, AMOUNT, 0n);
+        expect(() => {
+          multisig.execute(
+            to,
+            100n,
+            coin,
+            [PK1, NON_SIGNER_PK],
+            [DUMMY_SIG, DUMMY_SIG],
+          );
+        }).toThrow('SignerManager: not a signer');
+      });
+    });
+  });
+});

--- a/contracts/src/multisig/test/ShieldedTreasury.test.ts
+++ b/contracts/src/multisig/test/ShieldedTreasury.test.ts
@@ -27,13 +27,6 @@ describe('ShieldedTreasury', () => {
     treasury = new ShieldedTreasurySimulator();
   });
 
-  describe('UINT128_MAX', () => {
-    it('should return max uint128 value', () => {
-      const max = ShieldedTreasurySimulator.UINT128_MAX();
-      expect(max).toEqual((1n << 128n) - 1n);
-    });
-  });
-
   describe('initial state', () => {
     it('should return 0 balance for unknown color', () => {
       expect(treasury.getTokenBalance(COLOR)).toEqual(0n);

--- a/contracts/src/multisig/test/SignerManager.test.ts
+++ b/contracts/src/multisig/test/SignerManager.test.ts
@@ -1,13 +1,16 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import * as utils from '#test-utils/address.js';
-import { SignerManagerSimulator } from './simulators/SignerManagerSimulator.js';
+import {
+  SignerManagerSimulator,
+  type SignerSet,
+} from './simulators/SignerManagerSimulator.js';
 
 const THRESHOLD = 2n;
 
 const [_SIGNER, Z_SIGNER] = utils.generateEitherPubKeyPair('SIGNER');
 const [_SIGNER2, Z_SIGNER2] = utils.generateEitherPubKeyPair('SIGNER2');
 const [_SIGNER3, Z_SIGNER3] = utils.generateEitherPubKeyPair('SIGNER3');
-const SIGNERS = [Z_SIGNER, Z_SIGNER2, Z_SIGNER3];
+const SIGNERS: SignerSet = [Z_SIGNER, Z_SIGNER2, Z_SIGNER3];
 const [_OTHER, Z_OTHER] = utils.generateEitherPubKeyPair('OTHER');
 const [_OTHER2, Z_OTHER2] = utils.generateEitherPubKeyPair('OTHER2');
 
@@ -22,7 +25,7 @@ describe('SigningManager', () => {
     });
 
     it('should fail with duplicate signers', () => {
-      const duplicateSigners = [Z_SIGNER, Z_SIGNER, Z_SIGNER2];
+      const duplicateSigners: SignerSet = [Z_SIGNER, Z_SIGNER, Z_SIGNER2];
       expect(() => {
         new SignerManagerSimulator(duplicateSigners, THRESHOLD);
       }).toThrow('SignerManager: signer already active');

--- a/contracts/src/multisig/test/mocks/MockShieldedTreasury.compact
+++ b/contracts/src/multisig/test/mocks/MockShieldedTreasury.compact
@@ -4,10 +4,6 @@ import CompactStandardLibrary;
 
 import "../../ShieldedTreasury" prefix Treasury_;
 
-export circuit UINT128_MAX(): Uint<128> {
-  return Treasury_UINT128_MAX();
-}
-
 export circuit _deposit(coin: ShieldedCoinInfo): [] {
   return Treasury__deposit(coin);
 }

--- a/contracts/src/multisig/test/mocks/MockUnshieldedTreasury.compact
+++ b/contracts/src/multisig/test/mocks/MockUnshieldedTreasury.compact
@@ -4,10 +4,6 @@ import CompactStandardLibrary;
 
 import "../../UnshieldedTreasury" prefix Treasury_;
 
-export circuit UINT128_MAX(): Uint<128> {
-  return Treasury_UINT128_MAX();
-}
-
 export circuit _deposit(color: Bytes<32>, amount: Uint<128>): [] {
   return Treasury__deposit(color, amount);
 }

--- a/contracts/src/multisig/test/simulators/ShieldedMultiSigV2Simulator.ts
+++ b/contracts/src/multisig/test/simulators/ShieldedMultiSigV2Simulator.ts
@@ -1,0 +1,104 @@
+import {
+  type BaseSimulatorOptions,
+  createSimulator,
+} from '@openzeppelin-compact/contracts-simulator';
+import {
+  type Ledger,
+  ledger,
+  pureCircuits,
+  Contract as ShieldedMultiSigV2,
+} from '../../../../artifacts/ShieldedMultiSigV2/contract/index.js';
+import {
+  ShieldedMultiSigV2PrivateState,
+  ShieldedMultiSigV2Witnesses,
+} from '../../witnesses/ShieldedMultiSigV2Witnesses.js';
+
+type Recipient = { kind: number; address: Uint8Array };
+type ShieldedCoinInfo = { nonce: Uint8Array; color: Uint8Array; value: bigint };
+type QualifiedShieldedCoinInfo = {
+  nonce: Uint8Array;
+  color: Uint8Array;
+  value: bigint;
+  mt_index: bigint;
+};
+type ShieldedSendResult = {
+  change: { is_some: boolean; value: ShieldedCoinInfo };
+  sent: ShieldedCoinInfo;
+};
+
+type ShieldedMultiSigV2Args = readonly [
+  instanceSalt: Uint8Array,
+  signerCommitments: Uint8Array[],
+  thresh: bigint,
+];
+
+const ShieldedMultiSigV2SimulatorBase = createSimulator<
+  ShieldedMultiSigV2PrivateState,
+  ReturnType<typeof ledger>,
+  ReturnType<typeof ShieldedMultiSigV2Witnesses>,
+  ShieldedMultiSigV2<ShieldedMultiSigV2PrivateState>,
+  ShieldedMultiSigV2Args
+>({
+  contractFactory: (witnesses) =>
+    new ShieldedMultiSigV2<ShieldedMultiSigV2PrivateState>(witnesses),
+  defaultPrivateState: () => ShieldedMultiSigV2PrivateState,
+  contractArgs: (instanceSalt, signerCommitments, thresh) => [
+    instanceSalt,
+    signerCommitments,
+    thresh,
+  ],
+  ledgerExtractor: (state) => ledger(state),
+  witnessesFactory: () => ShieldedMultiSigV2Witnesses(),
+});
+
+export class ShieldedMultiSigV2Simulator extends ShieldedMultiSigV2SimulatorBase {
+  constructor(
+    instanceSalt: Uint8Array,
+    signerCommitments: Uint8Array[],
+    thresh: bigint,
+    options: BaseSimulatorOptions<
+      ShieldedMultiSigV2PrivateState,
+      ReturnType<typeof ShieldedMultiSigV2Witnesses>
+    > = {},
+  ) {
+    super([instanceSalt, signerCommitments, thresh], options);
+  }
+
+  public static calculateSignerId(pk: Uint8Array, salt: Uint8Array): Uint8Array {
+    return pureCircuits._calculateSignerId(pk, salt);
+  }
+
+  public deposit(coin: ShieldedCoinInfo) {
+    return this.circuits.impure.deposit(coin);
+  }
+
+  public execute(
+    to: Recipient,
+    amount: bigint,
+    coin: QualifiedShieldedCoinInfo,
+    pubkeys: Uint8Array[],
+    signatures: Uint8Array[],
+  ): ShieldedSendResult {
+    return this.circuits.impure.execute(to, amount, coin, pubkeys, signatures);
+  }
+
+  public getNonce(): bigint {
+    return this.circuits.impure.getNonce();
+  }
+
+  public getSignerCount(): bigint {
+    return this.circuits.impure.getSignerCount();
+  }
+
+  public getThreshold(): bigint {
+    return this.circuits.impure.getThreshold();
+  }
+
+  public isSigner(commitment: Uint8Array): boolean {
+    return this.circuits.impure.isSigner(commitment);
+  }
+
+  public getLedger(): Ledger {
+    return this.getPublicState();
+  }
+}

--- a/contracts/src/multisig/test/simulators/ShieldedMultiSigV2Simulator.ts
+++ b/contracts/src/multisig/test/simulators/ShieldedMultiSigV2Simulator.ts
@@ -64,7 +64,10 @@ export class ShieldedMultiSigV2Simulator extends ShieldedMultiSigV2SimulatorBase
     super([instanceSalt, signerCommitments, thresh], options);
   }
 
-  public static calculateSignerId(pk: Uint8Array, salt: Uint8Array): Uint8Array {
+  public static calculateSignerId(
+    pk: Uint8Array,
+    salt: Uint8Array,
+  ): Uint8Array {
     return pureCircuits._calculateSignerId(pk, salt);
   }
 

--- a/contracts/src/multisig/test/simulators/ShieldedTreasurySimulator.ts
+++ b/contracts/src/multisig/test/simulators/ShieldedTreasurySimulator.ts
@@ -5,7 +5,6 @@ import {
 import {
   ledger,
   Contract as MockShieldedTreasury,
-  pureCircuits,
 } from '../../../../artifacts/MockShieldedTreasury/contract/index.js';
 import {
   ShieldedTreasuryPrivateState,
@@ -43,10 +42,6 @@ export class ShieldedTreasurySimulator extends ShieldedTreasurySimulatorBase {
     > = {},
   ) {
     super([], options);
-  }
-
-  public static UINT128_MAX(): bigint {
-    return pureCircuits.UINT128_MAX();
   }
 
   public _deposit(coin: ShieldedCoinInfo) {

--- a/contracts/src/multisig/test/simulators/SignerManagerSimulator.ts
+++ b/contracts/src/multisig/test/simulators/SignerManagerSimulator.ts
@@ -15,12 +15,20 @@ import {
 } from '../../witnesses/SignerManagerWitnesses.js';
 
 /**
+ * A fixed set of exactly three signers, matching the
+ * `Vector<3, Either<ZswapCoinPublicKey, ContractAddress>>` the underlying
+ * `MockSignerManager` constructor expects.
+ */
+export type SignerSet = readonly [
+  Either<ZswapCoinPublicKey, ContractAddress>,
+  Either<ZswapCoinPublicKey, ContractAddress>,
+  Either<ZswapCoinPublicKey, ContractAddress>,
+];
+
+/**
  * Type constructor args
  */
-type SignerManagerArgs = readonly [
-  signers: Either<ZswapCoinPublicKey, ContractAddress>[],
-  thresh: bigint,
-];
+type SignerManagerArgs = readonly [signers: SignerSet, thresh: bigint];
 
 const SignerManagerSimulatorBase = createSimulator<
   SignerManagerPrivateState,
@@ -42,7 +50,7 @@ const SignerManagerSimulatorBase = createSimulator<
  */
 export class SignerManagerSimulator extends SignerManagerSimulatorBase {
   constructor(
-    signers: Either<ZswapCoinPublicKey, ContractAddress>[],
+    signers: SignerSet,
     thresh: bigint,
     options: BaseSimulatorOptions<
       SignerManagerPrivateState,

--- a/contracts/src/multisig/witnesses/ProposalManagerWitnesses.ts
+++ b/contracts/src/multisig/witnesses/ProposalManagerWitnesses.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Compact Contracts v0.0.1-alpha.1 (multisig/witnesses/ProposalManagerWitness.ts)
+// OpenZeppelin Compact Contracts v0.0.1-alpha.1 (multisig/witnesses/ProposalManagerWitnesses.ts)
 
 export type ProposalManagerPrivateState = Record<string, never>;
 export const ProposalManagerPrivateState: ProposalManagerPrivateState = {};

--- a/contracts/src/multisig/witnesses/ShieldedMultiSigV2Witnesses.ts
+++ b/contracts/src/multisig/witnesses/ShieldedMultiSigV2Witnesses.ts
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Compact Contracts v0.0.1-alpha.1 (multisig/witnesses/ShieldedMultiSigV2Witnesses.ts)
+
+export type ShieldedMultiSigV2PrivateState = Record<string, never>;
+export const ShieldedMultiSigV2PrivateState: ShieldedMultiSigV2PrivateState = {};
+export const ShieldedMultiSigV2Witnesses = () => ({});

--- a/contracts/src/multisig/witnesses/ShieldedMultiSigV2Witnesses.ts
+++ b/contracts/src/multisig/witnesses/ShieldedMultiSigV2Witnesses.ts
@@ -2,5 +2,6 @@
 // OpenZeppelin Compact Contracts v0.0.1-alpha.1 (multisig/witnesses/ShieldedMultiSigV2Witnesses.ts)
 
 export type ShieldedMultiSigV2PrivateState = Record<string, never>;
-export const ShieldedMultiSigV2PrivateState: ShieldedMultiSigV2PrivateState = {};
+export const ShieldedMultiSigV2PrivateState: ShieldedMultiSigV2PrivateState =
+  {};
 export const ShieldedMultiSigV2Witnesses = () => ({});

--- a/contracts/src/multisig/witnesses/ShieldedTreasuryWitnesses.ts
+++ b/contracts/src/multisig/witnesses/ShieldedTreasuryWitnesses.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Compact Contracts v0.0.1-alpha.1 (multisig/witnesses/ShieldedTreasuryWitness.ts)
+// OpenZeppelin Compact Contracts v0.0.1-alpha.1 (multisig/witnesses/ShieldedTreasuryWitnesses.ts)
 
 export type ShieldedTreasuryPrivateState = Record<string, never>;
 export const ShieldedTreasuryPrivateState: ShieldedTreasuryPrivateState = {};

--- a/contracts/src/multisig/witnesses/SignerManagerWitnesses.ts
+++ b/contracts/src/multisig/witnesses/SignerManagerWitnesses.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Compact Contracts v0.0.1-alpha.1 (multisig/witnesses/SignerManagerWitness.ts)
+// OpenZeppelin Compact Contracts v0.0.1-alpha.1 (multisig/witnesses/SignerManagerWitnesses.ts)
 
 export type SignerManagerPrivateState = Record<string, never>;
 export const SignerManagerPrivateState: SignerManagerPrivateState = {};

--- a/contracts/src/multisig/witnesses/UnshieldedTreasuryWitnesses.ts
+++ b/contracts/src/multisig/witnesses/UnshieldedTreasuryWitnesses.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Compact Contracts v0.0.1-alpha.1 (multisig/witnesses/UnshieldedTreasuryWitness.ts)
+// OpenZeppelin Compact Contracts v0.0.1-alpha.1 (multisig/witnesses/UnshieldedTreasuryWitnesses.ts)
 
 export type UnshieldedTreasuryPrivateState = Record<string, never>;
 export const UnshieldedTreasuryPrivateState: UnshieldedTreasuryPrivateState =

--- a/contracts/src/utils/Utils.compact
+++ b/contracts/src/utils/Utils.compact
@@ -95,4 +95,26 @@ module Utils {
       ? Either<T1, T2>{ is_left: true, left: value.left, right: default<T2> }
       : Either<T1, T2>{ is_left: false, left: default<T1>, right: value.right };
   }
+
+  /**
+   * @description Returns the current contract's address as an
+   * `Either<ZswapCoinPublicKey, ContractAddress>` for use as a
+   * recipient in shielded send operations (deposits and receiving change).
+   *
+   * @returns {Either<ZswapCoinPublicKey, ContractAddress>} The contract's address as a recipient.
+   */
+  export circuit selfAsRecipient(): Either<ZswapCoinPublicKey, ContractAddress> {
+    return right<ZswapCoinPublicKey, ContractAddress>(kernel.self());
+  }
+
+  /**
+   * @description The maximum value representable by a `Uint<128>`.
+   *
+   * @notice TODO: Remove once a math module providing this constant is available.
+   *
+   * @returns {Uint<128>} `2^128 - 1`.
+   */
+  export pure circuit UINT128_MAX(): Uint<128> {
+    return 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF;
+  }
 }

--- a/contracts/src/utils/test/mocks/MockUtils.compact
+++ b/contracts/src/utils/test/mocks/MockUtils.compact
@@ -41,3 +41,11 @@ export pure circuit canonicalizeKeyOrAddress(
 ): Either<ZswapCoinPublicKey, ContractAddress> {
   return Utils_canonicalize<ZswapCoinPublicKey, ContractAddress>(keyOrAddress);
 }
+
+export circuit selfAsRecipient(): Either<ZswapCoinPublicKey, ContractAddress> {
+  return Utils_selfAsRecipient();
+}
+
+export pure circuit UINT128_MAX(): Uint<128> {
+  return Utils_UINT128_MAX();
+}

--- a/contracts/src/utils/test/simulators/UtilsSimulator.ts
+++ b/contracts/src/utils/test/simulators/UtilsSimulator.ts
@@ -111,4 +111,21 @@ export class UtilsSimulator extends UtilsSimulatorBase {
   ): Either<ZswapCoinPublicKey, ContractAddress> {
     return this.circuits.pure.canonicalizeKeyOrAddress(keyOrAddress);
   }
+
+  /**
+   * @description Returns the current contract's address wrapped as a
+   * right-variant `Either<ZswapCoinPublicKey, ContractAddress>`.
+   * @returns The contract's own address as a recipient.
+   */
+  public selfAsRecipient(): Either<ZswapCoinPublicKey, ContractAddress> {
+    return this.circuits.impure.selfAsRecipient();
+  }
+
+  /**
+   * @description The maximum value representable by a `Uint<128>`.
+   * @returns `2^128 - 1`.
+   */
+  public UINT128_MAX(): bigint {
+    return this.circuits.pure.UINT128_MAX();
+  }
 }

--- a/contracts/src/utils/test/utils.test.ts
+++ b/contracts/src/utils/test/utils.test.ts
@@ -145,4 +145,30 @@ describe('Utils', () => {
       expect(canonical).toEqual(contractUtils.ZERO_ADDRESS);
     });
   });
+
+  describe('selfAsRecipient', () => {
+    it('should return the contract address as a right-variant recipient', () => {
+      const result = contract.selfAsRecipient();
+      expect(result.is_left).toBe(false);
+      expect(contract.isContractAddress(result)).toBe(true);
+    });
+
+    it('should return a 32-byte contract address', () => {
+      const result = contract.selfAsRecipient();
+      expect(result.right.bytes).toBeInstanceOf(Uint8Array);
+      expect(result.right.bytes.length).toBe(32);
+    });
+
+    it('should return the same address on repeated calls', () => {
+      const first = contract.selfAsRecipient();
+      const second = contract.selfAsRecipient();
+      expect(first.right.bytes).toEqual(second.right.bytes);
+    });
+  });
+
+  describe('UINT128_MAX', () => {
+    it('should return 2^128 - 1', () => {
+      expect(contract.UINT128_MAX()).toBe((1n << 128n) - 1n);
+    });
+  });
 });

--- a/turbo.json
+++ b/turbo.json
@@ -32,7 +32,7 @@
     "compact:multisig": {
       "dependsOn": ["^build", "compact:security", "compact:utils"],
       "env": ["COMPACT_HOME", "SKIP_ZK"],
-      "inputs": ["src/access/**/*.compact"],
+      "inputs": ["src/multisig/**/*.compact"],
       "outputLogs": "new-only",
       "outputs": ["artifacts/**/"]
     },


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->

<!-- New features will be merged faster if they were first discussed and designed with the team. -->

## Types of changes

What types of changes does your code introduce to OpenZeppelin Midnight Contracts?
*Put an *``* in the boxes that apply*

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

Fixes #??? <!-- Fill in with issue number -->

### Contracts

- **ShieldedMultiSig preset**
  - Validated `createShieldedProposal` recipient kind — rejects `UnshieldedUser`, preventing permanently unexecutable proposals.
  - Added module `@notice`/`@warning` documenting that contract-address signers are unreachable until C2C auth lands, with CMA-based upgrade path.
- **ShieldedMultiSigV2 preset**
  - Constructor now asserts `thresh <= 2` to match the 2-signature `execute` surface.
  - Docstring threshold range corrected.
- **ShieldedTreasury**
  - Moved sent-total overflow check to fail-fast before `sendShielded` (mirrors `_deposit`).
  - Renamed `_shieldedReceived`/`_shieldedSent` → `_received`/`_sent`.
  - Exported ledger fields so devs can fetch state client-side for free.
- **ShieldedTreasuryStateless** — `_send` docstring synchronized with the real signature (coin, not color).
- **SignerManager** — `_signers` changed from `Map<T, Boolean>` to `Set<T>`.
- **ProposalManager** — ledger fields made `export`.

### Utils

- Moved `UINT128_MAX` and `selfAsRecipient` from both treasuries into `Utils.compact`; consumers now import via `Utils_` prefix.
- `UINT128_MAX` tagged with TODO to remove once a math module is available.



### Tests

- New **ShieldedMultiSigV2** test scaffolding: simulator + witnesses + 12 tests (threshold guard, signer registration, duplicate/non-signer rejection, deposit, views).
- Tightened `SignerManagerSimulator` signer type to an exported `SignerSet` readonly 3-tuple — compile-time enforcement of the `Vector<3>` contract invariant.
- New tests in `createShieldedProposal` for recipient-kind guard (reject `UnshieldedUser`, accept `Contract`).
- New tests in `utils.test.ts` for `selfAsRecipient` and `UINT128_MAX`.
- Removed redundant `UINT128_MAX` exposure from treasury mocks/simulators/tests (now covered in Utils).

### Docs / hygiene

- Added SPDX + OZ header banners across all `multisig/*.compact` files.
- Normalized JSDoc: blank line between last `@param` and `@returns` in all multisig contracts.
- Fixed witness-file header typos (`…Witness.ts` → `…Witnesses.ts`) in 4 files.
- `turbo.json` — `compact:multisig` inputs corrected from `src/access/**/*.compact` to `src/multisig/**/*.compact`.

## PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->

<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->

<!-- Some of the items may not apply. -->

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md#your-first-code-contribution)
- [ ] I have added tests that prove my fix is effective or that my feature works. See [GUIDELINES.md#testing](../GUIDELINES.md#testing) for more information.
- [ ] I have added documentation for new methods or changes to existing method behavior. See [GUIDELINES.md#documentation](../GUIDELINES.md#documentation) for more information.
- [ ] CI Workflows Are Passing

#### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
