### PR TITLE
NFT refactor -> replace pk with sk

### DIFF
--- a/contracts/src/token/NonFungibleToken.compact
+++ b/contracts/src/token/NonFungibleToken.compact
@@ -138,7 +138,7 @@ module NonFungibleToken {
 
   /**
    * @description Returns a canonical zero Either value (left variant with zero Bytes<32>).
-   * Used as the zero address for mint/burn operations and cleared approvals.
+   * Used as the zero value for mint/burn operations and cleared approvals.
    *
    * @return {Either<Bytes<32>, ContractAddress>} - The zero value.
    */
@@ -300,7 +300,7 @@ module NonFungibleToken {
    * @description Gives permission to `to` to transfer `tokenId` token to another account.
    * The approval is cleared when the token is transferred.
    *
-   * Only a single account can be approved at a time, so approving the zero address clears previous approvals.
+   * Only a single account can be approved at a time, so approving the zero value clears previous approvals.
    *
    * The caller's identity is derived from the `wit_NonFungibleTokenSK` witness as
    * `persistentHash(secretKey)`.
@@ -355,7 +355,7 @@ module NonFungibleToken {
    * Requirements:
    *
    * - The contract is initialized.
-   * - The `operator` cannot be the address zero.
+   * - The `operator` cannot be zero.
    *
    * @param {Either<Bytes<32>, ContractAddress>} operator - An operator to manage the caller's tokens
    * @param {Boolean} approved - A boolean determining if `operator` may manage all tokens of the caller
@@ -411,8 +411,8 @@ module NonFungibleToken {
    * Requirements:
    *
    * - The contract is initialized.
-   * - `fromAddress` is not the zero address.
-   * - `to` is not the zero address.
+   * - `fromAddress` is not zero.
+   * - `to` is not zero.
    * - `to` is not a ContractAddress.
    * - `tokenId` token must be owned by `fromAddress`.
    * - If the caller is not `fromAddress`, it must be approved to move this token by either {approve} or {setApprovalForAll}.
@@ -449,8 +449,8 @@ module NonFungibleToken {
    * Requirements:
    *
    * - The contract is initialized.
-   * - `fromAddress` is not the zero address.
-   * - `to` is not the zero address.
+   * - `fromAddress` is not zero.
+   * - `to` is not zero.
    * - `tokenId` token must be owned by `fromAddress`.
    * - If the caller is not `fromAddress`, it must be approved to move this token by either {approve} or {setApprovalForAll}.
    *
@@ -497,7 +497,7 @@ module NonFungibleToken {
   }
 
   /**
-   * @description Returns the approved address for `tokenId`. Returns the zero address if `tokenId` is not minted.
+   * @description Returns the approved address for `tokenId`. Returns the zero value if `tokenId` is not minted.
    *
    * @circuitInfo k=9, rows=308
    *
@@ -581,7 +581,7 @@ module NonFungibleToken {
 
   /**
    * @description Transfers `tokenId` from its current owner to `to`, or alternatively mints (or burns) if the current owner
-   * (or `to`) is the zero address. Returns the owner of the `tokenId` before the update.
+   * (or `to`) is zero. Returns the owner of the `tokenId` before the update.
    *
    * Requirements:
    *
@@ -639,7 +639,7 @@ module NonFungibleToken {
    *
    * - The contract is initialized.
    * - `tokenId` must not exist.
-   * - `to` is not the zero address.
+   * - `to` is not zero.
    * - `to` is not a ContractAddress.
    *
    * @param {Either<Bytes<32>, ContractAddress>} to - The account receiving `tokenId`
@@ -663,7 +663,7 @@ module NonFungibleToken {
    *
    * - The contract is initialized.
    * - `tokenId` must not exist.
-   * - `to` is not the zero address.
+   * - `to` is not zero.
    *
    * @warning Transfers to contract addresses are considered unsafe because contract-to-contract
    * calls are not currently supported. Tokens sent to a contract address may become irretrievable.
@@ -720,7 +720,7 @@ module NonFungibleToken {
    * Requirements:
    *
    * - The contract is initialized.
-   * - `to` is not the zero address.
+   * - `to` is not zero.
    * - `to` is not a ContractAddress.
    * - `tokenId` token must be owned by `fromAddress`.
    *
@@ -751,7 +751,7 @@ module NonFungibleToken {
    * Requirements:
    *
    * - The contract is initialized.
-   * - `to` is not the zero address.
+   * - `to` is not zero.
    * - `tokenId` token must be owned by `fromAddress`.
    *
    * @warning Transfers to contract addresses are considered unsafe because contract-to-contract

--- a/contracts/src/token/NonFungibleToken.compact
+++ b/contracts/src/token/NonFungibleToken.compact
@@ -7,6 +7,17 @@ pragma language_version >= 0.21.0;
  * @module NonFungibleToken
  * @description An unshielded Non-Fungible Token library.
  *
+ * Authorization is based on a witness-derived identity scheme. Each caller proves knowledge
+ * of a secret key by injecting it via the `wit_NonFungibleTokenSK` witness. The module computes
+ * an account identifier as `persistentHash(secretKey)` which is a commitment that hides the key
+ * while providing a stable, pseudonymous on-chain identity.
+ *
+ * Because the account identifier is `H(secretKey)` with no per-deployment salt or domain
+ * separator, the same secret key produces the same identity across all contracts. This is
+ * intentional. It provides a linkable pseudonymous identity analogous to Solidity's
+ * `msg.sender`. Users who desire cross-contract unlinkability can use different secret keys
+ * per contract at the wallet layer.
+ *
  * @notice One notable difference regarding this implementation and the EIP721 spec
  * consists of the token size. Uint<128> is used as the token size because Uint<256>
  * cannot be supported.
@@ -30,6 +41,25 @@ pragma language_version >= 0.21.0;
  * - Drop _unsafeTransfer and remove `isContract` guard from `transfer`.
  * - By this point, anyone using _unsafeTransfer should have migrated to the now C2C-capable `transfer`.
  *
+ * @dev Canonicalization
+ * All `Either<Bytes<32>, ContractAddress>` values are canonicalized before use as map keys
+ * or in ledger writes. Canonicalization zeroes out the inactive branch of the Either,
+ * ensuring that two values with the same active branch always resolve to the same map key
+ * regardless of what data the inactive branch carries. Write paths are canonicalized in
+ * `_update` (for `_owners` and `_balances`), `_approve` (for `_tokenApprovals`), and
+ * `_setApprovalForAll` (for `_operatorApprovals`). Read paths are canonicalized in
+ * `balanceOf`, `isApprovedForAll`, and `_isAuthorized`.
+ *
+ * @dev Security Considerations:
+ * - The `secretKey` must be kept private. Loss of the key prevents token holders
+ *   from proving ownership or authorization. Key exposure allows impersonation.
+ * - It is strongly recommended to use cryptographically secure random values for the secret key
+ *   (e.g., `crypto.getRandomValues()`). Weak or predictable keys can be brute-forced.
+ * - The `secretKey` is provided via the `wit_NonFungibleTokenSK` witness. As with all witnesses,
+ *   the contract must not assume that the witness implementation matches the developer's code.
+ *   Any DApp may provide any implementation. The ZK proof system constrains what values
+ *   can produce valid proofs.
+ *
  * @notice Missing Features and Improvements:
  *
  * - Uint256 token IDs
@@ -51,40 +81,40 @@ module NonFungibleToken {
   /**
    * @description Mapping from token IDs to their owner addresses.
    * @type {Uint<128>} tokenId - The unique identifier for a token.
-   * @type {Either<ZswapCoinPublicKey, ContractAddress>} owner - The owner address (public key or contract).
+   * @type {Either<Bytes<32>, ContractAddress>} owner - The owner address (account ID or contract).
    * @type {Map<tokenId, owner>}
-   * @type {Map<Uint<128>, Either<ZswapCoinPublicKey, ContractAddress>>} _owners
+   * @type {Map<Uint<128>, Either<Bytes<32>, ContractAddress>>} _owners
    */
-  export ledger _owners: Map<Uint<128>, Either<ZswapCoinPublicKey, ContractAddress>>;
+  export ledger _owners: Map<Uint<128>, Either<Bytes<32>, ContractAddress>>;
 
   /**
    * @description Mapping from account addresses to their token balances.
-   * @type {Either<ZswapCoinPublicKey, ContractAddress>} owner - The owner address.
+   * @type {Either<Bytes<32>, ContractAddress>} owner - The owner address.
    * @type {Uint<128>} balance - The balance of the owner.
    * @type {Map<owner, balance>}
-   * @type {Map<Either<ZswapCoinPublicKey, ContractAddress>, Uint<128>>} _balances
+   * @type {Map<Either<Bytes<32>, ContractAddress>, Uint<128>>} _balances
    */
-  export ledger _balances: Map<Either<ZswapCoinPublicKey, ContractAddress>, Uint<128>>;
+  export ledger _balances: Map<Either<Bytes<32>, ContractAddress>, Uint<128>>;
 
   /**
    * @description Mapping from token IDs to approved addresses.
    * @type {Uint<128>} tokenId - The unique identifier for a token.
-   * @type {Either<ZswapCoinPublicKey, ContractAddress>} approved - The approved address (public key or contract).
+   * @type {Either<Bytes<32>, ContractAddress>} approved - The approved address (account ID or contract).
    * @type {Map<tokenId, approved>}
-   * @type {Map<Uint<128>, Either<ZswapCoinPublicKey, ContractAddress>>} _tokenApprovals
+   * @type {Map<Uint<128>, Either<Bytes<32>, ContractAddress>>} _tokenApprovals
    */
-  export ledger _tokenApprovals: Map<Uint<128>, Either<ZswapCoinPublicKey, ContractAddress>>;
+  export ledger _tokenApprovals: Map<Uint<128>, Either<Bytes<32>, ContractAddress>>;
 
   /**
    * @description Mapping from owner addresses to operator approvals.
-   * @type {Either<ZswapCoinPublicKey, ContractAddress>} owner - The owner address.
-   * @type {Either<ZswapCoinPublicKey, ContractAddress>} operator - The operator address.
+   * @type {Either<Bytes<32>, ContractAddress>} owner - The owner address.
+   * @type {Either<Bytes<32>, ContractAddress>} operator - The operator address.
    * @type {Boolean} approved - Whether the operator is approved.
    * @type {Map<owner, Map<operator, approved>>}
-   * @type {Map<Either<ZswapCoinPublicKey, ContractAddress>, Map<Either<ZswapCoinPublicKey, ContractAddress>, Boolean>>} _operatorApprovals
+   * @type {Map<Either<Bytes<32>, ContractAddress>, Map<Either<Bytes<32>, ContractAddress>, Boolean>>} _operatorApprovals
    */
-  export ledger _operatorApprovals: Map<Either<ZswapCoinPublicKey, ContractAddress>,
-                                        Map<Either<ZswapCoinPublicKey, ContractAddress>, Boolean>>;
+  export ledger _operatorApprovals: Map<Either<Bytes<32>, ContractAddress>,
+                                        Map<Either<Bytes<32>, ContractAddress>, Boolean>>;
 
   /**
    * @description Mapping from token IDs to their metadata URIs.
@@ -94,6 +124,29 @@ module NonFungibleToken {
    * @type {Map<Uint<128>, Opaque<"string">>} _tokenURIs
    */
   export ledger _tokenURIs: Map<Uint<128>, Opaque<"string">>;
+
+  /**
+   * @witness wit_NonFungibleTokenSK
+   * @description Returns the caller's secret key used in deriving the account identifier.
+   *
+   * The same key produces the same account identifier across all contracts. Users who
+   * desire cross-contract unlinkability should use different keys per contract.
+   *
+   * @returns {Bytes<32>} secretKey - A 32-byte cryptographically secure random value.
+   */
+  witness wit_NonFungibleTokenSK(): Bytes<32>;
+
+  /**
+   * @description Returns a canonical zero Either value (left variant with zero Bytes<32>).
+   * Used as the zero address for mint/burn operations and cleared approvals.
+   *
+   * @return {Either<Bytes<32>, ContractAddress>} - The zero value.
+   */
+  export circuit ZERO(): Either<Bytes<32>, ContractAddress> {
+    return Either<Bytes<32>, ContractAddress> {
+      is_left: true, left: default<Bytes<32>>, right: default<ContractAddress>
+    };
+  }
 
   /**
    * @description Initializes the contract by setting the name and symbol.
@@ -120,28 +173,26 @@ module NonFungibleToken {
   /**
    * @description Returns the number of tokens in `owner`'s account.
    *
-   * @circuitInfo k=10, rows=309
-   *
    * Requirements:
    *
    * - The contract is initialized.
    *
-   * @param {Either<ZswapCoinPublicKey, ContractAddress>)} owner - The account to query.
+   * @param {Either<Bytes<32>, ContractAddress>} owner - The account to query.
    * @return {Uint<128>} - The number of tokens in `owner`'s account.
    */
-  export circuit balanceOf(owner: Either<ZswapCoinPublicKey, ContractAddress>): Uint<128> {
+  export circuit balanceOf(owner: Either<Bytes<32>, ContractAddress>): Uint<128> {
     Initializable_assertInitialized();
-    if (!_balances.member(disclose(owner))) {
+    const canonOwner = Utils_canonicalize<Bytes<32>, ContractAddress>(owner);
+
+    if (!_balances.member(disclose(canonOwner))) {
       return 0;
     }
 
-    return _balances.lookup(disclose(owner));
+    return _balances.lookup(disclose(canonOwner));
   }
 
   /**
    * @description Returns the owner of the `tokenId` token.
-   *
-   * @circuitInfo k=10, rows=290
    *
    * Requirements:
    *
@@ -149,17 +200,15 @@ module NonFungibleToken {
    * - The `tokenId` must exist.
    *
    * @param {Uint<128>} tokenId - The identifier for a token.
-   * @return {Either<ZswapCoinPublicKey, ContractAddress>} - The account that owns the token.
+   * @return {Either<Bytes<32>, ContractAddress>} - The account that owns the token.
    */
-  export circuit ownerOf(tokenId: Uint<128>): Either<ZswapCoinPublicKey, ContractAddress> {
+  export circuit ownerOf(tokenId: Uint<128>): Either<Bytes<32>, ContractAddress> {
     Initializable_assertInitialized();
     return _requireOwned(tokenId);
   }
 
   /**
    * @description Returns the token name.
-   *
-   * @circuitInfo k=10, rows=36
    *
    * Requirements:
    *
@@ -175,8 +224,6 @@ module NonFungibleToken {
   /**
    * @description Returns the symbol of the token.
    *
-   * @circuitInfo k=10, rows=36
-   *
    * Requirements:
    *
    * - The contract is initialized.
@@ -191,8 +238,6 @@ module NonFungibleToken {
   /**
    * @description Returns the token URI for the given `tokenId`. Returns the empty
    * string if a tokenURI does not exist.
-   *
-   * @circuitInfo k=10, rows=296
    *
    * Requirements:
    *
@@ -221,8 +266,6 @@ module NonFungibleToken {
   /**
    * @description Sets the URI as `tokenURI` for the given `tokenId`.
    *
-   * @circuitInfo k=10, rows=253
-   *
    * Requirements:
    *
    * - The contract is initialized.
@@ -247,7 +290,8 @@ module NonFungibleToken {
    *
    * Only a single account can be approved at a time, so approving the zero address clears previous approvals.
    *
-   * @circuitInfo k=10, rows=966
+   * The caller's identity is derived from the `wit_NonFungibleTokenSK` witness as
+   * `persistentHash(secretKey)`.
    *
    * Requirements:
    *
@@ -255,20 +299,18 @@ module NonFungibleToken {
    * - The caller must either own the token or be an approved operator.
    * - `tokenId` must exist.
    *
-   * @param {Either<ZswapCoinPublicKey, ContractAddress>} to - The account receiving the approval
+   * @param {Either<Bytes<32>, ContractAddress>} to - The account receiving the approval
    * @param {Uint<128>} tokenId - The token `to` may be permitted to transfer
    * @return {[]} - Empty tuple.
    */
-  export circuit approve(to: Either<ZswapCoinPublicKey, ContractAddress>, tokenId: Uint<128>): [] {
+  export circuit approve(to: Either<Bytes<32>, ContractAddress>, tokenId: Uint<128>): [] {
     Initializable_assertInitialized();
-    const auth = left<ZswapCoinPublicKey, ContractAddress>(ownPublicKey());
+    const auth = left<Bytes<32>, ContractAddress>(_computeAccountId());
     _approve(to, tokenId, auth);
   }
 
   /**
    * @description Returns the account approved for `tokenId` token.
-   *
-   * @circuitInfo k=10, rows=409
    *
    * Requirements:
    *
@@ -276,9 +318,9 @@ module NonFungibleToken {
    * - `tokenId` must exist.
    *
    * @param {Uint<128>} tokenId - The token an account may be approved to manage
-   * @return {Either<ZswapCoinPublicKey, ContractAddress>} Operator- The account approved to manage the token
+   * @return {Either<Bytes<32>, ContractAddress>} - The account approved to manage the token
    */
-  export circuit getApproved(tokenId: Uint<128>): Either<ZswapCoinPublicKey, ContractAddress> {
+  export circuit getApproved(tokenId: Uint<128>): Either<Bytes<32>, ContractAddress> {
     Initializable_assertInitialized();
     _requireOwned(tokenId);
 
@@ -289,47 +331,49 @@ module NonFungibleToken {
    * @description Approve or remove `operator` as an operator for the caller.
    * Operators can call {transferFrom} for any token owned by the caller.
    *
-   * @circuitInfo k=10, rows=409
+   * The caller's identity is derived from the `wit_NonFungibleTokenSK` witness as
+   * `persistentHash(secretKey)`.
    *
    * Requirements:
    *
    * - The contract is initialized.
    * - The `operator` cannot be the address zero.
    *
-   * @param {Either<ZswapCoinPublicKey, ContractAddress>} operator - An operator to manage the caller's tokens
+   * @param {Either<Bytes<32>, ContractAddress>} operator - An operator to manage the caller's tokens
    * @param {Boolean} approved - A boolean determining if `operator` may manage all tokens of the caller
    * @return {[]} - Empty tuple.
    */
   export circuit setApprovalForAll(
-                   operator: Either<ZswapCoinPublicKey, ContractAddress>,
+                   operator: Either<Bytes<32>, ContractAddress>,
                    approved: Boolean
                    ): [] {
     Initializable_assertInitialized();
-    const owner = left<ZswapCoinPublicKey, ContractAddress>(ownPublicKey());
+    const owner = left<Bytes<32>, ContractAddress>(_computeAccountId());
     _setApprovalForAll(owner, operator, approved);
   }
 
   /**
    * @description Returns if the `operator` is allowed to manage all of the assets of `owner`.
    *
-   * @circuitInfo k=10, rows=621
-   *
    * Requirements:
    *
    * - The contract is initialized.
    *
-   * @param {Either<ZswapCoinPublicKey, ContractAddress>} owner - The owner of a token
-   * @param {Either<ZswapCoinPublicKey, ContractAddress>} operator - An account that may operate on `owner`'s tokens
-   * @return {Boolean} - A boolean determining if `operator` is allowed to manage all of the tokens of `owner` 
+   * @param {Either<Bytes<32>, ContractAddress>} owner - The owner of a token
+   * @param {Either<Bytes<32>, ContractAddress>} operator - An account that may operate on `owner`'s tokens
+   * @return {Boolean} - A boolean determining if `operator` is allowed to manage all of the tokens of `owner`
    */
   export circuit isApprovedForAll(
-                   owner: Either<ZswapCoinPublicKey, ContractAddress>,
-                   operator: Either<ZswapCoinPublicKey, ContractAddress>
+                   owner: Either<Bytes<32>, ContractAddress>,
+                   operator: Either<Bytes<32>, ContractAddress>
                    ): Boolean {
     Initializable_assertInitialized();
-    return _operatorApprovals.member(disclose(owner)) &&
-           _operatorApprovals.lookup(owner).member(disclose(operator)) &&
-           _operatorApprovals.lookup(owner).lookup(disclose(operator));
+    const canonOwner = Utils_canonicalize<Bytes<32>, ContractAddress>(owner);
+    const canonOp = Utils_canonicalize<Bytes<32>, ContractAddress>(operator);
+
+    return _operatorApprovals.member(disclose(canonOwner)) &&
+           _operatorApprovals.lookup(canonOwner).member(disclose(canonOp)) &&
+           _operatorApprovals.lookup(canonOwner).lookup(disclose(canonOp));
   }
 
   /**
@@ -339,7 +383,8 @@ module NonFungibleToken {
    * are supported in Compact. This restriction prevents assets from being inadvertently locked in contracts that cannot
    * currently handle token receipt.
    *
-   * @circuitInfo k=11, rows=1966
+   * The caller's identity is derived from the `wit_NonFungibleTokenSK` witness as
+   * `persistentHash(secretKey)`.
    *
    * Requirements:
    *
@@ -350,18 +395,19 @@ module NonFungibleToken {
    * - `tokenId` token must be owned by `fromAddress`.
    * - If the caller is not `fromAddress`, it must be approved to move this token by either {approve} or {setApprovalForAll}.
    *
-   * @param {Either<ZswapCoinPublicKey, ContractAddress>} fromAddress - The source account from which the token is being transfered
-   * @param {Either<ZswapCoinPublicKey, ContractAddress>} to - The target account to transfer token to
-   * @param {Uint<128>} tokenId - The token being transfered
+   * @param {Either<Bytes<32>, ContractAddress>} fromAddress - The source account from which the token is being transferred
+   * @param {Either<Bytes<32>, ContractAddress>} to - The target account to transfer token to
+   * @param {Uint<128>} tokenId - The token being transferred
    * @return {[]} - Empty tuple.
    */
   export circuit transferFrom(
-                   fromAddress: Either<ZswapCoinPublicKey, ContractAddress>,
-                   to: Either<ZswapCoinPublicKey, ContractAddress>,
+                   fromAddress: Either<Bytes<32>, ContractAddress>,
+                   to: Either<Bytes<32>, ContractAddress>,
                    tokenId: Uint<128>
                    ): [] {
     Initializable_assertInitialized();
-    assert(!Utils_isContractAddress(to), "NonFungibleToken: Unsafe Transfer");
+    const isContractAddr = !to.is_left;
+    assert(!isContractAddr, "NonFungibleToken: unsafe transfer");
 
     _unsafeTransferFrom(fromAddress, to, tokenId);
   }
@@ -369,11 +415,12 @@ module NonFungibleToken {
   /**
    * @description Transfers `tokenId` token from `fromAddress` to `to`. It does NOT check if the recipient is a ContractAddress.
    *
-   * WARNING: Transfers to contract addresses are considered unsafe because contract-to-contract calls
+   * The caller's identity is derived from the `wit_NonFungibleTokenSK` witness as
+   * `persistentHash(secretKey)`.
+   *
+   * @warning Transfers to contract addresses are considered unsafe because contract-to-contract calls
    * are not currently supported. Tokens sent to a contract address may become irretrievable.
    * Once contract-to-contract calls are supported, this circuit may be deprecated.
-   *
-   * @circuitInfo k=11, rows=1963
    *
    * Requirements:
    *
@@ -383,41 +430,41 @@ module NonFungibleToken {
    * - `tokenId` token must be owned by `fromAddress`.
    * - If the caller is not `fromAddress`, it must be approved to move this token by either {approve} or {setApprovalForAll}.
    *
-   * @param {Either<ZswapCoinPublicKey, ContractAddress>} fromAddress - The source account from which the token is being transfered
-   * @param {Either<ZswapCoinPublicKey, ContractAddress>} to - The target account to transfer token to
-   * @param {Uint<128>} tokenId - The token being transfered
+   * @param {Either<Bytes<32>, ContractAddress>} fromAddress - The source account from which the token is being transferred
+   * @param {Either<Bytes<32>, ContractAddress>} to - The target account to transfer token to
+   * @param {Uint<128>} tokenId - The token being transferred
    * @return {[]} - Empty tuple.
    */
   export circuit _unsafeTransferFrom(
-                   fromAddress: Either<ZswapCoinPublicKey, ContractAddress>,
-                   to: Either<ZswapCoinPublicKey, ContractAddress>,
+                   fromAddress: Either<Bytes<32>, ContractAddress>,
+                   to: Either<Bytes<32>, ContractAddress>,
                    tokenId: Uint<128>
                    ): [] {
     Initializable_assertInitialized();
-    assert(!Utils_isKeyOrAddressZero(to), "NonFungibleToken: Invalid Receiver");
-    // Setting an "auth" arguments enables the `_isAuthorized` check which verifies that the token exists
+    assert(!_isTargetZero(to), "NonFungibleToken: invalid receiver");
+    // Setting an "auth" argument enables the `_isAuthorized` check which verifies that the token exists
     // (fromAddress != 0). Therefore, it is not needed to verify that the return value is not 0 here.
-    const auth = left<ZswapCoinPublicKey, ContractAddress>(ownPublicKey());
+    const auth = left<Bytes<32>, ContractAddress>(_computeAccountId());
     const previousOwner = _update(to, tokenId, auth);
-    assert(previousOwner == fromAddress, "NonFungibleToken: Incorrect Owner");
+
+    const canonFrom = Utils_canonicalize<Bytes<32>, ContractAddress>(fromAddress);
+    assert(previousOwner == canonFrom, "NonFungibleToken: incorrect owner");
   }
 
   /**
-   * @description Returns the owner of the `tokenId`. Does NOT revert if token doesn't exist
-   *
-   * @circuitInfo k=10, rows=253
+   * @description Returns the owner of the `tokenId`. Does NOT revert if token doesn't exist.
    *
    * Requirements:
    *
    * - The contract is initialized.
    *
    * @param {Uint<128>} tokenId - The target token of the owner query
-   * @return {Either<ZswapCoinPublicKey, ContractAddress>} - The owner of the token
+   * @return {Either<Bytes<32>, ContractAddress>} - The owner of the token
    */
-  export circuit _ownerOf(tokenId: Uint<128>): Either<ZswapCoinPublicKey, ContractAddress> {
+  export circuit _ownerOf(tokenId: Uint<128>): Either<Bytes<32>, ContractAddress> {
     Initializable_assertInitialized();
     if (!_owners.member(disclose(tokenId))) {
-      return shieldedBurnAddress();
+      return ZERO();
     }
 
     return _owners.lookup(disclose(tokenId));
@@ -426,19 +473,17 @@ module NonFungibleToken {
   /**
    * @description Returns the approved address for `tokenId`. Returns the zero address if `tokenId` is not minted.
    *
-   * @circuitInfo k=10, rows=253
-   *
    * Requirements:
    *
    * - The contract is initialized.
    *
    * @param {Uint<128>} tokenId - The token to query
-   * @return {Either<ZswapCoinPublicKey, ContractAddress>} - An account approved to spend `tokenId`
+   * @return {Either<Bytes<32>, ContractAddress>} - An account approved to spend `tokenId`
    */
-  export circuit _getApproved(tokenId: Uint<128>): Either<ZswapCoinPublicKey, ContractAddress> {
+  export circuit _getApproved(tokenId: Uint<128>): Either<Bytes<32>, ContractAddress> {
     Initializable_assertInitialized();
     if (!_tokenApprovals.member(disclose(tokenId))) {
-      return shieldedBurnAddress();
+      return ZERO();
     }
     return _tokenApprovals.lookup(disclose(tokenId));
   }
@@ -447,59 +492,58 @@ module NonFungibleToken {
    * @description Returns whether `spender` is allowed to manage `owner`'s tokens, or `tokenId` in
    * particular (ignoring whether it is owned by `owner`).
    *
-   * @circuitInfo k=11, rows=1098
-   *
    * Requirements:
    *
    * - The contract is initialized.
    *
-   * WARNING: This function assumes that `owner` is the actual owner of `tokenId` and does not verify this
+   * @warning This function assumes that `owner` is the actual owner of `tokenId` and does not verify this
    * assumption.
    *
-   * @param {Either<ZswapCoinPublicKey, ContractAddress>} owner - Owner of the token
-   * @param {Either<ZswapCoinPublicKey, ContractAddress>} spender - Account that wishes to spend `tokenId`
+   * @param {Either<Bytes<32>, ContractAddress>} owner - Owner of the token
+   * @param {Either<Bytes<32>, ContractAddress>} spender - Account that wishes to spend `tokenId`
    * @param {Uint<128>} tokenId - Token to spend
    * @return {Boolean} - A boolean determining if `spender` may manage `tokenId`
    */
   export circuit _isAuthorized(
-                   owner: Either<ZswapCoinPublicKey, ContractAddress>,
-                   spender: Either<ZswapCoinPublicKey, ContractAddress>,
+                   owner: Either<Bytes<32>, ContractAddress>,
+                   spender: Either<Bytes<32>, ContractAddress>,
                    tokenId: Uint<128>
                    ): Boolean {
     Initializable_assertInitialized();
-    return (!Utils_isKeyOrAddressZero(disclose(spender)) &&
-            (disclose(owner) == disclose(spender) ||
-             isApprovedForAll(owner, spender) ||
-             _getApproved(tokenId) == disclose(spender)));
+    const canonOwner = Utils_canonicalize<Bytes<32>, ContractAddress>(owner);
+    const canonSpender = Utils_canonicalize<Bytes<32>, ContractAddress>(spender);
+
+    return (!_isTargetZero(disclose(canonSpender)) &&
+            (disclose(canonOwner) == disclose(canonSpender) ||
+             isApprovedForAll(canonOwner, canonSpender) ||
+             _getApproved(tokenId) == disclose(canonSpender)));
   }
 
   /**
    * @description Checks if `spender` can operate on `tokenId`, assuming the provided `owner` is the actual owner.
-   *
-   * @circuitInfo k=11, rows=1121
    *
    * Requirements:
    *
    * - The contract is initialized.
    * - `spender` has approval from `owner` for `tokenId` OR `spender` has approval to manage all of `owner`'s assets.
    *
-   * WARNING: This function assumes that `owner` is the actual owner of `tokenId` and does not verify this
+   * @warning This function assumes that `owner` is the actual owner of `tokenId` and does not verify this
    * assumption.
    *
-   * @param {Either<ZswapCoinPublicKey, ContractAddress>} owner - Owner of the token
-   * @param {Either<ZswapCoinPublicKey, ContractAddress>} spender - Account operating on `tokenId`
+   * @param {Either<Bytes<32>, ContractAddress>} owner - Owner of the token
+   * @param {Either<Bytes<32>, ContractAddress>} spender - Account operating on `tokenId`
    * @param {Uint<128>} tokenId - The token to spend
    * @return {[]} - Empty tuple.
    */
   export circuit _checkAuthorized(
-                   owner: Either<ZswapCoinPublicKey, ContractAddress>,
-                   spender: Either<ZswapCoinPublicKey, ContractAddress>,
+                   owner: Either<Bytes<32>, ContractAddress>,
+                   spender: Either<Bytes<32>, ContractAddress>,
                    tokenId: Uint<128>
                    ): [] {
     Initializable_assertInitialized();
     if (!_isAuthorized(owner, spender, tokenId)) {
-      assert(!Utils_isKeyOrAddressZero(owner), "NonFungibleToken: Nonexistent Token");
-      assert(false, "NonFungibleToken: Insufficient Approval");
+      assert(!_isTargetZero(owner), "NonFungibleToken: nonexistent token");
+      assert(false, "NonFungibleToken: insufficient approval");
     }
   }
 
@@ -507,56 +551,55 @@ module NonFungibleToken {
    * @description Transfers `tokenId` from its current owner to `to`, or alternatively mints (or burns) if the current owner
    * (or `to`) is the zero address. Returns the owner of the `tokenId` before the update.
    *
-   * @circuitInfo k=11, rows=1959
-   *
    * Requirements:
    *
    * - The contract is initialized.
    * - If `auth` is non 0, then this function will check that `auth` is either the owner of the token,
    * or approved to operate on the token (by the owner).
    *
-   * @param {Either<ZswapCoinPublicKey, ContractAddress>} to - The intended recipient of the token transfer
-   * @param {Uint<128>} tokenId - The token being transfered
-   * @param {Either<ZswapCoinPublicKey, ContractAddress>} auth - An account authorized to transfer the token
-   * @return {Either<ZswapCoinPublicKey, ContractAddress>} - Owner of the token before it was transfered
+   * @param {Either<Bytes<32>, ContractAddress>} to - The intended recipient of the token transfer
+   * @param {Uint<128>} tokenId - The token being transferred
+   * @param {Either<Bytes<32>, ContractAddress>} auth - An account authorized to transfer the token
+   * @return {Either<Bytes<32>, ContractAddress>} - Owner of the token before it was transferred
    */
-  circuit _update(to: Either<ZswapCoinPublicKey, ContractAddress>,
+  circuit _update(to: Either<Bytes<32>, ContractAddress>,
                   tokenId: Uint<128>,
-                  auth: Either<ZswapCoinPublicKey, ContractAddress>
-                  ): Either<ZswapCoinPublicKey, ContractAddress> {
+                  auth: Either<Bytes<32>, ContractAddress>
+                  ): Either<Bytes<32>, ContractAddress> {
     Initializable_assertInitialized();
+    const canonTo = Utils_canonicalize<Bytes<32>, ContractAddress>(to);
+    const canonAuth = Utils_canonicalize<Bytes<32>, ContractAddress>(auth);
     const fromAddress = _ownerOf(tokenId);
 
     // Perform (optional) operator check
-    if (!Utils_isKeyOrAddressZero(disclose(auth))) {
-      _checkAuthorized(fromAddress, auth, tokenId);
+    if (!_isTargetZero(disclose(canonAuth))) {
+      _checkAuthorized(fromAddress, canonAuth, tokenId);
     }
 
     // Execute the update
-    if (!Utils_isKeyOrAddressZero(disclose(fromAddress))) {
+    if (!_isTargetZero(disclose(fromAddress))) {
       // Clear approval. No need to re-authorize
-      _approve(shieldedBurnAddress(), tokenId, shieldedBurnAddress());
-      const newBalance = _balances.lookup(disclose(fromAddress)) - 1 as Uint<128>;
-      _balances.insert(disclose(fromAddress), disclose(newBalance));
+      _approve(ZERO(), tokenId, ZERO());
+      const canonFrom = Utils_canonicalize<Bytes<32>, ContractAddress>(fromAddress);
+      const newBalance = _balances.lookup(disclose(canonFrom)) - 1 as Uint<128>;
+      _balances.insert(disclose(canonFrom), disclose(newBalance));
     }
 
-    if (!Utils_isKeyOrAddressZero(disclose(to))) {
-      if (!_balances.member(disclose(to))) {
-        _balances.insert(disclose(to), 0);
+    if (!_isTargetZero(disclose(canonTo))) {
+      if (!_balances.member(disclose(canonTo))) {
+        _balances.insert(disclose(canonTo), 0);
       }
-      const newBalance = _balances.lookup(disclose(to)) + 1 as Uint<128>;
-      _balances.insert(disclose(to), disclose(newBalance));
+      const newBalance = _balances.lookup(disclose(canonTo)) + 1 as Uint<128>;
+      _balances.insert(disclose(canonTo), disclose(newBalance));
     }
 
-    _owners.insert(disclose(tokenId), disclose(to));
+    _owners.insert(disclose(tokenId), disclose(canonTo));
 
     return fromAddress;
   }
 
   /**
    * @description Mints `tokenId` and transfers it to `to`.
-   *
-   * @circuitInfo k=11, rows=1013
    *
    * Requirements:
    *
@@ -565,13 +608,14 @@ module NonFungibleToken {
    * - `to` is not the zero address.
    * - `to` is not a ContractAddress.
    *
-   * @param {Either<ZswapCoinPublicKey, ContractAddress>} to - The account receiving `tokenId`
+   * @param {Either<Bytes<32>, ContractAddress>} to - The account receiving `tokenId`
    * @param {Uint<128>} tokenId - The token to transfer
    * @return {[]} - Empty tuple.
    */
-  export circuit _mint(to: Either<ZswapCoinPublicKey, ContractAddress>, tokenId: Uint<128>): [] {
+  export circuit _mint(to: Either<Bytes<32>, ContractAddress>, tokenId: Uint<128>): [] {
     Initializable_assertInitialized();
-    assert(!Utils_isContractAddress(to), "NonFungibleToken: Unsafe Transfer");
+    const isContractAddr = !to.is_left;
+    assert(!isContractAddr, "NonFungibleToken: unsafe transfer");
 
     _unsafeMint(to, tokenId);
   }
@@ -579,40 +623,36 @@ module NonFungibleToken {
   /**
    * @description Mints `tokenId` and transfers it to `to`. It does NOT check if the recipient is a ContractAddress.
    *
-   * @circuitInfo k=11, rows=1010
-   *
    * Requirements:
    *
    * - The contract is initialized.
    * - `tokenId` must not exist.
    * - `to` is not the zero address.
    *
-   * WARNING: Transfers to contract addresses are considered unsafe because contract-to-contract
+   * @warning Transfers to contract addresses are considered unsafe because contract-to-contract
    * calls are not currently supported. Tokens sent to a contract address may become irretrievable.
    * Once contract-to-contract calls are supported, this circuit may be deprecated.
    *
-   * @param {Either<ZswapCoinPublicKey, ContractAddress>} to - The account receiving `tokenId`
+   * @param {Either<Bytes<32>, ContractAddress>} to - The account receiving `tokenId`
    * @param {Uint<128>} tokenId - The token to transfer
    * @return {[]} - Empty tuple.
    */
   export circuit _unsafeMint(
-                   to: Either<ZswapCoinPublicKey, ContractAddress>,
+                   to: Either<Bytes<32>, ContractAddress>,
                    tokenId: Uint<128>
                    ): [] {
     Initializable_assertInitialized();
-    assert(!Utils_isKeyOrAddressZero(to), "NonFungibleToken: Invalid Receiver");
+    assert(!_isTargetZero(to), "NonFungibleToken: invalid receiver");
 
-    const previousOwner = _update(to, tokenId, shieldedBurnAddress());
+    const previousOwner = _update(to, tokenId, ZERO());
 
-    assert(Utils_isKeyOrAddressZero(previousOwner), "NonFungibleToken: Invalid Sender");
+    assert(_isTargetZero(previousOwner), "NonFungibleToken: invalid sender");
   }
 
   /**
    * @description Destroys `tokenId`.
    * The approval is cleared when the token is burned.
    * This circuit does not check if the sender is authorized to operate on the token.
-   *
-   * @circuitInfo k=10, rows=479
    *
    * Requirements:
    *
@@ -624,20 +664,18 @@ module NonFungibleToken {
    */
   export circuit _burn(tokenId: Uint<128>): [] {
     Initializable_assertInitialized();
-    const previousOwner = _update(shieldedBurnAddress(), tokenId, shieldedBurnAddress());
-    assert(!Utils_isKeyOrAddressZero(previousOwner), "NonFungibleToken: Invalid Sender");
+    const previousOwner = _update(ZERO(), tokenId, ZERO());
+    assert(!_isTargetZero(previousOwner), "NonFungibleToken: invalid sender");
     _tokenURIs.remove(disclose(tokenId));
   }
 
   /**
    * @description Transfers `tokenId` from `fromAddress` to `to`.
-   *  As opposed to {transferFrom}, this imposes no restrictions on ownPublicKey().
+   * As opposed to {transferFrom}, this imposes no restrictions on the caller's identity.
    *
    * @notice Transfers to contract addresses are currently disallowed until contract-to-contract
    * interactions are supported in Compact. This restriction prevents assets from being inadvertently
    * locked in contracts that cannot currently handle token receipt.
-   *
-   * @circuitInfo k=11, rows=1224
    *
    * Requirements:
    *
@@ -646,28 +684,27 @@ module NonFungibleToken {
    * - `to` is not a ContractAddress.
    * - `tokenId` token must be owned by `fromAddress`.
    *
-   * @param {Either<ZswapCoinPublicKey, ContractAddress>} fromAddress - The source account of the token transfer
-   * @param {Either<ZswapCoinPublicKey, ContractAddress>} to - The target account of the token transfer
+   * @param {Either<Bytes<32>, ContractAddress>} fromAddress - The source account of the token transfer
+   * @param {Either<Bytes<32>, ContractAddress>} to - The target account of the token transfer
    * @param {Uint<128>} tokenId - The token to transfer
    * @return {[]} - Empty tuple.
    */
   export circuit _transfer(
-                   fromAddress: Either<ZswapCoinPublicKey, ContractAddress>,
-                   to: Either<ZswapCoinPublicKey, ContractAddress>,
+                   fromAddress: Either<Bytes<32>, ContractAddress>,
+                   to: Either<Bytes<32>, ContractAddress>,
                    tokenId: Uint<128>
                    ): [] {
     Initializable_assertInitialized();
-    assert(!Utils_isContractAddress(to), "NonFungibleToken: Unsafe Transfer");
+    const isContractAddr = !to.is_left;
+    assert(!isContractAddr, "NonFungibleToken: unsafe transfer");
 
     _unsafeTransfer(fromAddress, to, tokenId);
   }
 
   /**
    * @description Transfers `tokenId` from `fromAddress` to `to`.
-   * As opposed to {_unsafeTransferFrom}, this imposes no restrictions on ownPublicKey().
+   * As opposed to {_unsafeTransferFrom}, this imposes no restrictions on the caller's identity.
    * It does NOT check if the recipient is a ContractAddress.
-   *
-   * @circuitInfo k=11, rows=1221
    *
    * Requirements:
    *
@@ -675,33 +712,33 @@ module NonFungibleToken {
    * - `to` is not the zero address.
    * - `tokenId` token must be owned by `fromAddress`.
    *
-   * WARNING: Transfers to contract addresses are considered unsafe because contract-to-contract
+   * @warning Transfers to contract addresses are considered unsafe because contract-to-contract
    * calls are not currently supported. Tokens sent to a contract address may become irretrievable.
    * Once contract-to-contract calls are supported, this circuit may be deprecated.
    *
-   * @param {Either<ZswapCoinPublicKey, ContractAddress>} fromAddress - The source account of the token transfer
-   * @param {Either<ZswapCoinPublicKey, ContractAddress>} to - The target account of the token transfer
+   * @param {Either<Bytes<32>, ContractAddress>} fromAddress - The source account of the token transfer
+   * @param {Either<Bytes<32>, ContractAddress>} to - The target account of the token transfer
    * @param {Uint<128>} tokenId - The token to transfer
    * @return {[]} - Empty tuple.
    */
   export circuit _unsafeTransfer(
-                   fromAddress: Either<ZswapCoinPublicKey, ContractAddress>,
-                   to: Either<ZswapCoinPublicKey, ContractAddress>,
+                   fromAddress: Either<Bytes<32>, ContractAddress>,
+                   to: Either<Bytes<32>, ContractAddress>,
                    tokenId: Uint<128>
                    ): [] {
     Initializable_assertInitialized();
-    assert(!Utils_isKeyOrAddressZero(to), "NonFungibleToken: Invalid Receiver");
+    assert(!_isTargetZero(to), "NonFungibleToken: invalid receiver");
 
-    const previousOwner = _update(to, tokenId, shieldedBurnAddress());
+    const previousOwner = _update(to, tokenId, ZERO());
 
-    assert(!Utils_isKeyOrAddressZero(previousOwner), "NonFungibleToken: Nonexistent Token");
-    assert(previousOwner == fromAddress, "NonFungibleToken: Incorrect Owner");
+    assert(!_isTargetZero(previousOwner), "NonFungibleToken: nonexistent token");
+
+    const canonFrom = Utils_canonicalize<Bytes<32>, ContractAddress>(fromAddress);
+    assert(previousOwner == canonFrom, "NonFungibleToken: incorrect owner");
   }
 
   /**
-   * @description Approve `to` to operate on `tokenId`
-   *
-   * @circuitInfo k=11, rows=1109
+   * @description Approve `to` to operate on `tokenId`.
    *
    * Requirements:
    *
@@ -709,67 +746,69 @@ module NonFungibleToken {
    * - If `auth` is non 0, then this function will check that `auth` is either the owner of the token,
    * or approved to operate on the token (by the owner).
    *
-   * @param {Either<ZswapCoinPublicKey, ContractAddress>} to - The target account to approve
+   * @param {Either<Bytes<32>, ContractAddress>} to - The target account to approve
    * @param {Uint<128>} tokenId - The token to approve
-   * @param {Either<ZswapCoinPublicKey, ContractAddress>} auth - An account authorized to operate on all tokens held by the owner of the token
+   * @param {Either<Bytes<32>, ContractAddress>} auth - An account authorized to operate on all tokens held by the owner of the token
    * @return {[]} - Empty tuple.
    */
   export circuit _approve(
-                   to: Either<ZswapCoinPublicKey, ContractAddress>,
+                   to: Either<Bytes<32>, ContractAddress>,
                    tokenId: Uint<128>,
-                   auth: Either<ZswapCoinPublicKey, ContractAddress>
+                   auth: Either<Bytes<32>, ContractAddress>
                    ): [] {
     Initializable_assertInitialized();
-    if (!Utils_isKeyOrAddressZero(disclose(auth))) {
+    const canonTo = Utils_canonicalize<Bytes<32>, ContractAddress>(to);
+    const canonAuth = Utils_canonicalize<Bytes<32>, ContractAddress>(auth);
+
+    if (!_isTargetZero(disclose(canonAuth))) {
       const owner = _requireOwned(tokenId);
 
       // We do not use _isAuthorized because single-token approvals should not be able to call approve
-      assert((owner == disclose(auth) || isApprovedForAll(owner, auth)),
-             "NonFungibleToken: Invalid Approver"
+      assert((owner == disclose(canonAuth) || isApprovedForAll(owner, canonAuth)),
+             "NonFungibleToken: invalid approver"
              );
     }
 
-    _tokenApprovals.insert(disclose(tokenId), disclose(to));
+    _tokenApprovals.insert(disclose(tokenId), disclose(canonTo));
   }
 
   /**
-   * @description Approve `operator` to operate on all of `owner` tokens
-   *
-   * @circuitInfo k=10, rows=524
+   * @description Approve `operator` to operate on all of `owner` tokens.
    *
    * Requirements:
    *
    * - The contract is initialized.
    * - `operator` is not the address zero.
    *
-   * @param {Either<ZswapCoinPublicKey, ContractAddress>} owner - Owner of a token
-   * @param {Either<ZswapCoinPublicKey, ContractAddress>} operator - The account to approve
+   * @param {Either<Bytes<32>, ContractAddress>} owner - Owner of a token
+   * @param {Either<Bytes<32>, ContractAddress>} operator - The account to approve
    * @param {Boolean} approved - A boolean determining if `operator` may operate on all of `owner` tokens
    * @return {[]} - Empty tuple.
    */
   export circuit _setApprovalForAll(
-                   owner: Either<ZswapCoinPublicKey, ContractAddress>,
-                   operator: Either<ZswapCoinPublicKey, ContractAddress>,
+                   owner: Either<Bytes<32>, ContractAddress>,
+                   operator: Either<Bytes<32>, ContractAddress>,
                    approved: Boolean
                    ): [] {
     Initializable_assertInitialized();
-    assert(!Utils_isKeyOrAddressZero(operator), "NonFungibleToken: Invalid Operator");
+    const canonOwner = Utils_canonicalize<Bytes<32>, ContractAddress>(owner);
+    const canonOp = Utils_canonicalize<Bytes<32>, ContractAddress>(operator);
 
-    if (!_operatorApprovals.member(disclose(owner))) {
+    assert(!_isTargetZero(canonOp), "NonFungibleToken: invalid operator");
+
+    if (!_operatorApprovals.member(disclose(canonOwner))) {
       _operatorApprovals.insert(
-        disclose(owner),
-        default<Map<Either<ZswapCoinPublicKey, ContractAddress>, Boolean>>
+        disclose(canonOwner),
+        default<Map<Either<Bytes<32>, ContractAddress>, Boolean>>
         );
     }
 
-    _operatorApprovals.lookup(owner).insert(disclose(operator), disclose(approved));
+    _operatorApprovals.lookup(canonOwner).insert(disclose(canonOp), disclose(approved));
   }
 
   /**
    * @description Reverts if the `tokenId` doesn't have a current owner (it hasn't been minted, or it has been burned).
    * Returns the owner.
-   *
-   * @circuitInfo k=10, rows=288
    *
    * Requirements:
    *
@@ -777,13 +816,73 @@ module NonFungibleToken {
    * - `tokenId` must exist.
    *
    * @param {Uint<128>} tokenId - The token that should be owned
-   * @return {Either<ZswapCoinPublicKey, ContractAddress>} - The owner of `tokenId`
+   * @return {Either<Bytes<32>, ContractAddress>} - The owner of `tokenId`
    */
-  export circuit _requireOwned(tokenId: Uint<128>): Either<ZswapCoinPublicKey, ContractAddress> {
+  export circuit _requireOwned(tokenId: Uint<128>): Either<Bytes<32>, ContractAddress> {
     Initializable_assertInitialized();
     const owner = _ownerOf(tokenId);
 
-    assert(!Utils_isKeyOrAddressZero(owner), "NonFungibleToken: Nonexistent Token");
+    assert(!_isTargetZero(owner), "NonFungibleToken: nonexistent token");
     return owner;
+  }
+
+  /**
+   * @description Computes the caller's account identifier from the `wit_NonFungibleTokenSK` witness.
+   *
+   * ## ID Derivation
+   * `accountId = persistentHash(secretKey)`
+   *
+   * The result is a 32-byte commitment that uniquely identifies the caller.
+   *
+   * @returns {Bytes<32>} accountId - The computed account identifier.
+   */
+  circuit _computeAccountId(): Bytes<32> {
+    return computeAccountId(wit_NonFungibleTokenSK());
+  }
+
+  /**
+   * @description Computes an account identifier without on-chain state, allowing a user to derive
+   * their identity commitment before submitting it in a token operation.
+   * This is the off-chain counterpart to {_computeAccountId} and produces an identical result
+   * given the same inputs.
+   *
+   * @warning OpSec: The `secretKey` parameter is a sensitive secret. Mishandling it can
+   * permanently compromise the security of this system:
+   *
+   * - **Never log or persist** the `secretKey` in plaintext — avoid browser devtools,
+   *   application logs, analytics pipelines, or any observable side-channel.
+   * - **Store offline or in secure enclaves** — hardware security modules (HSMs),
+   *   air-gapped devices, or encrypted vaults are strongly preferred over hot storage.
+   * - **Use cryptographically secure randomness** — generate keys with `crypto.getRandomValues()`
+   *   or equivalent; weak or predictable keys can be brute-forced to reveal your identity.
+   * - **Treat key loss as identity loss** — a lost key cannot be recovered.
+   * - **Avoid calling this circuit in untrusted environments** — executing this in an
+   *   unverified browser extension, compromised runtime, or shared machine may expose
+   *   the key to a malicious observer.
+   *
+   * ## ID Derivation
+   * `accountId = persistentHash(secretKey)`
+   *
+   * @param {Bytes<32>} secretKey - A 32-byte cryptographically secure random value.
+   *
+   * @returns {Bytes<32>} accountId - The computed account identifier.
+   */
+  export pure circuit computeAccountId(secretKey: Bytes<32>): Bytes<32> {
+    return persistentHash<Vector<1, Bytes<32>>>([secretKey]);
+  }
+
+  /**
+   * @description Returns `true` if `target`'s active branch (as indicated by `is_left`)
+   * holds the zero value.
+   *
+   * @param {Either<Bytes<32>, ContractAddress>} target - The value to check.
+   * @returns {Boolean} - `true` if the active branch is zero, `false` otherwise.
+   */
+  circuit _isTargetZero(target: Either<Bytes<32>, ContractAddress>): Boolean {
+    if (target.is_left) {
+      return target.left == default<Bytes<32>>;
+    } else {
+      return target.right == default<ContractAddress>;
+    }
   }
 }

--- a/contracts/src/token/NonFungibleToken.compact
+++ b/contracts/src/token/NonFungibleToken.compact
@@ -142,7 +142,7 @@ module NonFungibleToken {
    *
    * @return {Either<Bytes<32>, ContractAddress>} - The zero value.
    */
-  export circuit ZERO(): Either<Bytes<32>, ContractAddress> {
+  export pure circuit ZERO(): Either<Bytes<32>, ContractAddress> {
     return Either<Bytes<32>, ContractAddress> {
       is_left: true, left: default<Bytes<32>>, right: default<ContractAddress>
     };

--- a/contracts/src/token/NonFungibleToken.compact
+++ b/contracts/src/token/NonFungibleToken.compact
@@ -828,7 +828,8 @@ module NonFungibleToken {
    * Requirements:
    *
    * - The contract is initialized.
-   * - `operator` is not the address zero.
+   * - `owner` is not zero.
+   * - `operator` is not zero.
    *
    * @param {Either<Bytes<32>, ContractAddress>} owner - Owner of a token
    * @param {Either<Bytes<32>, ContractAddress>} operator - The account to approve
@@ -842,8 +843,9 @@ module NonFungibleToken {
                    ): [] {
     Initializable_assertInitialized();
     const canonOwner = Utils_canonicalize<Bytes<32>, ContractAddress>(owner);
-    const canonOp = Utils_canonicalize<Bytes<32>, ContractAddress>(operator);
+    assert(!_isTargetZero(canonOwner), "NonFungibleToken: invalid owner");
 
+    const canonOp = Utils_canonicalize<Bytes<32>, ContractAddress>(operator);
     assert(!_isTargetZero(canonOp), "NonFungibleToken: invalid operator");
 
     if (!_operatorApprovals.member(disclose(canonOwner))) {

--- a/contracts/src/token/NonFungibleToken.compact
+++ b/contracts/src/token/NonFungibleToken.compact
@@ -801,7 +801,11 @@ module NonFungibleToken {
                    auth: Either<Bytes<32>, ContractAddress>
                    ): [] {
     Initializable_assertInitialized();
+    // Canonicalize + normalize `to`
     const canonTo = Utils_canonicalize<Bytes<32>, ContractAddress>(to);
+    const normalizedTo = _isTargetZero(canonTo) ? ZERO() : canonTo;
+
+    // Canonicalize auth
     const canonAuth = Utils_canonicalize<Bytes<32>, ContractAddress>(auth);
 
     if (!_isTargetZero(disclose(canonAuth))) {
@@ -813,7 +817,7 @@ module NonFungibleToken {
              );
     }
 
-    _tokenApprovals.insert(disclose(tokenId), disclose(canonTo));
+    _tokenApprovals.insert(disclose(tokenId), disclose(normalizedTo));
   }
 
   /**

--- a/contracts/src/token/NonFungibleToken.compact
+++ b/contracts/src/token/NonFungibleToken.compact
@@ -154,7 +154,7 @@ module NonFungibleToken {
    * This MUST be called in the implementing contract's constructor.
    * Failure to do so can lead to an irreparable contract.
    *
-   * @circuitInfo k=10, rows=65
+   * @circuitInfo k=6, rows=52
    *
    * Requirements:
    *

--- a/contracts/src/token/NonFungibleToken.compact
+++ b/contracts/src/token/NonFungibleToken.compact
@@ -173,6 +173,8 @@ module NonFungibleToken {
   /**
    * @description Returns the number of tokens in `owner`'s account.
    *
+   * @circuitInfo k=10, rows=673
+   *
    * Requirements:
    *
    * - The contract is initialized.
@@ -194,6 +196,8 @@ module NonFungibleToken {
   /**
    * @description Returns the owner of the `tokenId` token.
    *
+   * @circuitInfo k=9, rows=333
+   *
    * Requirements:
    *
    * - The contract is initialized.
@@ -210,6 +214,8 @@ module NonFungibleToken {
   /**
    * @description Returns the token name.
    *
+   * @circuitInfo k=6, rows=28
+   *
    * Requirements:
    *
    * - The contract is initialized.
@@ -223,6 +229,8 @@ module NonFungibleToken {
 
   /**
    * @description Returns the symbol of the token.
+   *
+   * @circuitInfo k=6, rows=28
    *
    * Requirements:
    *
@@ -238,6 +246,8 @@ module NonFungibleToken {
   /**
    * @description Returns the token URI for the given `tokenId`. Returns the empty
    * string if a tokenURI does not exist.
+   *
+   * @circuitInfo k=9, rows=326
    *
    * Requirements:
    *
@@ -266,6 +276,8 @@ module NonFungibleToken {
   /**
    * @description Sets the URI as `tokenURI` for the given `tokenId`.
    *
+   * @circuitInfo k=9, rows=289
+   *
    * Requirements:
    *
    * - The contract is initialized.
@@ -293,6 +305,8 @@ module NonFungibleToken {
    * The caller's identity is derived from the `wit_NonFungibleTokenSK` witness as
    * `persistentHash(secretKey)`.
    *
+   * @circuitInfo k=13, rows=3468
+   *
    * Requirements:
    *
    * - The contract is initialized.
@@ -311,6 +325,8 @@ module NonFungibleToken {
 
   /**
    * @description Returns the account approved for `tokenId` token.
+   *
+   * @circuitInfo k=9, rows=422
    *
    * Requirements:
    *
@@ -334,6 +350,8 @@ module NonFungibleToken {
    * The caller's identity is derived from the `wit_NonFungibleTokenSK` witness as
    * `persistentHash(secretKey)`.
    *
+   * @circuitInfo k=13, rows=2936
+   *
    * Requirements:
    *
    * - The contract is initialized.
@@ -354,6 +372,8 @@ module NonFungibleToken {
 
   /**
    * @description Returns if the `operator` is allowed to manage all of the assets of `owner`.
+   *
+   * @circuitInfo k=11, rows=1343
    *
    * Requirements:
    *
@@ -385,6 +405,8 @@ module NonFungibleToken {
    *
    * The caller's identity is derived from the `wit_NonFungibleTokenSK` witness as
    * `persistentHash(secretKey)`.
+   *
+   * @circuitInfo k=13, rows=4800
    *
    * Requirements:
    *
@@ -422,6 +444,8 @@ module NonFungibleToken {
    * are not currently supported. Tokens sent to a contract address may become irretrievable.
    * Once contract-to-contract calls are supported, this circuit may be deprecated.
    *
+   * @circuitInfo k=13, rows=4797
+   *
    * Requirements:
    *
    * - The contract is initialized.
@@ -454,6 +478,8 @@ module NonFungibleToken {
   /**
    * @description Returns the owner of the `tokenId`. Does NOT revert if token doesn't exist.
    *
+   * @circuitInfo k=9, rows=308
+   *
    * Requirements:
    *
    * - The contract is initialized.
@@ -473,6 +499,8 @@ module NonFungibleToken {
   /**
    * @description Returns the approved address for `tokenId`. Returns the zero address if `tokenId` is not minted.
    *
+   * @circuitInfo k=9, rows=308
+   *
    * Requirements:
    *
    * - The contract is initialized.
@@ -491,6 +519,8 @@ module NonFungibleToken {
   /**
    * @description Returns whether `spender` is allowed to manage `owner`'s tokens, or `tokenId` in
    * particular (ignoring whether it is owned by `owner`).
+   *
+   * @circuitInfo k=11, rows=1798
    *
    * Requirements:
    *
@@ -521,6 +551,8 @@ module NonFungibleToken {
 
   /**
    * @description Checks if `spender` can operate on `tokenId`, assuming the provided `owner` is the actual owner.
+   *
+   * @circuitInfo k=11, rows=1804
    *
    * Requirements:
    *
@@ -601,6 +633,8 @@ module NonFungibleToken {
   /**
    * @description Mints `tokenId` and transfers it to `to`.
    *
+   * @circuitInfo k=11, rows=1473
+   *
    * Requirements:
    *
    * - The contract is initialized.
@@ -622,6 +656,8 @@ module NonFungibleToken {
 
   /**
    * @description Mints `tokenId` and transfers it to `to`. It does NOT check if the recipient is a ContractAddress.
+   *
+   * @circuitInfo k=11, rows=1470
    *
    * Requirements:
    *
@@ -654,6 +690,8 @@ module NonFungibleToken {
    * The approval is cleared when the token is burned.
    * This circuit does not check if the sender is authorized to operate on the token.
    *
+   * @circuitInfo k=10, rows=509
+   *
    * Requirements:
    *
    * - The contract is initialized.
@@ -676,6 +714,8 @@ module NonFungibleToken {
    * @notice Transfers to contract addresses are currently disallowed until contract-to-contract
    * interactions are supported in Compact. This restriction prevents assets from being inadvertently
    * locked in contracts that cannot currently handle token receipt.
+   *
+   * @circuitInfo k=12, rows=2067
    *
    * Requirements:
    *
@@ -705,6 +745,8 @@ module NonFungibleToken {
    * @description Transfers `tokenId` from `fromAddress` to `to`.
    * As opposed to {_unsafeTransferFrom}, this imposes no restrictions on the caller's identity.
    * It does NOT check if the recipient is a ContractAddress.
+   *
+   * @circuitInfo k=12, rows=2064
    *
    * Requirements:
    *
@@ -739,6 +781,8 @@ module NonFungibleToken {
 
   /**
    * @description Approve `to` to operate on `tokenId`.
+   *
+   * @circuitInfo k=11, rows=1810
    *
    * Requirements:
    *
@@ -775,6 +819,8 @@ module NonFungibleToken {
   /**
    * @description Approve `operator` to operate on all of `owner` tokens.
    *
+   * @circuitInfo k=11, rows=1261
+   *
    * Requirements:
    *
    * - The contract is initialized.
@@ -809,6 +855,8 @@ module NonFungibleToken {
   /**
    * @description Reverts if the `tokenId` doesn't have a current owner (it hasn't been minted, or it has been burned).
    * Returns the owner.
+   *
+   * @circuitInfo k=9, rows=331
    *
    * Requirements:
    *

--- a/contracts/src/token/NonFungibleToken.compact
+++ b/contracts/src/token/NonFungibleToken.compact
@@ -302,8 +302,8 @@ module NonFungibleToken {
    *
    * Only a single account can be approved at a time, so approving the zero value clears previous approvals.
    *
-   * The caller's identity is derived from the `wit_NonFungibleTokenSK` witness as
-   * `persistentHash(secretKey)`.
+   * In the case of an external (non-contract) caller, the caller's identity is derived from the `wit_NonFungibleTokenSK`
+   * witness as `persistentHash(secretKey)`.
    *
    * @circuitInfo k=13, rows=3468
    *
@@ -347,8 +347,8 @@ module NonFungibleToken {
    * @description Approve or remove `operator` as an operator for the caller.
    * Operators can call {transferFrom} for any token owned by the caller.
    *
-   * The caller's identity is derived from the `wit_NonFungibleTokenSK` witness as
-   * `persistentHash(secretKey)`.
+   * In the case of an external (non-contract) caller, the caller's identity is derived from the `wit_NonFungibleTokenSK`
+   * witness as `persistentHash(secretKey)`.
    *
    * @circuitInfo k=13, rows=2936
    *
@@ -403,8 +403,8 @@ module NonFungibleToken {
    * are supported in Compact. This restriction prevents assets from being inadvertently locked in contracts that cannot
    * currently handle token receipt.
    *
-   * The caller's identity is derived from the `wit_NonFungibleTokenSK` witness as
-   * `persistentHash(secretKey)`.
+   * In the case of an external (non-contract) caller, the caller's identity is derived from the `wit_NonFungibleTokenSK`
+   * witness as `persistentHash(secretKey)`.
    *
    * @circuitInfo k=13, rows=4800
    *
@@ -437,8 +437,8 @@ module NonFungibleToken {
   /**
    * @description Transfers `tokenId` token from `fromAddress` to `to`. It does NOT check if the recipient is a ContractAddress.
    *
-   * The caller's identity is derived from the `wit_NonFungibleTokenSK` witness as
-   * `persistentHash(secretKey)`.
+   * In the case of an external (non-contract) caller, the caller's identity is derived from the `wit_NonFungibleTokenSK`
+   * witness as `persistentHash(secretKey)`.
    *
    * @warning Transfers to contract addresses are considered unsafe because contract-to-contract calls
    * are not currently supported. Tokens sent to a contract address may become irretrievable.

--- a/contracts/src/token/test/mocks/MockNonFungibleToken.compact
+++ b/contracts/src/token/test/mocks/MockNonFungibleToken.compact
@@ -29,6 +29,10 @@ constructor(
   }
 }
 
+export pure circuit ZERO(): Either<Bytes<32>, ContractAddress> {
+  return NonFungibleToken_ZERO();
+}
+
 export circuit name(): Opaque<"string"> {
   return NonFungibleToken_name();
 }

--- a/contracts/src/token/test/mocks/MockNonFungibleToken.compact
+++ b/contracts/src/token/test/mocks/MockNonFungibleToken.compact
@@ -11,7 +11,7 @@ import CompactStandardLibrary;
 
 import "../../NonFungibleToken" prefix NonFungibleToken_;
 
-export { ZswapCoinPublicKey, ContractAddress, Either, Maybe };
+export { ContractAddress, Either, Maybe };
 
 /**
  * @description `init` is a param for testing.
@@ -37,11 +37,11 @@ export circuit symbol(): Opaque<"string"> {
   return NonFungibleToken_symbol();
 }
 
-export circuit balanceOf(account: Either<ZswapCoinPublicKey, ContractAddress>): Uint<128> {
+export circuit balanceOf(account: Either<Bytes<32>, ContractAddress>): Uint<128> {
   return NonFungibleToken_balanceOf(account);
 }
 
-export circuit ownerOf(tokenId: Uint<128>): Either<ZswapCoinPublicKey, ContractAddress> {
+export circuit ownerOf(tokenId: Uint<128>): Either<Bytes<32>, ContractAddress> {
   return NonFungibleToken_ownerOf(tokenId);
 }
 
@@ -50,84 +50,84 @@ export circuit tokenURI(tokenId: Uint<128>): Opaque<"string"> {
 }
 
 export circuit approve(
-  to: Either<ZswapCoinPublicKey, ContractAddress>,
+  to: Either<Bytes<32>, ContractAddress>,
   tokenId: Uint<128>
 ): [] {
   return NonFungibleToken_approve(to, tokenId);
 }
 
-export circuit getApproved(tokenId: Uint<128>): Either<ZswapCoinPublicKey, ContractAddress> {
+export circuit getApproved(tokenId: Uint<128>): Either<Bytes<32>, ContractAddress> {
   return NonFungibleToken_getApproved(tokenId);
 }
 
 export circuit setApprovalForAll(
-  operator: Either<ZswapCoinPublicKey, ContractAddress>,
+  operator: Either<Bytes<32>, ContractAddress>,
   approved: Boolean
 ): [] {
   return NonFungibleToken_setApprovalForAll(operator, approved);
 }
 
 export circuit isApprovedForAll(
-  owner: Either<ZswapCoinPublicKey, ContractAddress>,
-  operator: Either<ZswapCoinPublicKey, ContractAddress>
+  owner: Either<Bytes<32>, ContractAddress>,
+  operator: Either<Bytes<32>, ContractAddress>
 ): Boolean {
   return NonFungibleToken_isApprovedForAll(owner, operator);
 }
 
 export circuit transferFrom(
-  fromAddress: Either<ZswapCoinPublicKey, ContractAddress>,
-  to: Either<ZswapCoinPublicKey, ContractAddress>,
+  fromAddress: Either<Bytes<32>, ContractAddress>,
+  to: Either<Bytes<32>, ContractAddress>,
   tokenId: Uint<128>
 ): [] {
   return NonFungibleToken_transferFrom(fromAddress, to, tokenId);
 }
 
-export circuit _requireOwned(tokenId: Uint<128>): Either<ZswapCoinPublicKey, ContractAddress> {
+export circuit _requireOwned(tokenId: Uint<128>): Either<Bytes<32>, ContractAddress> {
   return NonFungibleToken__requireOwned(tokenId);
 }
 
-export circuit _ownerOf(tokenId: Uint<128>): Either<ZswapCoinPublicKey, ContractAddress> {
+export circuit _ownerOf(tokenId: Uint<128>): Either<Bytes<32>, ContractAddress> {
   return NonFungibleToken__ownerOf(tokenId);
 }
 
 export circuit _approve(
-  to: Either<ZswapCoinPublicKey, ContractAddress>,
+  to: Either<Bytes<32>, ContractAddress>,
   tokenId: Uint<128>,
-  auth: Either<ZswapCoinPublicKey, ContractAddress>
+  auth: Either<Bytes<32>, ContractAddress>
 ): [] {
   return NonFungibleToken__approve(to, tokenId, auth);
 }
 
 export circuit _checkAuthorized(
-  owner: Either<ZswapCoinPublicKey, ContractAddress>,
-  spender: Either<ZswapCoinPublicKey, ContractAddress>,
+  owner: Either<Bytes<32>, ContractAddress>,
+  spender: Either<Bytes<32>, ContractAddress>,
   tokenId: Uint<128>
 ): [] {
   return NonFungibleToken__checkAuthorized(owner, spender, tokenId);
 }
 
 export circuit _isAuthorized(
-  owner: Either<ZswapCoinPublicKey, ContractAddress>,
-  spender: Either<ZswapCoinPublicKey, ContractAddress>,
+  owner: Either<Bytes<32>, ContractAddress>,
+  spender: Either<Bytes<32>, ContractAddress>,
   tokenId: Uint<128>
 ): Boolean {
   return NonFungibleToken__isAuthorized(owner, spender, tokenId);
 }
 
-export circuit _getApproved(tokenId: Uint<128>): Either<ZswapCoinPublicKey, ContractAddress> {
+export circuit _getApproved(tokenId: Uint<128>): Either<Bytes<32>, ContractAddress> {
   return NonFungibleToken__getApproved(tokenId);
 }
 
 export circuit _setApprovalForAll(
-  owner: Either<ZswapCoinPublicKey, ContractAddress>,
-  operator: Either<ZswapCoinPublicKey, ContractAddress>,
+  owner: Either<Bytes<32>, ContractAddress>,
+  operator: Either<Bytes<32>, ContractAddress>,
   approved: Boolean
 ): [] {
   return NonFungibleToken__setApprovalForAll(owner, operator, approved);
 }
 
 export circuit _mint(
-  to: Either<ZswapCoinPublicKey, ContractAddress>,
+  to: Either<Bytes<32>, ContractAddress>,
   tokenId: Uint<128>
 ): [] {
   return NonFungibleToken__mint(to, tokenId);
@@ -138,8 +138,8 @@ export circuit _burn(tokenId: Uint<128>): [] {
 }
 
 export circuit _transfer(
-  fromAddress: Either<ZswapCoinPublicKey, ContractAddress>,
-  to: Either<ZswapCoinPublicKey, ContractAddress>,
+  fromAddress: Either<Bytes<32>, ContractAddress>,
+  to: Either<Bytes<32>, ContractAddress>,
   tokenId: Uint<128>
 ): [] {
   return NonFungibleToken__transfer(fromAddress, to, tokenId);
@@ -150,24 +150,28 @@ export circuit _setTokenURI(tokenId: Uint<128>, tokenURI: Opaque<"string">): [] 
 }
 
 export circuit _unsafeTransferFrom(
-  fromAddress: Either<ZswapCoinPublicKey, ContractAddress>,
-  to: Either<ZswapCoinPublicKey, ContractAddress>,
+  fromAddress: Either<Bytes<32>, ContractAddress>,
+  to: Either<Bytes<32>, ContractAddress>,
   tokenId: Uint<128>
 ): [] {
   return NonFungibleToken__unsafeTransferFrom(fromAddress, to, tokenId);
 }
 
 export circuit _unsafeTransfer(
-  fromAddress: Either<ZswapCoinPublicKey, ContractAddress>,
-  to: Either<ZswapCoinPublicKey, ContractAddress>,
+  fromAddress: Either<Bytes<32>, ContractAddress>,
+  to: Either<Bytes<32>, ContractAddress>,
   tokenId: Uint<128>
 ): [] {
   return NonFungibleToken__unsafeTransfer(fromAddress, to, tokenId);
 }
 
 export circuit _unsafeMint(
-  to: Either<ZswapCoinPublicKey, ContractAddress>,
+  to: Either<Bytes<32>, ContractAddress>,
   tokenId: Uint<128>
 ): [] {
   return NonFungibleToken__unsafeMint(to, tokenId);
+}
+
+export pure circuit computeAccountId(secretKey: Bytes<32>): Bytes<32> {
+  return NonFungibleToken_computeAccountId(secretKey);
 }

--- a/contracts/src/token/test/nonFungibleToken.test.ts
+++ b/contracts/src/token/test/nonFungibleToken.test.ts
@@ -394,6 +394,13 @@ describe('NonFungibleToken', () => {
       token.approve(SPENDER.either, longTokenId);
       expect(token.getApproved(longTokenId)).toEqual(SPENDER.either);
     });
+
+    it('should normalize right-variant zero approval', () => {
+      token.privateState.injectSecretKey(OWNER.secretKey);
+      token.approve(ZERO_CONTRACT, TOKENID_1);
+
+      expect(token.getApproved(TOKENID_1)).toEqual(ZERO_ACCOUNT);
+    });
   });
 
   describe('getApproved', () => {
@@ -709,6 +716,17 @@ describe('NonFungibleToken', () => {
         token.transferFrom(OTHER.either, UNAUTHORIZED.either, TOKENID_1);
       }).toThrow('NonFungibleToken: insufficient approval');
     });
+
+    it('should store canonical zero after clearing approval via transfer', () => {
+      token.privateState.injectSecretKey(OWNER.secretKey);
+      token.approve(SPENDER.either, TOKENID_1);
+
+      token.transferFrom(OWNER.either, RECIPIENT.either, TOKENID_1);
+
+      // _update calls _approve(ZERO(), tokenId, ZERO()) internally,
+      // which should store the left-variant zero
+      expect(token.getApproved(TOKENID_1)).toEqual(ZERO_ACCOUNT);
+    });
   });
 
   describe('_requireOwned', () => {
@@ -783,6 +801,28 @@ describe('NonFungibleToken', () => {
 
       token._approve(nonCanonical, TOKENID_1, OWNER.either);
       expect(token.getApproved(TOKENID_1)).toEqual(SPENDER.either);
+    });
+
+    it('should normalize right-variant zero to ZERO()', () => {
+      token._mint(OWNER.either, TOKENID_1);
+
+      // Approve with a right-variant zero (contract address zero)
+      token._approve(ZERO_CONTRACT, TOKENID_1, OWNER.either);
+
+      // getApproved should return the left-variant ZERO, not the right-variant
+      expect(token.getApproved(TOKENID_1)).toEqual(ZERO_ACCOUNT);
+    });
+
+    it('should normalize left-variant zero to ZERO()', () => {
+      token._mint(OWNER.either, TOKENID_1);
+
+      // First set a real approval
+      token._approve(SPENDER.either, TOKENID_1, OWNER.either);
+      expect(token.getApproved(TOKENID_1)).toEqual(SPENDER.either);
+
+      // Clear it with left-variant zero
+      token._approve(ZERO_ACCOUNT, TOKENID_1, OWNER.either);
+      expect(token.getApproved(TOKENID_1)).toEqual(ZERO_ACCOUNT);
     });
   });
 
@@ -892,10 +932,28 @@ describe('NonFungibleToken', () => {
       expect(token.isApprovedForAll(OWNER.either, SPENDER.either)).toBe(false);
     });
 
-    it('should throw if operator is zero address', () => {
+    it('should throw if operator is zero address (left)', () => {
       expect(() => {
         token._setApprovalForAll(OWNER.either, ZERO_ACCOUNT, true);
       }).toThrow('NonFungibleToken: invalid operator');
+    });
+
+    it('should throw if operator is zero address (right)', () => {
+      expect(() => {
+        token._setApprovalForAll(OWNER.either, ZERO_CONTRACT, true);
+      }).toThrow('NonFungibleToken: invalid operator');
+    });
+
+    it('should fail if owner is zero address (left)', () => {
+      expect(() => {
+        token._setApprovalForAll(ZERO_ACCOUNT, RECIPIENT.either, true);
+      }).toThrow('NonFungibleToken: invalid owner');
+    });
+
+    it('should fail if owner is zero address (right)', () => {
+      expect(() => {
+        token._setApprovalForAll(ZERO_CONTRACT, RECIPIENT.either, true);
+      }).toThrow('NonFungibleToken: invalid owner');
     });
 
     it('should canonicalize owner and operator', () => {

--- a/contracts/src/token/test/nonFungibleToken.test.ts
+++ b/contracts/src/token/test/nonFungibleToken.test.ts
@@ -1,11 +1,67 @@
-import { beforeEach, describe, expect, it } from 'vitest';
 import {
-  createEitherTestContractAddress,
-  generateEitherPubKeyPair,
-  ZERO_ADDRESS,
-  ZERO_KEY,
-} from '#test-utils/address.js';
+  CompactTypeBytes,
+  CompactTypeVector,
+  persistentHash,
+} from '@midnight-ntwrk/compact-runtime';
+import { beforeEach, describe, expect, it } from 'vitest';
+import * as utils from '#test-utils/address.js';
 import { NonFungibleTokenSimulator } from './simulators/NonFungibleTokenSimulator.js';
+
+// Helpers
+const buildAccountIdHash = (sk: Uint8Array): Uint8Array => {
+  const rt_type = new CompactTypeVector(1, new CompactTypeBytes(32));
+  return persistentHash(rt_type, [sk]);
+};
+
+const zeroBytes = utils.zeroUint8Array();
+
+const eitherAccountId = (accountId: Uint8Array) => {
+  return {
+    is_left: true,
+    left: accountId,
+    right: { bytes: zeroBytes },
+  };
+};
+
+const eitherContract = (address: string) => {
+  return {
+    is_left: false,
+    left: zeroBytes,
+    right: utils.encodeToAddress(address),
+  };
+};
+
+const createTestSK = (label: string): Uint8Array => {
+  const sk = new Uint8Array(32);
+  const encoded = new TextEncoder().encode(label);
+  sk.set(encoded.slice(0, 32));
+  return sk;
+};
+
+const makeUser = (label: string) => {
+  const secretKey = createTestSK(label);
+  const accountId = buildAccountIdHash(secretKey);
+  const either = eitherAccountId(accountId);
+  return { secretKey, accountId, either };
+};
+
+// Users
+const OWNER = makeUser('OWNER');
+const SPENDER = makeUser('SPENDER');
+const RECIPIENT = makeUser('RECIPIENT');
+const OTHER = makeUser('OTHER');
+const UNAUTHORIZED = makeUser('UNAUTHORIZED');
+
+// Contract addresses
+const SOME_CONTRACT = eitherContract('CONTRACT');
+
+// Zero values
+const ZERO_ACCOUNT = eitherAccountId(zeroBytes);
+const ZERO_CONTRACT = {
+  is_left: false,
+  left: zeroBytes,
+  right: { bytes: zeroBytes },
+};
 
 // Contract Metadata
 const NAME = 'NAME';
@@ -15,23 +71,13 @@ const INIT = true;
 const BAD_INIT = false;
 
 // Token Metadata
-const TOKENID_1: bigint = BigInt(1);
-const TOKENID_2: bigint = BigInt(2);
-const TOKENID_3: bigint = BigInt(3);
-const NON_EXISTENT_TOKEN: bigint = BigInt(0xdead);
-const SOME_URI = 'https://openzeppelin.example';
+const TOKENID_1 = 1n;
+const TOKENID_2 = 2n;
+const TOKENID_3 = 3n;
+const NON_EXISTENT_TOKEN = 0xdeadn;
+const SOME_URI = 'https://some.example';
 const EMPTY_URI = '';
-const AMOUNT: bigint = BigInt(1);
-
-// PKs
-const [OWNER, Z_OWNER] = generateEitherPubKeyPair('OWNER');
-const [SPENDER, Z_SPENDER] = generateEitherPubKeyPair('SPENDER');
-const [UNAUTHORIZED, Z_UNAUTHORIZED] = generateEitherPubKeyPair('UNAUTHORIZED');
-const [, Z_RECIPIENT] = generateEitherPubKeyPair('RECIPIENT');
-const [, Z_OTHER] = generateEitherPubKeyPair('OTHER');
-
-// Encoded contract addresses
-const SOME_CONTRACT = createEitherTestContractAddress('CONTRACT');
+const AMOUNT = 1n;
 
 let token: NonFungibleTokenSimulator;
 
@@ -39,14 +85,12 @@ describe('NonFungibleToken', () => {
   describe('initializer and metadata', () => {
     it('should initialize metadata', () => {
       token = new NonFungibleTokenSimulator(NAME, SYMBOL, INIT);
-
       expect(token.name()).toEqual(NAME);
       expect(token.symbol()).toEqual(SYMBOL);
     });
 
     it('should initialize empty metadata', () => {
       token = new NonFungibleTokenSimulator(EMPTY_STRING, EMPTY_STRING, INIT);
-
       expect(token.name()).toEqual(EMPTY_STRING);
       expect(token.symbol()).toEqual(EMPTY_STRING);
     });
@@ -76,40 +120,83 @@ describe('NonFungibleToken', () => {
     token = new NonFungibleTokenSimulator(NAME, SYMBOL, INIT);
   });
 
+  describe('computeAccountId', () => {
+    const users = [OWNER, SPENDER, RECIPIENT, UNAUTHORIZED];
+
+    it('should match the test helper derivation', () => {
+      for (const user of users) {
+        expect(token.computeAccountId(user.secretKey)).toEqual(user.accountId);
+      }
+    });
+
+    it('should produce distinct identifiers for distinct keys', () => {
+      const ids = users.map((u) => token.computeAccountId(u.secretKey));
+      for (let i = 0; i < ids.length; i++) {
+        for (let j = i + 1; j < ids.length; j++) {
+          expect(ids[i]).not.toEqual(ids[j]);
+        }
+      }
+    });
+  });
+
   describe('balanceOf', () => {
     it('should return zero when requested account has no balance', () => {
-      expect(token.balanceOf(Z_OWNER)).toEqual(0n);
+      expect(token.balanceOf(OWNER.either)).toEqual(0n);
     });
 
     it('should return balance when requested account has tokens', () => {
-      token._mint(Z_OWNER, AMOUNT);
-      expect(token.balanceOf(Z_OWNER)).toEqual(AMOUNT);
+      token._mint(OWNER.either, AMOUNT);
+      expect(token.balanceOf(OWNER.either)).toEqual(AMOUNT);
     });
 
     it('should return correct balance for multiple tokens', () => {
-      token._mint(Z_OWNER, TOKENID_1);
-      token._mint(Z_OWNER, TOKENID_2);
-      token._mint(Z_OWNER, TOKENID_3);
-      expect(token.balanceOf(Z_OWNER)).toEqual(3n);
+      token._mint(OWNER.either, TOKENID_1);
+      token._mint(OWNER.either, TOKENID_2);
+      token._mint(OWNER.either, TOKENID_3);
+      expect(token.balanceOf(OWNER.either)).toEqual(3n);
     });
 
     it('should return correct balance after burning multiple tokens', () => {
-      token._mint(Z_OWNER, TOKENID_1);
-      token._mint(Z_OWNER, TOKENID_2);
-      token._mint(Z_OWNER, TOKENID_3);
+      token._mint(OWNER.either, TOKENID_1);
+      token._mint(OWNER.either, TOKENID_2);
+      token._mint(OWNER.either, TOKENID_3);
       token._burn(TOKENID_1);
       token._burn(TOKENID_2);
-      expect(token.balanceOf(Z_OWNER)).toEqual(1n);
+      expect(token.balanceOf(OWNER.either)).toEqual(1n);
     });
 
     it('should return correct balance after transferring multiple tokens', () => {
-      token._mint(Z_OWNER, TOKENID_1);
-      token._mint(Z_OWNER, TOKENID_2);
-      token._mint(Z_OWNER, TOKENID_3);
-      token._transfer(Z_OWNER, Z_RECIPIENT, TOKENID_1);
-      token._transfer(Z_OWNER, Z_RECIPIENT, TOKENID_2);
-      expect(token.balanceOf(Z_OWNER)).toEqual(1n);
-      expect(token.balanceOf(Z_RECIPIENT)).toEqual(2n);
+      token._mint(OWNER.either, TOKENID_1);
+      token._mint(OWNER.either, TOKENID_2);
+      token._mint(OWNER.either, TOKENID_3);
+      token._transfer(OWNER.either, RECIPIENT.either, TOKENID_1);
+      token._transfer(OWNER.either, RECIPIENT.either, TOKENID_2);
+      expect(token.balanceOf(OWNER.either)).toEqual(1n);
+      expect(token.balanceOf(RECIPIENT.either)).toEqual(2n);
+    });
+
+    it('should return correct balance with non-canonical lookup (left)', () => {
+      token._mint(OWNER.either, TOKENID_1);
+
+      const nonCanonical = {
+        is_left: true,
+        left: OWNER.accountId,
+        right: utils.encodeToAddress('JUNK_DATA'),
+      };
+
+      expect(token.balanceOf(nonCanonical)).toEqual(1n);
+    });
+
+    it('should return correct balance with non-canonical lookup (right)', () => {
+      token._unsafeMint(SOME_CONTRACT, TOKENID_1);
+
+      const nonCanonical = {
+        is_left: false,
+        left: new Uint8Array(32).fill(1),
+        right: SOME_CONTRACT.right,
+      };
+
+      expect(token.balanceOf(nonCanonical)).toEqual(1n);
     });
   });
 
@@ -117,57 +204,57 @@ describe('NonFungibleToken', () => {
     it('should throw if token does not exist', () => {
       expect(() => {
         token.ownerOf(NON_EXISTENT_TOKEN);
-      }).toThrow('NonFungibleToken: Nonexistent Token');
+      }).toThrow('NonFungibleToken: nonexistent token');
     });
 
     it('should throw if token has been burned', () => {
-      token._mint(Z_OWNER, TOKENID_1);
+      token._mint(OWNER.either, TOKENID_1);
       token._burn(TOKENID_1);
       expect(() => {
         token.ownerOf(TOKENID_1);
-      }).toThrow('NonFungibleToken: Nonexistent Token');
+      }).toThrow('NonFungibleToken: nonexistent token');
     });
 
     it('should return owner of token if it exists', () => {
-      token._mint(Z_OWNER, TOKENID_1);
-      expect(token.ownerOf(TOKENID_1)).toEqual(Z_OWNER);
+      token._mint(OWNER.either, TOKENID_1);
+      expect(token.ownerOf(TOKENID_1)).toEqual(OWNER.either);
     });
 
     it('should return correct owner for multiple tokens', () => {
-      token._mint(Z_OWNER, TOKENID_1);
-      token._mint(Z_OWNER, TOKENID_2);
-      token._mint(Z_OWNER, TOKENID_3);
-      expect(token.ownerOf(TOKENID_1)).toEqual(Z_OWNER);
-      expect(token.ownerOf(TOKENID_2)).toEqual(Z_OWNER);
-      expect(token.ownerOf(TOKENID_3)).toEqual(Z_OWNER);
+      token._mint(OWNER.either, TOKENID_1);
+      token._mint(OWNER.either, TOKENID_2);
+      token._mint(OWNER.either, TOKENID_3);
+      expect(token.ownerOf(TOKENID_1)).toEqual(OWNER.either);
+      expect(token.ownerOf(TOKENID_2)).toEqual(OWNER.either);
+      expect(token.ownerOf(TOKENID_3)).toEqual(OWNER.either);
     });
 
     it('should return correct owner after multiple transfers', () => {
-      token._mint(Z_OWNER, TOKENID_1);
-      token._mint(Z_OWNER, TOKENID_2);
-      token._transfer(Z_OWNER, Z_SPENDER, TOKENID_1);
-      token._transfer(Z_OWNER, Z_OTHER, TOKENID_2);
-      expect(token.ownerOf(TOKENID_1)).toEqual(Z_SPENDER);
-      expect(token.ownerOf(TOKENID_2)).toEqual(Z_OTHER);
+      token._mint(OWNER.either, TOKENID_1);
+      token._mint(OWNER.either, TOKENID_2);
+      token._transfer(OWNER.either, SPENDER.either, TOKENID_1);
+      token._transfer(OWNER.either, OTHER.either, TOKENID_2);
+      expect(token.ownerOf(TOKENID_1)).toEqual(SPENDER.either);
+      expect(token.ownerOf(TOKENID_2)).toEqual(OTHER.either);
     });
 
     it('should return correct owner after multiple burns and mints', () => {
-      token._mint(Z_OWNER, TOKENID_1);
+      token._mint(OWNER.either, TOKENID_1);
       token._burn(TOKENID_1);
-      token._mint(Z_SPENDER, TOKENID_1);
-      expect(token.ownerOf(TOKENID_1)).toEqual(Z_SPENDER);
+      token._mint(SPENDER.either, TOKENID_1);
+      expect(token.ownerOf(TOKENID_1)).toEqual(SPENDER.either);
     });
   });
 
   describe('tokenURI', () => {
     beforeEach(() => {
-      token._mint(Z_OWNER, TOKENID_1);
+      token._mint(OWNER.either, TOKENID_1);
     });
 
     it('should throw if token does not exist', () => {
       expect(() => {
         token.tokenURI(NON_EXISTENT_TOKEN);
-      }).toThrow('NonFungibleToken: Nonexistent Token');
+      }).toThrow('NonFungibleToken: nonexistent token');
     });
 
     it('should return the empty string for an unset tokenURI', () => {
@@ -205,311 +292,391 @@ describe('NonFungibleToken', () => {
 
     it('should maintain tokenURI after token transfer', () => {
       token._setTokenURI(TOKENID_1, SOME_URI);
-      token._transfer(Z_OWNER, Z_RECIPIENT, TOKENID_1);
+      token._transfer(OWNER.either, RECIPIENT.either, TOKENID_1);
       expect(token.tokenURI(TOKENID_1)).toEqual(SOME_URI);
     });
   });
 
   describe('approve', () => {
     beforeEach(() => {
-      token._mint(Z_OWNER, TOKENID_1);
-      expect(token.getApproved(TOKENID_1)).toEqual(ZERO_KEY);
+      token._mint(OWNER.either, TOKENID_1);
+      expect(token.getApproved(TOKENID_1)).toEqual(ZERO_ACCOUNT);
     });
 
     it('should throw if not owner', () => {
+      token.privateState.injectSecretKey(UNAUTHORIZED.secretKey);
       expect(() => {
-        token.as(UNAUTHORIZED).approve(Z_SPENDER, TOKENID_1);
-      }).toThrow('NonFungibleToken: Invalid Approver');
+        token.approve(SPENDER.either, TOKENID_1);
+      }).toThrow('NonFungibleToken: invalid approver');
     });
 
     it('should approve spender', () => {
-      token.as(OWNER).approve(Z_SPENDER, TOKENID_1);
-      expect(token.getApproved(TOKENID_1)).toEqual(Z_SPENDER);
+      token.privateState.injectSecretKey(OWNER.secretKey);
+      token.approve(SPENDER.either, TOKENID_1);
+      expect(token.getApproved(TOKENID_1)).toEqual(SPENDER.either);
     });
 
     it('should allow operator to approve', () => {
-      token.as(OWNER).setApprovalForAll(Z_SPENDER, true);
-      token.as(SPENDER).approve(Z_OTHER, TOKENID_1);
-      expect(token.getApproved(TOKENID_1)).toEqual(Z_OTHER);
+      token.privateState.injectSecretKey(OWNER.secretKey);
+      token.setApprovalForAll(SPENDER.either, true);
+
+      token.privateState.injectSecretKey(SPENDER.secretKey);
+      token.approve(OTHER.either, TOKENID_1);
+      expect(token.getApproved(TOKENID_1)).toEqual(OTHER.either);
     });
 
     it('spender approved for only TOKENID_1 should not be able to approve', () => {
-      token.as(OWNER).approve(Z_SPENDER, TOKENID_1);
+      token.privateState.injectSecretKey(OWNER.secretKey);
+      token.approve(SPENDER.either, TOKENID_1);
 
+      token.privateState.injectSecretKey(SPENDER.secretKey);
       expect(() => {
-        token.as(SPENDER).approve(Z_OTHER, TOKENID_1);
-      }).toThrow('NonFungibleToken: Invalid Approver');
+        token.approve(OTHER.either, TOKENID_1);
+      }).toThrow('NonFungibleToken: invalid approver');
     });
 
     it('should approve same address multiple times', () => {
-      token.as(OWNER).approve(Z_SPENDER, TOKENID_1);
-      token.as(OWNER).approve(Z_SPENDER, TOKENID_1);
-      expect(token.getApproved(TOKENID_1)).toEqual(Z_SPENDER);
+      token.privateState.injectSecretKey(OWNER.secretKey);
+      token.approve(SPENDER.either, TOKENID_1);
+      token.approve(SPENDER.either, TOKENID_1);
+      expect(token.getApproved(TOKENID_1)).toEqual(SPENDER.either);
     });
 
     it('should approve after token transfer', () => {
-      token._transfer(Z_OWNER, Z_SPENDER, TOKENID_1);
+      token._transfer(OWNER.either, SPENDER.either, TOKENID_1);
 
-      token.as(SPENDER).approve(Z_OTHER, TOKENID_1);
-      expect(token.getApproved(TOKENID_1)).toEqual(Z_OTHER);
+      token.privateState.injectSecretKey(SPENDER.secretKey);
+      token.approve(OTHER.either, TOKENID_1);
+      expect(token.getApproved(TOKENID_1)).toEqual(OTHER.either);
     });
 
     it('should approve after token burn and remint', () => {
       token._burn(TOKENID_1);
-      token._mint(Z_OWNER, TOKENID_1);
-      token.as(OWNER).approve(Z_SPENDER, TOKENID_1);
-      expect(token.getApproved(TOKENID_1)).toEqual(Z_SPENDER);
+      token._mint(OWNER.either, TOKENID_1);
+
+      token.privateState.injectSecretKey(OWNER.secretKey);
+      token.approve(SPENDER.either, TOKENID_1);
+      expect(token.getApproved(TOKENID_1)).toEqual(SPENDER.either);
     });
 
     it('should approve with very long token ID', () => {
       const longTokenId = BigInt('18446744073709551615');
-      token._mint(Z_OWNER, longTokenId);
-      token.as(OWNER).approve(Z_SPENDER, longTokenId);
-      expect(token.getApproved(longTokenId)).toEqual(Z_SPENDER);
+      token._mint(OWNER.either, longTokenId);
+
+      token.privateState.injectSecretKey(OWNER.secretKey);
+      token.approve(SPENDER.either, longTokenId);
+      expect(token.getApproved(longTokenId)).toEqual(SPENDER.either);
     });
   });
 
   describe('getApproved', () => {
     beforeEach(() => {
-      token._mint(Z_OWNER, TOKENID_1);
+      token._mint(OWNER.either, TOKENID_1);
     });
 
     it('should throw if token does not exist', () => {
       expect(() => {
         token.getApproved(NON_EXISTENT_TOKEN);
-      }).toThrow('NonFungibleToken: Nonexistent Token');
+      }).toThrow('NonFungibleToken: nonexistent token');
     });
 
     it('should throw if token has been burned', () => {
       token._burn(TOKENID_1);
       expect(() => {
         token.getApproved(TOKENID_1);
-      }).toThrow('NonFungibleToken: Nonexistent Token');
+      }).toThrow('NonFungibleToken: nonexistent token');
     });
 
     it('should get current approved spender', () => {
-      token.as(OWNER).approve(Z_OWNER, TOKENID_1);
-      expect(token.getApproved(TOKENID_1)).toEqual(Z_OWNER);
+      token.privateState.injectSecretKey(OWNER.secretKey);
+      token.approve(OWNER.either, TOKENID_1);
+      expect(token.getApproved(TOKENID_1)).toEqual(OWNER.either);
     });
 
-    it('should return zero key if approval not set', () => {
-      expect(token.getApproved(TOKENID_1)).toEqual(ZERO_KEY);
+    it('should return zero if approval not set', () => {
+      expect(token.getApproved(TOKENID_1)).toEqual(ZERO_ACCOUNT);
     });
   });
 
   describe('setApprovalForAll', () => {
     it('should not approve zero address', () => {
-      token._mint(Z_OWNER, TOKENID_1);
+      token._mint(OWNER.either, TOKENID_1);
+      token.privateState.injectSecretKey(OWNER.secretKey);
+
       expect(() => {
-        token.as(OWNER).setApprovalForAll(ZERO_KEY, true);
-      }).toThrow('NonFungibleToken: Invalid Operator');
+        token.setApprovalForAll(ZERO_ACCOUNT, true);
+      }).toThrow('NonFungibleToken: invalid operator');
     });
 
     it('should set operator', () => {
-      token._mint(Z_OWNER, TOKENID_1);
+      token._mint(OWNER.either, TOKENID_1);
+      token.privateState.injectSecretKey(OWNER.secretKey);
 
-      token.as(OWNER).setApprovalForAll(Z_SPENDER, true);
-      expect(token.isApprovedForAll(Z_OWNER, Z_SPENDER)).toBe(true);
+      token.setApprovalForAll(SPENDER.either, true);
+      expect(token.isApprovedForAll(OWNER.either, SPENDER.either)).toBe(true);
     });
 
     it('should allow operator to manage owner tokens', () => {
-      token._mint(Z_OWNER, TOKENID_1);
-      token._mint(Z_OWNER, TOKENID_2);
-      token._mint(Z_OWNER, TOKENID_3);
-      token.as(OWNER).setApprovalForAll(Z_SPENDER, true);
+      token._mint(OWNER.either, TOKENID_1);
+      token._mint(OWNER.either, TOKENID_2);
+      token._mint(OWNER.either, TOKENID_3);
 
-      token.as(SPENDER).transferFrom(Z_OWNER, Z_SPENDER, TOKENID_1);
-      expect(token.ownerOf(TOKENID_1)).toEqual(Z_SPENDER);
+      token.privateState.injectSecretKey(OWNER.secretKey);
+      token.setApprovalForAll(SPENDER.either, true);
 
-      token.approve(Z_OTHER, TOKENID_2);
-      expect(token.getApproved(TOKENID_2)).toEqual(Z_OTHER);
+      token.privateState.injectSecretKey(SPENDER.secretKey);
+      token.transferFrom(OWNER.either, SPENDER.either, TOKENID_1);
+      expect(token.ownerOf(TOKENID_1)).toEqual(SPENDER.either);
 
-      token.approve(Z_SPENDER, TOKENID_3);
-      expect(token.getApproved(TOKENID_3)).toEqual(Z_SPENDER);
+      token.approve(OTHER.either, TOKENID_2);
+      expect(token.getApproved(TOKENID_2)).toEqual(OTHER.either);
+
+      token.approve(SPENDER.either, TOKENID_3);
+      expect(token.getApproved(TOKENID_3)).toEqual(SPENDER.either);
     });
 
     it('should revoke approval for all', () => {
-      token._mint(Z_OWNER, TOKENID_1);
-      token.as(OWNER).setApprovalForAll(Z_SPENDER, true);
-      expect(token.isApprovedForAll(Z_OWNER, Z_SPENDER)).toBe(true);
+      token._mint(OWNER.either, TOKENID_1);
+      token.privateState.injectSecretKey(OWNER.secretKey);
 
-      token.as(OWNER).setApprovalForAll(Z_SPENDER, false);
-      expect(token.isApprovedForAll(Z_OWNER, Z_SPENDER)).toBe(false);
+      token.setApprovalForAll(SPENDER.either, true);
+      expect(token.isApprovedForAll(OWNER.either, SPENDER.either)).toBe(true);
 
+      token.setApprovalForAll(SPENDER.either, false);
+      expect(token.isApprovedForAll(OWNER.either, SPENDER.either)).toBe(false);
+
+      token.privateState.injectSecretKey(SPENDER.secretKey);
       expect(() => {
-        token.as(SPENDER).approve(Z_SPENDER, TOKENID_1);
-      }).toThrow('NonFungibleToken: Invalid Approver');
+        token.approve(SPENDER.either, TOKENID_1);
+      }).toThrow('NonFungibleToken: invalid approver');
     });
 
     it('should set approval for all to same address multiple times', () => {
-      token._mint(Z_OWNER, TOKENID_1);
-      token.as(OWNER).setApprovalForAll(Z_SPENDER, true);
-      token.as(OWNER).setApprovalForAll(Z_SPENDER, true);
-      expect(token.isApprovedForAll(Z_OWNER, Z_SPENDER)).toBe(true);
+      token._mint(OWNER.either, TOKENID_1);
+      token.privateState.injectSecretKey(OWNER.secretKey);
+
+      token.setApprovalForAll(SPENDER.either, true);
+      token.setApprovalForAll(SPENDER.either, true);
+      expect(token.isApprovedForAll(OWNER.either, SPENDER.either)).toBe(true);
     });
 
     it('should set approval for all after token transfer', () => {
-      token._mint(Z_OWNER, TOKENID_1);
-      token._transfer(Z_OWNER, Z_SPENDER, TOKENID_1);
+      token._mint(OWNER.either, TOKENID_1);
+      token._transfer(OWNER.either, SPENDER.either, TOKENID_1);
 
-      token.as(SPENDER).setApprovalForAll(Z_OTHER, true);
-      expect(token.isApprovedForAll(Z_SPENDER, Z_OTHER)).toBe(true);
+      token.privateState.injectSecretKey(SPENDER.secretKey);
+      token.setApprovalForAll(OTHER.either, true);
+      expect(token.isApprovedForAll(SPENDER.either, OTHER.either)).toBe(true);
     });
 
     it('should set approval for all with multiple operators', () => {
-      token._mint(Z_OWNER, TOKENID_1);
-      token.as(OWNER).setApprovalForAll(Z_SPENDER, true);
-      token.as(OWNER).setApprovalForAll(Z_OTHER, true);
-      expect(token.isApprovedForAll(Z_OWNER, Z_SPENDER)).toBe(true);
-      expect(token.isApprovedForAll(Z_OWNER, Z_OTHER)).toBe(true);
+      token._mint(OWNER.either, TOKENID_1);
+      token.privateState.injectSecretKey(OWNER.secretKey);
+
+      token.setApprovalForAll(SPENDER.either, true);
+      token.setApprovalForAll(OTHER.either, true);
+      expect(token.isApprovedForAll(OWNER.either, SPENDER.either)).toBe(true);
+      expect(token.isApprovedForAll(OWNER.either, OTHER.either)).toBe(true);
     });
 
     it('should set approval for all with very long token IDs', () => {
       const longTokenId = BigInt('18446744073709551615');
-      token._mint(Z_OWNER, longTokenId);
-      token.as(OWNER).setApprovalForAll(Z_SPENDER, true);
-      expect(token.isApprovedForAll(Z_OWNER, Z_SPENDER)).toBe(true);
+      token._mint(OWNER.either, longTokenId);
+      token.privateState.injectSecretKey(OWNER.secretKey);
+
+      token.setApprovalForAll(SPENDER.either, true);
+      expect(token.isApprovedForAll(OWNER.either, SPENDER.either)).toBe(true);
     });
   });
 
   describe('isApprovedForAll', () => {
     it('should return false if approval not set', () => {
-      expect(token.isApprovedForAll(Z_OWNER, Z_SPENDER)).toBe(false);
+      expect(token.isApprovedForAll(OWNER.either, SPENDER.either)).toBe(false);
     });
 
     it('should return true if approval set', () => {
-      token._mint(Z_OWNER, TOKENID_1);
-      token.as(OWNER).setApprovalForAll(Z_SPENDER, true);
-      expect(token.isApprovedForAll(Z_OWNER, Z_SPENDER)).toBe(true);
+      token._mint(OWNER.either, TOKENID_1);
+      token.privateState.injectSecretKey(OWNER.secretKey);
+      token.setApprovalForAll(SPENDER.either, true);
+      expect(token.isApprovedForAll(OWNER.either, SPENDER.either)).toBe(true);
+    });
+
+    it('should return correct result with non-canonical owner lookup', () => {
+      token._mint(OWNER.either, TOKENID_1);
+      token.privateState.injectSecretKey(OWNER.secretKey);
+      token.setApprovalForAll(SPENDER.either, true);
+
+      const nonCanonical = {
+        is_left: true,
+        left: OWNER.accountId,
+        right: utils.encodeToAddress('JUNK_DATA'),
+      };
+
+      expect(token.isApprovedForAll(nonCanonical, SPENDER.either)).toBe(true);
+    });
+
+    it('should return correct result with non-canonical operator lookup', () => {
+      token._mint(OWNER.either, TOKENID_1);
+      token.privateState.injectSecretKey(OWNER.secretKey);
+      token.setApprovalForAll(SPENDER.either, true);
+
+      const nonCanonical = {
+        is_left: true,
+        left: SPENDER.accountId,
+        right: utils.encodeToAddress('JUNK_DATA'),
+      };
+
+      expect(token.isApprovedForAll(OWNER.either, nonCanonical)).toBe(true);
     });
   });
 
   describe('transferFrom', () => {
     beforeEach(() => {
-      token._mint(Z_OWNER, TOKENID_1);
+      token._mint(OWNER.either, TOKENID_1);
     });
 
     it('should not transfer to ContractAddress', () => {
+      token.privateState.injectSecretKey(OWNER.secretKey);
       expect(() => {
-        token.transferFrom(Z_OWNER, SOME_CONTRACT, TOKENID_1);
-      }).toThrow('NonFungibleToken: Unsafe Transfer');
+        token.transferFrom(OWNER.either, SOME_CONTRACT, TOKENID_1);
+      }).toThrow('NonFungibleToken: unsafe transfer');
     });
 
     it('should not transfer to zero address', () => {
+      token.privateState.injectSecretKey(OWNER.secretKey);
       expect(() => {
-        token.transferFrom(Z_OWNER, ZERO_KEY, TOKENID_1);
-      }).toThrow('NonFungibleToken: Invalid Receiver');
+        token.transferFrom(OWNER.either, ZERO_ACCOUNT, TOKENID_1);
+      }).toThrow('NonFungibleToken: invalid receiver');
     });
 
     it('should not transfer from zero address', () => {
+      token.privateState.injectSecretKey(OWNER.secretKey);
       expect(() => {
-        token.transferFrom(ZERO_KEY, Z_SPENDER, TOKENID_1);
-      }).toThrow('NonFungibleToken: Incorrect Owner');
+        token.transferFrom(ZERO_ACCOUNT, SPENDER.either, TOKENID_1);
+      }).toThrow('NonFungibleToken: incorrect owner');
     });
 
     it('should not transfer from unauthorized', () => {
+      token.privateState.injectSecretKey(UNAUTHORIZED.secretKey);
       expect(() => {
-        token.as(UNAUTHORIZED).transferFrom(Z_OWNER, Z_UNAUTHORIZED, TOKENID_1);
-      }).toThrow('NonFungibleToken: Insufficient Approval');
+        token.transferFrom(OWNER.either, UNAUTHORIZED.either, TOKENID_1);
+      }).toThrow('NonFungibleToken: insufficient approval');
     });
 
     it('should not transfer token that has not been minted', () => {
+      token.privateState.injectSecretKey(OWNER.secretKey);
       expect(() => {
-        token.as(OWNER).transferFrom(Z_OWNER, Z_SPENDER, NON_EXISTENT_TOKEN);
-      }).toThrow('NonFungibleToken: Nonexistent Token');
+        token.transferFrom(OWNER.either, SPENDER.either, NON_EXISTENT_TOKEN);
+      }).toThrow('NonFungibleToken: nonexistent token');
     });
 
     it('should transfer token without approvers or operators', () => {
-      token.as(OWNER).transferFrom(Z_OWNER, Z_RECIPIENT, TOKENID_1);
-      expect(token.ownerOf(TOKENID_1)).toEqual(Z_RECIPIENT);
+      token.privateState.injectSecretKey(OWNER.secretKey);
+      token.transferFrom(OWNER.either, RECIPIENT.either, TOKENID_1);
+      expect(token.ownerOf(TOKENID_1)).toEqual(RECIPIENT.either);
     });
 
     it('should transfer token via approved operator', () => {
-      token.as(OWNER).approve(Z_SPENDER, TOKENID_1);
+      token.privateState.injectSecretKey(OWNER.secretKey);
+      token.approve(SPENDER.either, TOKENID_1);
 
-      token.as(SPENDER).transferFrom(Z_OWNER, Z_SPENDER, TOKENID_1);
-      expect(token.ownerOf(TOKENID_1)).toEqual(Z_SPENDER);
+      token.privateState.injectSecretKey(SPENDER.secretKey);
+      token.transferFrom(OWNER.either, SPENDER.either, TOKENID_1);
+      expect(token.ownerOf(TOKENID_1)).toEqual(SPENDER.either);
     });
 
     it('should transfer token via approvedForAll operator', () => {
-      token.as(OWNER).setApprovalForAll(Z_SPENDER, true);
+      token.privateState.injectSecretKey(OWNER.secretKey);
+      token.setApprovalForAll(SPENDER.either, true);
 
-      token.as(SPENDER).transferFrom(Z_OWNER, Z_SPENDER, TOKENID_1);
-      expect(token.ownerOf(TOKENID_1)).toEqual(Z_SPENDER);
+      token.privateState.injectSecretKey(SPENDER.secretKey);
+      token.transferFrom(OWNER.either, SPENDER.either, TOKENID_1);
+      expect(token.ownerOf(TOKENID_1)).toEqual(SPENDER.either);
     });
 
     it('should allow transfer to same address', () => {
-      token._approve(Z_SPENDER, TOKENID_1, Z_OWNER);
-      token._setApprovalForAll(Z_OWNER, Z_SPENDER, true);
+      token._approve(SPENDER.either, TOKENID_1, OWNER.either);
+      token._setApprovalForAll(OWNER.either, SPENDER.either, true);
 
+      token.privateState.injectSecretKey(OWNER.secretKey);
       expect(() => {
-        token.as(OWNER).transferFrom(Z_OWNER, Z_OWNER, TOKENID_1);
+        token.transferFrom(OWNER.either, OWNER.either, TOKENID_1);
       }).not.toThrow();
-      expect(token.ownerOf(TOKENID_1)).toEqual(Z_OWNER);
-      expect(token.balanceOf(Z_OWNER)).toEqual(1n);
-      expect(token.getApproved(TOKENID_1)).toEqual(ZERO_KEY);
-      expect(token._isAuthorized(Z_OWNER, Z_SPENDER, TOKENID_1)).toEqual(true);
+      expect(token.ownerOf(TOKENID_1)).toEqual(OWNER.either);
+      expect(token.balanceOf(OWNER.either)).toEqual(1n);
+      expect(token.getApproved(TOKENID_1)).toEqual(ZERO_ACCOUNT);
+      expect(token._isAuthorized(OWNER.either, SPENDER.either, TOKENID_1)).toEqual(true);
     });
 
     it('should not transfer after approval revocation', () => {
-      token.as(OWNER).approve(Z_SPENDER, TOKENID_1);
-      token.as(OWNER).approve(ZERO_KEY, TOKENID_1);
+      token.privateState.injectSecretKey(OWNER.secretKey);
+      token.approve(SPENDER.either, TOKENID_1);
+      token.approve(ZERO_ACCOUNT, TOKENID_1);
 
+      token.privateState.injectSecretKey(SPENDER.secretKey);
       expect(() => {
-        token.as(SPENDER).transferFrom(Z_OWNER, Z_SPENDER, TOKENID_1);
-      }).toThrow('NonFungibleToken: Insufficient Approval');
+        token.transferFrom(OWNER.either, SPENDER.either, TOKENID_1);
+      }).toThrow('NonFungibleToken: insufficient approval');
     });
 
     it('should not transfer after approval for all revocation', () => {
-      token.as(OWNER).setApprovalForAll(Z_SPENDER, true);
-      token.as(OWNER).setApprovalForAll(Z_SPENDER, false);
+      token.privateState.injectSecretKey(OWNER.secretKey);
+      token.setApprovalForAll(SPENDER.either, true);
+      token.setApprovalForAll(SPENDER.either, false);
 
+      token.privateState.injectSecretKey(SPENDER.secretKey);
       expect(() => {
-        token.as(SPENDER).transferFrom(Z_OWNER, Z_SPENDER, TOKENID_1);
-      }).toThrow('NonFungibleToken: Insufficient Approval');
+        token.transferFrom(OWNER.either, SPENDER.either, TOKENID_1);
+      }).toThrow('NonFungibleToken: insufficient approval');
     });
 
     it('should transfer multiple tokens in sequence', () => {
-      token._mint(Z_OWNER, TOKENID_2);
-      token._mint(Z_OWNER, TOKENID_3);
+      token._mint(OWNER.either, TOKENID_2);
+      token._mint(OWNER.either, TOKENID_3);
 
-      token.as(OWNER).approve(Z_SPENDER, TOKENID_1);
-      token.as(OWNER).approve(Z_SPENDER, TOKENID_2);
-      token.as(OWNER).approve(Z_SPENDER, TOKENID_3);
+      token.privateState.injectSecretKey(OWNER.secretKey);
+      token.approve(SPENDER.either, TOKENID_1);
+      token.approve(SPENDER.either, TOKENID_2);
+      token.approve(SPENDER.either, TOKENID_3);
 
-      token.setPersistentCaller(SPENDER);
-      token.transferFrom(Z_OWNER, Z_SPENDER, TOKENID_1);
-      token.transferFrom(Z_OWNER, Z_SPENDER, TOKENID_2);
-      token.transferFrom(Z_OWNER, Z_SPENDER, TOKENID_3);
+      token.privateState.injectSecretKey(SPENDER.secretKey);
+      token.transferFrom(OWNER.either, SPENDER.either, TOKENID_1);
+      token.transferFrom(OWNER.either, SPENDER.either, TOKENID_2);
+      token.transferFrom(OWNER.either, SPENDER.either, TOKENID_3);
 
-      expect(token.ownerOf(TOKENID_1)).toEqual(Z_SPENDER);
-      expect(token.ownerOf(TOKENID_2)).toEqual(Z_SPENDER);
-      expect(token.ownerOf(TOKENID_3)).toEqual(Z_SPENDER);
+      expect(token.ownerOf(TOKENID_1)).toEqual(SPENDER.either);
+      expect(token.ownerOf(TOKENID_2)).toEqual(SPENDER.either);
+      expect(token.ownerOf(TOKENID_3)).toEqual(SPENDER.either);
     });
 
     it('should transfer with very long token IDs', () => {
       const longTokenId = BigInt('18446744073709551615');
-      token._mint(Z_OWNER, longTokenId);
-      token.as(OWNER).approve(Z_SPENDER, longTokenId);
+      token._mint(OWNER.either, longTokenId);
 
-      token.as(SPENDER).transferFrom(Z_OWNER, Z_SPENDER, longTokenId);
-      expect(token.ownerOf(longTokenId)).toEqual(Z_SPENDER);
+      token.privateState.injectSecretKey(OWNER.secretKey);
+      token.approve(SPENDER.either, longTokenId);
+
+      token.privateState.injectSecretKey(SPENDER.secretKey);
+      token.transferFrom(OWNER.either, SPENDER.either, longTokenId);
+      expect(token.ownerOf(longTokenId)).toEqual(SPENDER.either);
     });
 
     it('should revoke approval after transferFrom', () => {
-      token.as(OWNER).approve(Z_SPENDER, TOKENID_1);
-      token._setApprovalForAll(Z_OWNER, Z_SPENDER, true);
+      token.privateState.injectSecretKey(OWNER.secretKey);
+      token.approve(SPENDER.either, TOKENID_1);
+      token._setApprovalForAll(OWNER.either, SPENDER.either, true);
 
-      token.as(OWNER).transferFrom(Z_OWNER, Z_OTHER, TOKENID_1);
-      expect(token.getApproved(TOKENID_1)).toEqual(ZERO_KEY);
-      expect(token._isAuthorized(Z_OTHER, Z_SPENDER, TOKENID_1)).toBe(false);
+      token.transferFrom(OWNER.either, OTHER.either, TOKENID_1);
+      expect(token.getApproved(TOKENID_1)).toEqual(ZERO_ACCOUNT);
+      expect(token._isAuthorized(OTHER.either, SPENDER.either, TOKENID_1)).toBe(false);
 
+      token.privateState.injectSecretKey(SPENDER.secretKey);
       expect(() => {
-        token.as(SPENDER).approve(Z_UNAUTHORIZED, TOKENID_1);
-      }).toThrow('NonFungibleToken: Invalid Approver');
+        token.approve(UNAUTHORIZED.either, TOKENID_1);
+      }).toThrow('NonFungibleToken: invalid approver');
       expect(() => {
-        token.as(SPENDER).transferFrom(Z_OTHER, Z_UNAUTHORIZED, TOKENID_1);
-      }).toThrow('NonFungibleToken: Insufficient Approval');
+        token.transferFrom(OTHER.either, UNAUTHORIZED.either, TOKENID_1);
+      }).toThrow('NonFungibleToken: insufficient approval');
     });
   });
 
@@ -517,158 +684,195 @@ describe('NonFungibleToken', () => {
     it('should throw if token has not been minted', () => {
       expect(() => {
         token._requireOwned(TOKENID_1);
-      }).toThrow('NonFungibleToken: Nonexistent Token');
+      }).toThrow('NonFungibleToken: nonexistent token');
     });
 
     it('should throw if token has been burned', () => {
-      token._mint(Z_OWNER, TOKENID_1);
+      token._mint(OWNER.either, TOKENID_1);
       token._burn(TOKENID_1);
       expect(() => {
         token._requireOwned(TOKENID_1);
-      }).toThrow('NonFungibleToken: Nonexistent Token');
+      }).toThrow('NonFungibleToken: nonexistent token');
     });
 
     it('should return correct owner', () => {
-      token._mint(Z_OWNER, TOKENID_1);
-      expect(token._requireOwned(TOKENID_1)).toEqual(Z_OWNER);
+      token._mint(OWNER.either, TOKENID_1);
+      expect(token._requireOwned(TOKENID_1)).toEqual(OWNER.either);
     });
   });
 
   describe('_ownerOf', () => {
     it('should return zero address if token does not exist', () => {
-      expect(token._ownerOf(NON_EXISTENT_TOKEN)).toEqual(ZERO_KEY);
+      expect(token._ownerOf(NON_EXISTENT_TOKEN)).toEqual(ZERO_ACCOUNT);
     });
 
     it('should return owner of token', () => {
-      token._mint(Z_OWNER, TOKENID_1);
-      expect(token._ownerOf(TOKENID_1)).toEqual(Z_OWNER);
+      token._mint(OWNER.either, TOKENID_1);
+      expect(token._ownerOf(TOKENID_1)).toEqual(OWNER.either);
     });
   });
 
   describe('_approve', () => {
     it('should approve if auth is owner', () => {
-      token._mint(Z_OWNER, TOKENID_1);
-      token._approve(Z_SPENDER, TOKENID_1, Z_OWNER);
-      expect(token.getApproved(TOKENID_1)).toEqual(Z_SPENDER);
+      token._mint(OWNER.either, TOKENID_1);
+      token._approve(SPENDER.either, TOKENID_1, OWNER.either);
+      expect(token.getApproved(TOKENID_1)).toEqual(SPENDER.either);
     });
 
     it('should approve if auth is approved for all', () => {
-      token._mint(Z_OWNER, TOKENID_1);
-      token.as(OWNER).setApprovalForAll(Z_SPENDER, true);
-      token._approve(Z_SPENDER, TOKENID_1, Z_SPENDER);
-      expect(token.getApproved(TOKENID_1)).toEqual(Z_SPENDER);
+      token._mint(OWNER.either, TOKENID_1);
+      token.privateState.injectSecretKey(OWNER.secretKey);
+      token.setApprovalForAll(SPENDER.either, true);
+
+      token._approve(SPENDER.either, TOKENID_1, SPENDER.either);
+      expect(token.getApproved(TOKENID_1)).toEqual(SPENDER.either);
     });
 
     it('should throw if auth is unauthorized', () => {
-      token._mint(Z_OWNER, TOKENID_1);
+      token._mint(OWNER.either, TOKENID_1);
       expect(() => {
-        token._approve(Z_SPENDER, TOKENID_1, Z_UNAUTHORIZED);
-      }).toThrow('NonFungibleToken: Invalid Approver');
+        token._approve(SPENDER.either, TOKENID_1, UNAUTHORIZED.either);
+      }).toThrow('NonFungibleToken: invalid approver');
     });
 
     it('should approve if auth is zero address', () => {
-      token._mint(Z_OWNER, TOKENID_1);
-      token._approve(Z_SPENDER, TOKENID_1, ZERO_KEY);
-      expect(token.getApproved(TOKENID_1)).toEqual(Z_SPENDER);
+      token._mint(OWNER.either, TOKENID_1);
+      token._approve(SPENDER.either, TOKENID_1, ZERO_ACCOUNT);
+      expect(token.getApproved(TOKENID_1)).toEqual(SPENDER.either);
+    });
+
+    it('should canonicalize approved address', () => {
+      token._mint(OWNER.either, TOKENID_1);
+
+      const nonCanonical = {
+        is_left: true,
+        left: SPENDER.accountId,
+        right: utils.encodeToAddress('JUNK_DATA'),
+      };
+
+      token._approve(nonCanonical, TOKENID_1, OWNER.either);
+      expect(token.getApproved(TOKENID_1)).toEqual(SPENDER.either);
     });
   });
 
   describe('_checkAuthorized', () => {
     it('should throw if token not minted', () => {
       expect(() => {
-        token._checkAuthorized(ZERO_KEY, Z_OWNER, TOKENID_1);
-      }).toThrow('NonFungibleToken: Nonexistent Token');
+        token._checkAuthorized(ZERO_ACCOUNT, OWNER.either, TOKENID_1);
+      }).toThrow('NonFungibleToken: nonexistent token');
     });
 
     it('should throw if unauthorized', () => {
-      token._mint(Z_OWNER, TOKENID_1);
+      token._mint(OWNER.either, TOKENID_1);
       expect(() => {
-        token._checkAuthorized(Z_OWNER, Z_UNAUTHORIZED, TOKENID_1);
-      }).toThrow('NonFungibleToken: Insufficient Approval');
+        token._checkAuthorized(OWNER.either, UNAUTHORIZED.either, TOKENID_1);
+      }).toThrow('NonFungibleToken: insufficient approval');
     });
 
     it('should not throw if approved', () => {
-      token._mint(Z_OWNER, TOKENID_1);
-      token.as(OWNER).approve(Z_SPENDER, TOKENID_1);
-      token._checkAuthorized(Z_OWNER, Z_SPENDER, TOKENID_1);
+      token._mint(OWNER.either, TOKENID_1);
+      token.privateState.injectSecretKey(OWNER.secretKey);
+      token.approve(SPENDER.either, TOKENID_1);
+      token._checkAuthorized(OWNER.either, SPENDER.either, TOKENID_1);
     });
 
     it('should not throw if approvedForAll', () => {
-      token._mint(Z_OWNER, TOKENID_1);
-      token.as(OWNER).setApprovalForAll(Z_SPENDER, true);
-      token._checkAuthorized(Z_OWNER, Z_SPENDER, TOKENID_1);
+      token._mint(OWNER.either, TOKENID_1);
+      token.privateState.injectSecretKey(OWNER.secretKey);
+      token.setApprovalForAll(SPENDER.either, true);
+      token._checkAuthorized(OWNER.either, SPENDER.either, TOKENID_1);
     });
   });
 
   describe('_isAuthorized', () => {
     beforeEach(() => {
-      token._mint(Z_OWNER, TOKENID_1);
+      token._mint(OWNER.either, TOKENID_1);
     });
 
     it('should return true if spender is authorized', () => {
-      token.as(OWNER).approve(Z_SPENDER, TOKENID_1);
-      expect(token._isAuthorized(Z_OWNER, Z_SPENDER, TOKENID_1)).toBe(true);
+      token.privateState.injectSecretKey(OWNER.secretKey);
+      token.approve(SPENDER.either, TOKENID_1);
+      expect(token._isAuthorized(OWNER.either, SPENDER.either, TOKENID_1)).toBe(true);
     });
 
     it('should return true if spender is authorized for all', () => {
-      token.as(OWNER).setApprovalForAll(Z_SPENDER, true);
-      expect(token._isAuthorized(Z_OWNER, Z_SPENDER, TOKENID_1)).toBe(true);
+      token.privateState.injectSecretKey(OWNER.secretKey);
+      token.setApprovalForAll(SPENDER.either, true);
+      expect(token._isAuthorized(OWNER.either, SPENDER.either, TOKENID_1)).toBe(true);
     });
 
     it('should return true if spender is owner', () => {
-      expect(token._isAuthorized(Z_OWNER, Z_OWNER, TOKENID_1)).toBe(true);
+      expect(token._isAuthorized(OWNER.either, OWNER.either, TOKENID_1)).toBe(true);
     });
 
     it('should return false if spender is zero address', () => {
-      expect(token._isAuthorized(Z_OWNER, ZERO_KEY, TOKENID_1)).toBe(false);
+      expect(token._isAuthorized(OWNER.either, ZERO_ACCOUNT, TOKENID_1)).toBe(false);
     });
 
     it('should return false for unauthorized', () => {
-      expect(token._isAuthorized(Z_OWNER, Z_UNAUTHORIZED, TOKENID_1)).toBe(
-        false,
-      );
+      expect(token._isAuthorized(OWNER.either, UNAUTHORIZED.either, TOKENID_1)).toBe(false);
     });
   });
 
   describe('_getApproved', () => {
     beforeEach(() => {
-      token._mint(Z_OWNER, TOKENID_1);
+      token._mint(OWNER.either, TOKENID_1);
     });
 
     it('should return zero address if token is not minted', () => {
-      expect(token._getApproved(NON_EXISTENT_TOKEN)).toEqual(ZERO_KEY);
+      expect(token._getApproved(NON_EXISTENT_TOKEN)).toEqual(ZERO_ACCOUNT);
     });
 
     it('should return approved address', () => {
-      token.as(OWNER).approve(Z_SPENDER, TOKENID_1);
-      expect(token._getApproved(TOKENID_1)).toEqual(Z_SPENDER);
+      token.privateState.injectSecretKey(OWNER.secretKey);
+      token.approve(SPENDER.either, TOKENID_1);
+      expect(token._getApproved(TOKENID_1)).toEqual(SPENDER.either);
     });
 
     it('should return zero address if no approvals', () => {
-      expect(token._getApproved(TOKENID_1)).toEqual(ZERO_KEY);
+      expect(token._getApproved(TOKENID_1)).toEqual(ZERO_ACCOUNT);
     });
   });
 
   describe('_setApprovalForAll', () => {
     it('should approve operator', () => {
-      token._mint(Z_OWNER, TOKENID_1);
-      token._setApprovalForAll(Z_OWNER, Z_SPENDER, true);
-      expect(token.isApprovedForAll(Z_OWNER, Z_SPENDER)).toBe(true);
+      token._mint(OWNER.either, TOKENID_1);
+      token._setApprovalForAll(OWNER.either, SPENDER.either, true);
+      expect(token.isApprovedForAll(OWNER.either, SPENDER.either)).toBe(true);
     });
 
     it('should revoke operator approval', () => {
-      token._mint(Z_OWNER, TOKENID_1);
-      token.as(OWNER).setApprovalForAll(Z_SPENDER, true);
-      expect(token.isApprovedForAll(Z_OWNER, Z_SPENDER)).toBe(true);
+      token._mint(OWNER.either, TOKENID_1);
+      token.privateState.injectSecretKey(OWNER.secretKey);
+      token.setApprovalForAll(SPENDER.either, true);
+      expect(token.isApprovedForAll(OWNER.either, SPENDER.either)).toBe(true);
 
-      token._setApprovalForAll(Z_OWNER, Z_SPENDER, false);
-      expect(token.isApprovedForAll(Z_OWNER, Z_SPENDER)).toBe(false);
+      token._setApprovalForAll(OWNER.either, SPENDER.either, false);
+      expect(token.isApprovedForAll(OWNER.either, SPENDER.either)).toBe(false);
     });
 
     it('should throw if operator is zero address', () => {
       expect(() => {
-        token._setApprovalForAll(Z_OWNER, ZERO_KEY, true);
-      }).toThrow('NonFungibleToken: Invalid Operator');
+        token._setApprovalForAll(OWNER.either, ZERO_ACCOUNT, true);
+      }).toThrow('NonFungibleToken: invalid operator');
+    });
+
+    it('should canonicalize owner and operator', () => {
+      token._mint(OWNER.either, TOKENID_1);
+
+      const nonCanonicalOwner = {
+        is_left: true,
+        left: OWNER.accountId,
+        right: utils.encodeToAddress('JUNK_DATA'),
+      };
+      const nonCanonicalOp = {
+        is_left: true,
+        left: SPENDER.accountId,
+        right: utils.encodeToAddress('JUNK_DATA'),
+      };
+
+      token._setApprovalForAll(nonCanonicalOwner, nonCanonicalOp, true);
+      expect(token.isApprovedForAll(OWNER.either, SPENDER.either)).toBe(true);
     });
   });
 
@@ -676,114 +880,128 @@ describe('NonFungibleToken', () => {
     it('should not mint to ContractAddress', () => {
       expect(() => {
         token._mint(SOME_CONTRACT, TOKENID_1);
-      }).toThrow('NonFungibleToken: Unsafe Transfer');
+      }).toThrow('NonFungibleToken: unsafe transfer');
     });
 
     it('should not mint to zero address', () => {
       expect(() => {
-        token._mint(ZERO_KEY, TOKENID_1);
-      }).toThrow('NonFungibleToken: Invalid Receiver');
+        token._mint(ZERO_ACCOUNT, TOKENID_1);
+      }).toThrow('NonFungibleToken: invalid receiver');
     });
 
     it('should not mint a token that already exists', () => {
-      token._mint(Z_OWNER, TOKENID_1);
+      token._mint(OWNER.either, TOKENID_1);
       expect(() => {
-        token._mint(Z_OWNER, TOKENID_1);
-      }).toThrow('NonFungibleToken: Invalid Sender');
+        token._mint(OWNER.either, TOKENID_1);
+      }).toThrow('NonFungibleToken: invalid sender');
     });
 
     it('should mint token', () => {
-      token._mint(Z_OWNER, TOKENID_1);
-      expect(token.ownerOf(TOKENID_1)).toEqual(Z_OWNER);
-      expect(token.balanceOf(Z_OWNER)).toEqual(1n);
+      token._mint(OWNER.either, TOKENID_1);
+      expect(token.ownerOf(TOKENID_1)).toEqual(OWNER.either);
+      expect(token.balanceOf(OWNER.either)).toEqual(1n);
 
-      token._mint(Z_OWNER, TOKENID_2);
-      token._mint(Z_OWNER, TOKENID_3);
-      expect(token.balanceOf(Z_OWNER)).toEqual(3n);
+      token._mint(OWNER.either, TOKENID_2);
+      token._mint(OWNER.either, TOKENID_3);
+      expect(token.balanceOf(OWNER.either)).toEqual(3n);
     });
 
     it('should mint multiple tokens in sequence', () => {
       for (let i = 0; i < 10; i++) {
-        token._mint(Z_OWNER, TOKENID_1 + BigInt(i));
+        token._mint(OWNER.either, TOKENID_1 + BigInt(i));
       }
-      expect(token.balanceOf(Z_OWNER)).toEqual(10n);
+      expect(token.balanceOf(OWNER.either)).toEqual(10n);
     });
 
     it('should mint with very long token IDs', () => {
       const longTokenId = BigInt('18446744073709551615');
-      token._mint(Z_OWNER, longTokenId);
-      expect(token.ownerOf(longTokenId)).toEqual(Z_OWNER);
+      token._mint(OWNER.either, longTokenId);
+      expect(token.ownerOf(longTokenId)).toEqual(OWNER.either);
     });
 
     it('should mint after burning', () => {
-      token._mint(Z_OWNER, TOKENID_1);
+      token._mint(OWNER.either, TOKENID_1);
       token._burn(TOKENID_1);
-      token._mint(Z_OWNER, TOKENID_1);
-      expect(token.ownerOf(TOKENID_1)).toEqual(Z_OWNER);
+      token._mint(OWNER.either, TOKENID_1);
+      expect(token.ownerOf(TOKENID_1)).toEqual(OWNER.either);
     });
 
     it('should mint with special characters in metadata', () => {
-      token._mint(Z_OWNER, TOKENID_1);
+      token._mint(OWNER.either, TOKENID_1);
       token._setTokenURI(TOKENID_1, '!@#$%^&*()_+');
       expect(token.tokenURI(TOKENID_1)).toEqual('!@#$%^&*()_+');
+    });
+
+    it('should canonicalize recipient', () => {
+      const nonCanonical = {
+        is_left: true,
+        left: OWNER.accountId,
+        right: utils.encodeToAddress('JUNK_DATA'),
+      };
+
+      token._mint(nonCanonical, TOKENID_1);
+      expect(token.ownerOf(TOKENID_1)).toEqual(OWNER.either);
+      expect(token.balanceOf(OWNER.either)).toEqual(1n);
     });
   });
 
   describe('_burn', () => {
     beforeEach(() => {
-      token._mint(Z_OWNER, TOKENID_1);
+      token._mint(OWNER.either, TOKENID_1);
     });
 
     it('should burn token', () => {
-      expect(token.balanceOf(Z_OWNER)).toEqual(1n);
+      expect(token.balanceOf(OWNER.either)).toEqual(1n);
 
       token._burn(TOKENID_1);
-      expect(token._ownerOf(TOKENID_1)).toEqual(ZERO_KEY);
-      expect(token.balanceOf(Z_OWNER)).toEqual(0n);
+      expect(token._ownerOf(TOKENID_1)).toEqual(ZERO_ACCOUNT);
+      expect(token.balanceOf(OWNER.either)).toEqual(0n);
     });
 
     it('should not burn a token that does not exist', () => {
       expect(() => {
         token._burn(NON_EXISTENT_TOKEN);
-      }).toThrow('NonFungibleToken: Invalid Sender');
+      }).toThrow('NonFungibleToken: invalid sender');
     });
 
     it('should clear approval when token is burned', () => {
-      token.as(OWNER).approve(Z_SPENDER, TOKENID_1);
-      expect(token.getApproved(TOKENID_1)).toEqual(Z_SPENDER);
+      token.privateState.injectSecretKey(OWNER.secretKey);
+      token.approve(SPENDER.either, TOKENID_1);
+      expect(token.getApproved(TOKENID_1)).toEqual(SPENDER.either);
 
       token._burn(TOKENID_1);
-      expect(token._getApproved(TOKENID_1)).toEqual(ZERO_KEY);
+      expect(token._getApproved(TOKENID_1)).toEqual(ZERO_ACCOUNT);
     });
 
     it('should burn multiple tokens in sequence', () => {
-      token._mint(Z_OWNER, TOKENID_2);
-      token._mint(Z_OWNER, TOKENID_3);
+      token._mint(OWNER.either, TOKENID_2);
+      token._mint(OWNER.either, TOKENID_3);
 
       token._burn(TOKENID_1);
       token._burn(TOKENID_2);
       token._burn(TOKENID_3);
-      expect(token.balanceOf(Z_OWNER)).toEqual(0n);
+      expect(token.balanceOf(OWNER.either)).toEqual(0n);
     });
 
     it('should burn with very long token IDs', () => {
       const longTokenId = BigInt('18446744073709551615');
-      token._mint(Z_OWNER, longTokenId);
+      token._mint(OWNER.either, longTokenId);
       token._burn(longTokenId);
-      expect(token._ownerOf(longTokenId)).toEqual(ZERO_KEY);
+      expect(token._ownerOf(longTokenId)).toEqual(ZERO_ACCOUNT);
     });
 
     it('should burn after transfer', () => {
-      token._transfer(Z_OWNER, Z_SPENDER, TOKENID_1);
+      token._transfer(OWNER.either, SPENDER.either, TOKENID_1);
       token._burn(TOKENID_1);
-      expect(token._ownerOf(TOKENID_1)).toEqual(ZERO_KEY);
+      expect(token._ownerOf(TOKENID_1)).toEqual(ZERO_ACCOUNT);
     });
 
     it('should burn after approval', () => {
-      token.as(OWNER).approve(Z_SPENDER, TOKENID_1);
+      token.privateState.injectSecretKey(OWNER.secretKey);
+      token.approve(SPENDER.either, TOKENID_1);
       token._burn(TOKENID_1);
-      expect(token._ownerOf(TOKENID_1)).toEqual(ZERO_KEY);
-      expect(token._getApproved(TOKENID_1)).toEqual(ZERO_KEY);
+      expect(token._ownerOf(TOKENID_1)).toEqual(ZERO_ACCOUNT);
+      expect(token._getApproved(TOKENID_1)).toEqual(ZERO_ACCOUNT);
     });
 
     it('should clear tokenURI on burn', () => {
@@ -792,55 +1010,57 @@ describe('NonFungibleToken', () => {
 
       token._burn(TOKENID_1);
 
-      token._mint(Z_OWNER, TOKENID_1);
+      token._mint(OWNER.either, TOKENID_1);
       expect(token.tokenURI(TOKENID_1)).toEqual(EMPTY_URI);
     });
   });
 
   describe('_transfer', () => {
     it('should not transfer to ContractAddress', () => {
-      token._mint(Z_OWNER, TOKENID_1);
+      token._mint(OWNER.either, TOKENID_1);
       expect(() => {
-        token._transfer(Z_OWNER, SOME_CONTRACT, TOKENID_1);
-      }).toThrow('NonFungibleToken: Unsafe Transfer');
+        token._transfer(OWNER.either, SOME_CONTRACT, TOKENID_1);
+      }).toThrow('NonFungibleToken: unsafe transfer');
     });
 
     it('should transfer token', () => {
-      token._mint(Z_OWNER, TOKENID_1);
-      expect(token.balanceOf(Z_OWNER)).toEqual(1n);
-      expect(token.balanceOf(Z_SPENDER)).toEqual(0n);
-      expect(token.ownerOf(TOKENID_1)).toEqual(Z_OWNER);
+      token._mint(OWNER.either, TOKENID_1);
+      expect(token.balanceOf(OWNER.either)).toEqual(1n);
+      expect(token.balanceOf(SPENDER.either)).toEqual(0n);
+      expect(token.ownerOf(TOKENID_1)).toEqual(OWNER.either);
 
-      token._transfer(Z_OWNER, Z_SPENDER, TOKENID_1);
-      expect(token.balanceOf(Z_OWNER)).toEqual(0n);
-      expect(token.balanceOf(Z_SPENDER)).toEqual(1n);
-      expect(token.ownerOf(TOKENID_1)).toEqual(Z_SPENDER);
+      token._transfer(OWNER.either, SPENDER.either, TOKENID_1);
+      expect(token.balanceOf(OWNER.either)).toEqual(0n);
+      expect(token.balanceOf(SPENDER.either)).toEqual(1n);
+      expect(token.ownerOf(TOKENID_1)).toEqual(SPENDER.either);
     });
 
     it('should not transfer to zero address', () => {
+      token._mint(OWNER.either, TOKENID_1);
       expect(() => {
-        token._transfer(Z_OWNER, ZERO_KEY, TOKENID_1);
-      }).toThrow('NonFungibleToken: Invalid Receiver');
+        token._transfer(OWNER.either, ZERO_ACCOUNT, TOKENID_1);
+      }).toThrow('NonFungibleToken: invalid receiver');
     });
 
     it('should throw if from does not own token', () => {
-      token._mint(Z_OWNER, TOKENID_1);
+      token._mint(OWNER.either, TOKENID_1);
       expect(() => {
-        token._transfer(Z_UNAUTHORIZED, Z_SPENDER, TOKENID_1);
-      }).toThrow('NonFungibleToken: Incorrect Owner');
+        token._transfer(UNAUTHORIZED.either, SPENDER.either, TOKENID_1);
+      }).toThrow('NonFungibleToken: incorrect owner');
     });
 
     it('should throw if token does not exist', () => {
       expect(() => {
-        token._transfer(Z_OWNER, Z_SPENDER, NON_EXISTENT_TOKEN);
-      }).toThrow('NonFungibleToken: Nonexistent Token');
+        token._transfer(OWNER.either, SPENDER.either, NON_EXISTENT_TOKEN);
+      }).toThrow('NonFungibleToken: nonexistent token');
     });
 
     it('should revoke approval after _transfer', () => {
-      token._mint(Z_OWNER, TOKENID_1);
-      token.as(OWNER).approve(Z_SPENDER, TOKENID_1);
-      token._transfer(Z_OWNER, Z_OTHER, TOKENID_1);
-      expect(token.getApproved(TOKENID_1)).toEqual(ZERO_KEY);
+      token._mint(OWNER.either, TOKENID_1);
+      token.privateState.injectSecretKey(OWNER.secretKey);
+      token.approve(SPENDER.either, TOKENID_1);
+      token._transfer(OWNER.either, OTHER.either, TOKENID_1);
+      expect(token.getApproved(TOKENID_1)).toEqual(ZERO_ACCOUNT);
     });
   });
 
@@ -848,11 +1068,11 @@ describe('NonFungibleToken', () => {
     it('should throw if token does not exist', () => {
       expect(() => {
         token._setTokenURI(NON_EXISTENT_TOKEN, EMPTY_URI);
-      }).toThrow('NonFungibleToken: Nonexistent Token');
+      }).toThrow('NonFungibleToken: nonexistent token');
     });
 
     it('should set tokenURI', () => {
-      token._mint(Z_OWNER, TOKENID_1);
+      token._mint(OWNER.either, TOKENID_1);
       token._setTokenURI(TOKENID_1, SOME_URI);
       expect(token.tokenURI(TOKENID_1)).toEqual(SOME_URI);
     });
@@ -865,198 +1085,214 @@ describe('NonFungibleToken', () => {
       }).not.toThrow();
     });
 
-    it('should not mint to zero address', () => {
+    it('should not mint to zero address (accountId)', () => {
       expect(() => {
-        token._unsafeMint(ZERO_KEY, TOKENID_1);
-      }).toThrow('NonFungibleToken: Invalid Receiver');
+        token._unsafeMint(ZERO_ACCOUNT, TOKENID_1);
+      }).toThrow('NonFungibleToken: invalid receiver');
+    });
 
+    it('should not mint to zero address (contract)', () => {
       expect(() => {
-        token._unsafeMint(ZERO_ADDRESS, TOKENID_1);
-      }).toThrow('NonFungibleToken: Invalid Receiver');
+        token._unsafeMint(ZERO_CONTRACT, TOKENID_1);
+      }).toThrow('NonFungibleToken: invalid receiver');
     });
 
     it('should not mint a token that already exists', () => {
-      token._unsafeMint(Z_OWNER, TOKENID_1);
+      token._unsafeMint(OWNER.either, TOKENID_1);
       expect(() => {
-        token._unsafeMint(Z_OWNER, TOKENID_1);
-      }).toThrow('NonFungibleToken: Invalid Sender');
+        token._unsafeMint(OWNER.either, TOKENID_1);
+      }).toThrow('NonFungibleToken: invalid sender');
     });
 
-    it('should mint token to public key', () => {
-      token._unsafeMint(Z_OWNER, TOKENID_1);
-      expect(token.ownerOf(TOKENID_1)).toEqual(Z_OWNER);
-      expect(token.balanceOf(Z_OWNER)).toEqual(1n);
+    it('should mint token to account', () => {
+      token._unsafeMint(OWNER.either, TOKENID_1);
+      expect(token.ownerOf(TOKENID_1)).toEqual(OWNER.either);
+      expect(token.balanceOf(OWNER.either)).toEqual(1n);
 
-      token._unsafeMint(Z_OWNER, TOKENID_2);
-      token._unsafeMint(Z_OWNER, TOKENID_3);
-      expect(token.balanceOf(Z_OWNER)).toEqual(3n);
+      token._unsafeMint(OWNER.either, TOKENID_2);
+      token._unsafeMint(OWNER.either, TOKENID_3);
+      expect(token.balanceOf(OWNER.either)).toEqual(3n);
     });
   });
 
   describe('_unsafeTransfer', () => {
     beforeEach(() => {
-      token._mint(Z_OWNER, TOKENID_1);
+      token._mint(OWNER.either, TOKENID_1);
     });
 
     it('should transfer to ContractAddress', () => {
       expect(() => {
-        token._unsafeTransfer(Z_OWNER, SOME_CONTRACT, TOKENID_1);
+        token._unsafeTransfer(OWNER.either, SOME_CONTRACT, TOKENID_1);
       }).not.toThrow();
     });
 
-    it('should transfer token to public key', () => {
-      expect(token.balanceOf(Z_OWNER)).toEqual(1n);
-      expect(token.balanceOf(Z_SPENDER)).toEqual(0n);
-      expect(token.ownerOf(TOKENID_1)).toEqual(Z_OWNER);
+    it('should transfer token to account', () => {
+      expect(token.balanceOf(OWNER.either)).toEqual(1n);
+      expect(token.balanceOf(SPENDER.either)).toEqual(0n);
+      expect(token.ownerOf(TOKENID_1)).toEqual(OWNER.either);
 
-      token._unsafeTransfer(Z_OWNER, Z_SPENDER, TOKENID_1);
-      expect(token.balanceOf(Z_OWNER)).toEqual(0n);
-      expect(token.balanceOf(Z_SPENDER)).toEqual(1n);
-      expect(token.ownerOf(TOKENID_1)).toEqual(Z_SPENDER);
+      token._unsafeTransfer(OWNER.either, SPENDER.either, TOKENID_1);
+      expect(token.balanceOf(OWNER.either)).toEqual(0n);
+      expect(token.balanceOf(SPENDER.either)).toEqual(1n);
+      expect(token.ownerOf(TOKENID_1)).toEqual(SPENDER.either);
     });
 
-    it('should not transfer to zero address', () => {
+    it('should not transfer to zero address (accountId)', () => {
       expect(() => {
-        token._unsafeTransfer(Z_OWNER, ZERO_KEY, TOKENID_1);
-      }).toThrow('NonFungibleToken: Invalid Receiver');
+        token._unsafeTransfer(OWNER.either, ZERO_ACCOUNT, TOKENID_1);
+      }).toThrow('NonFungibleToken: invalid receiver');
+    });
 
+    it('should not transfer to zero address (contract)', () => {
       expect(() => {
-        token._unsafeTransfer(Z_OWNER, ZERO_ADDRESS, TOKENID_1);
-      }).toThrow('NonFungibleToken: Invalid Receiver');
+        token._unsafeTransfer(OWNER.either, ZERO_CONTRACT, TOKENID_1);
+      }).toThrow('NonFungibleToken: invalid receiver');
     });
 
     it('should throw if from does not own token', () => {
       expect(() => {
-        token._unsafeTransfer(Z_UNAUTHORIZED, Z_UNAUTHORIZED, TOKENID_1);
-      }).toThrow('NonFungibleToken: Incorrect Owner');
+        token._unsafeTransfer(UNAUTHORIZED.either, UNAUTHORIZED.either, TOKENID_1);
+      }).toThrow('NonFungibleToken: incorrect owner');
     });
 
     it('should throw if token does not exist', () => {
       expect(() => {
-        token._unsafeTransfer(Z_OWNER, Z_SPENDER, NON_EXISTENT_TOKEN);
-      }).toThrow('NonFungibleToken: Nonexistent Token');
+        token._unsafeTransfer(OWNER.either, SPENDER.either, NON_EXISTENT_TOKEN);
+      }).toThrow('NonFungibleToken: nonexistent token');
     });
 
     it('should revoke approval after _unsafeTransfer', () => {
-      token.as(OWNER).approve(Z_SPENDER, TOKENID_1);
-      token._unsafeTransfer(Z_OWNER, Z_OTHER, TOKENID_1);
-      expect(token.getApproved(TOKENID_1)).toEqual(ZERO_KEY);
+      token.privateState.injectSecretKey(OWNER.secretKey);
+      token.approve(SPENDER.either, TOKENID_1);
+      token._unsafeTransfer(OWNER.either, OTHER.either, TOKENID_1);
+      expect(token.getApproved(TOKENID_1)).toEqual(ZERO_ACCOUNT);
     });
   });
 
   describe('_unsafeTransferFrom', () => {
     beforeEach(() => {
-      token._mint(Z_OWNER, TOKENID_1);
+      token._mint(OWNER.either, TOKENID_1);
     });
 
     it('should transfer to ContractAddress', () => {
+      token.privateState.injectSecretKey(OWNER.secretKey);
       expect(() => {
-        token._unsafeTransferFrom(Z_OWNER, SOME_CONTRACT, TOKENID_1);
+        token._unsafeTransferFrom(OWNER.either, SOME_CONTRACT, TOKENID_1);
       }).not.toThrow();
     });
 
-    it('should not transfer to zero address', () => {
+    it('should not transfer to zero address (accountId)', () => {
+      token.privateState.injectSecretKey(OWNER.secretKey);
       expect(() => {
-        token._unsafeTransferFrom(Z_OWNER, ZERO_KEY, TOKENID_1);
-      }).toThrow('NonFungibleToken: Invalid Receiver');
+        token._unsafeTransferFrom(OWNER.either, ZERO_ACCOUNT, TOKENID_1);
+      }).toThrow('NonFungibleToken: invalid receiver');
+    });
 
+    it('should not transfer to zero address (contract)', () => {
+      token.privateState.injectSecretKey(OWNER.secretKey);
       expect(() => {
-        token._unsafeTransferFrom(Z_OWNER, ZERO_ADDRESS, TOKENID_1);
-      }).toThrow('NonFungibleToken: Invalid Receiver');
+        token._unsafeTransferFrom(OWNER.either, ZERO_CONTRACT, TOKENID_1);
+      }).toThrow('NonFungibleToken: invalid receiver');
     });
 
     it('should not transfer from zero address', () => {
+      token.privateState.injectSecretKey(OWNER.secretKey);
       expect(() => {
-        token._unsafeTransferFrom(ZERO_KEY, Z_SPENDER, TOKENID_1);
-      }).toThrow('NonFungibleToken: Incorrect Owner');
-
-      expect(() => {
-        token._unsafeTransferFrom(ZERO_ADDRESS, Z_SPENDER, TOKENID_1);
-      }).toThrow('NonFungibleToken: Incorrect Owner');
+        token._unsafeTransferFrom(ZERO_ACCOUNT, SPENDER.either, TOKENID_1);
+      }).toThrow('NonFungibleToken: incorrect owner');
     });
 
     it('unapproved operator should not transfer', () => {
+      token.privateState.injectSecretKey(SPENDER.secretKey);
       expect(() => {
-        token
-          .as(SPENDER)
-          ._unsafeTransferFrom(Z_OWNER, Z_UNAUTHORIZED, TOKENID_1);
-      }).toThrow('NonFungibleToken: Insufficient Approval');
+        token._unsafeTransferFrom(OWNER.either, UNAUTHORIZED.either, TOKENID_1);
+      }).toThrow('NonFungibleToken: insufficient approval');
     });
 
     it('should not transfer token that has not been minted', () => {
+      token.privateState.injectSecretKey(OWNER.secretKey);
       expect(() => {
-        token
-          .as(OWNER)
-          ._unsafeTransferFrom(Z_OWNER, Z_SPENDER, NON_EXISTENT_TOKEN);
-      }).toThrow('NonFungibleToken: Nonexistent Token');
+        token._unsafeTransferFrom(OWNER.either, SPENDER.either, NON_EXISTENT_TOKEN);
+      }).toThrow('NonFungibleToken: nonexistent token');
     });
 
     it('should transfer token to spender via approved operator', () => {
-      token.as(OWNER).approve(Z_SPENDER, TOKENID_1);
+      token.privateState.injectSecretKey(OWNER.secretKey);
+      token.approve(SPENDER.either, TOKENID_1);
 
-      token.as(SPENDER)._unsafeTransferFrom(Z_OWNER, Z_SPENDER, TOKENID_1);
-      expect(token.ownerOf(TOKENID_1)).toEqual(Z_SPENDER);
+      token.privateState.injectSecretKey(SPENDER.secretKey);
+      token._unsafeTransferFrom(OWNER.either, SPENDER.either, TOKENID_1);
+      expect(token.ownerOf(TOKENID_1)).toEqual(SPENDER.either);
     });
 
     it('should transfer token to ContractAddress via approved operator', () => {
-      token.as(OWNER).approve(Z_SPENDER, TOKENID_1);
+      token.privateState.injectSecretKey(OWNER.secretKey);
+      token.approve(SPENDER.either, TOKENID_1);
 
-      token.as(SPENDER)._unsafeTransferFrom(Z_OWNER, SOME_CONTRACT, TOKENID_1);
+      token.privateState.injectSecretKey(SPENDER.secretKey);
+      token._unsafeTransferFrom(OWNER.either, SOME_CONTRACT, TOKENID_1);
       expect(token.ownerOf(TOKENID_1)).toEqual(SOME_CONTRACT);
     });
 
     it('should transfer token to spender via approvedForAll operator', () => {
-      token.as(OWNER).setApprovalForAll(Z_SPENDER, true);
+      token.privateState.injectSecretKey(OWNER.secretKey);
+      token.setApprovalForAll(SPENDER.either, true);
 
-      token.as(SPENDER)._unsafeTransferFrom(Z_OWNER, Z_SPENDER, TOKENID_1);
-      expect(token.ownerOf(TOKENID_1)).toEqual(Z_SPENDER);
+      token.privateState.injectSecretKey(SPENDER.secretKey);
+      token._unsafeTransferFrom(OWNER.either, SPENDER.either, TOKENID_1);
+      expect(token.ownerOf(TOKENID_1)).toEqual(SPENDER.either);
     });
 
     it('should transfer token to ContractAddress via approvedForAll operator', () => {
-      token.as(OWNER).setApprovalForAll(Z_SPENDER, true);
+      token.privateState.injectSecretKey(OWNER.secretKey);
+      token.setApprovalForAll(SPENDER.either, true);
 
-      token.as(SPENDER)._unsafeTransferFrom(Z_OWNER, SOME_CONTRACT, TOKENID_1);
+      token.privateState.injectSecretKey(SPENDER.secretKey);
+      token._unsafeTransferFrom(OWNER.either, SOME_CONTRACT, TOKENID_1);
       expect(token.ownerOf(TOKENID_1)).toEqual(SOME_CONTRACT);
     });
 
     it('should revoke approval after _unsafeTransferFrom', () => {
-      token.as(OWNER).approve(Z_SPENDER, TOKENID_1);
-      token.as(OWNER)._unsafeTransferFrom(Z_OWNER, Z_OTHER, TOKENID_1);
-      expect(token.getApproved(TOKENID_1)).toEqual(ZERO_KEY);
+      token.privateState.injectSecretKey(OWNER.secretKey);
+      token.approve(SPENDER.either, TOKENID_1);
+
+      token._unsafeTransferFrom(OWNER.either, OTHER.either, TOKENID_1);
+      expect(token.getApproved(TOKENID_1)).toEqual(ZERO_ACCOUNT);
     });
   });
 });
 
+// Uninitialized tests
 type FailingCircuits = [
   method: keyof NonFungibleTokenSimulator,
   args: unknown[],
-]; // Circuit calls should fail before the args are used
+];
 
 const circuitsToFail: FailingCircuits[] = [
   ['name', []],
   ['symbol', []],
-  ['balanceOf', [Z_OWNER]],
+  ['balanceOf', [OWNER.either]],
   ['ownerOf', [TOKENID_1]],
   ['tokenURI', [TOKENID_1]],
-  ['approve', [Z_OWNER, TOKENID_1]],
+  ['approve', [OWNER.either, TOKENID_1]],
   ['getApproved', [TOKENID_1]],
-  ['setApprovalForAll', [Z_SPENDER, true]],
-  ['isApprovedForAll', [Z_OWNER, Z_SPENDER]],
-  ['transferFrom', [Z_OWNER, Z_RECIPIENT, TOKENID_1]],
+  ['setApprovalForAll', [SPENDER.either, true]],
+  ['isApprovedForAll', [OWNER.either, SPENDER.either]],
+  ['transferFrom', [OWNER.either, RECIPIENT.either, TOKENID_1]],
   ['_requireOwned', [TOKENID_1]],
   ['_ownerOf', [TOKENID_1]],
-  ['_approve', [Z_OWNER, TOKENID_1, Z_SPENDER]],
-  ['_checkAuthorized', [Z_OWNER, Z_SPENDER, TOKENID_1]],
-  ['_isAuthorized', [Z_OWNER, Z_SPENDER, TOKENID_1]],
+  ['_approve', [OWNER.either, TOKENID_1, SPENDER.either]],
+  ['_checkAuthorized', [OWNER.either, SPENDER.either, TOKENID_1]],
+  ['_isAuthorized', [OWNER.either, SPENDER.either, TOKENID_1]],
   ['_getApproved', [TOKENID_1]],
-  ['_setApprovalForAll', [Z_OWNER, Z_SPENDER, true]],
-  ['_mint', [Z_OWNER, TOKENID_1]],
+  ['_setApprovalForAll', [OWNER.either, SPENDER.either, true]],
+  ['_mint', [OWNER.either, TOKENID_1]],
   ['_burn', [TOKENID_1]],
-  ['_transfer', [Z_OWNER, Z_RECIPIENT, TOKENID_1]],
+  ['_transfer', [OWNER.either, RECIPIENT.either, TOKENID_1]],
   ['_setTokenURI', [TOKENID_1]],
-  ['_unsafeTransferFrom', [Z_OWNER, Z_RECIPIENT, TOKENID_1]],
-  ['_unsafeTransfer', [Z_OWNER, Z_RECIPIENT, TOKENID_1]],
-  ['_unsafeMint', [Z_OWNER, TOKENID_1]],
+  ['_unsafeTransferFrom', [OWNER.either, RECIPIENT.either, TOKENID_1]],
+  ['_unsafeTransfer', [OWNER.either, RECIPIENT.either, TOKENID_1]],
+  ['_unsafeMint', [OWNER.either, TOKENID_1]],
 ];
 
 let uninitializedToken: NonFungibleTokenSimulator;

--- a/contracts/src/token/test/nonFungibleToken.test.ts
+++ b/contracts/src/token/test/nonFungibleToken.test.ts
@@ -139,6 +139,33 @@ describe('NonFungibleToken', () => {
     });
   });
 
+  describe('ZERO', () => {
+    it('should return a left variant', () => {
+      const zero = token.ZERO();
+      expect(zero.is_left).toBe(true);
+    });
+
+    it('should have zero left branch', () => {
+      const zero = token.ZERO();
+      expect(zero.left).toEqual(zeroBytes);
+    });
+
+    it('should have zero right branch', () => {
+      const zero = token.ZERO();
+      expect(zero.right).toEqual({ bytes: zeroBytes });
+    });
+
+    it('should be canonical', () => {
+      const zero = token.ZERO();
+      expect(zero).toEqual(ZERO_ACCOUNT);
+    });
+
+    it('should not equal a right-variant zero', () => {
+      const zero = token.ZERO();
+      expect(zero).not.toEqual(ZERO_CONTRACT);
+    });
+  });
+
   describe('balanceOf', () => {
     it('should return zero when requested account has no balance', () => {
       expect(token.balanceOf(OWNER.either)).toEqual(0n);
@@ -943,6 +970,12 @@ describe('NonFungibleToken', () => {
       expect(token.ownerOf(TOKENID_1)).toEqual(OWNER.either);
       expect(token.balanceOf(OWNER.either)).toEqual(1n);
     });
+
+    it('should not mint to zero (contract)', () => {
+      expect(() => {
+        token._mint(ZERO_CONTRACT, TOKENID_1);
+      }).toThrow('NonFungibleToken: unsafe transfer');
+    });
   });
 
   describe('_burn', () => {
@@ -1167,6 +1200,29 @@ describe('NonFungibleToken', () => {
       token._unsafeTransfer(OWNER.either, OTHER.either, TOKENID_1);
       expect(token.getApproved(TOKENID_1)).toEqual(ZERO_ACCOUNT);
     });
+
+    it('should canonicalize contract address recipient', () => {
+      const nonCanonical = {
+        is_left: false,
+        left: new Uint8Array(32).fill(1),
+        right: SOME_CONTRACT.right,
+      };
+
+      token._unsafeTransfer(OWNER.either, nonCanonical, TOKENID_1);
+      expect(token.ownerOf(TOKENID_1)).toEqual(SOME_CONTRACT);
+      expect(token.balanceOf(SOME_CONTRACT)).toEqual(1n);
+    });
+
+    it('should handle non-canonical fromAddress', () => {
+      const nonCanonical = {
+        is_left: true,
+        left: OWNER.accountId,
+        right: utils.encodeToAddress('JUNK_DATA'),
+      };
+
+      token._unsafeTransfer(nonCanonical, SPENDER.either, TOKENID_1);
+      expect(token.ownerOf(TOKENID_1)).toEqual(SPENDER.either);
+    });
   });
 
   describe('_unsafeTransferFrom', () => {
@@ -1259,6 +1315,33 @@ describe('NonFungibleToken', () => {
       token._unsafeTransferFrom(OWNER.either, OTHER.either, TOKENID_1);
       expect(token.getApproved(TOKENID_1)).toEqual(ZERO_ACCOUNT);
     });
+
+    it('should handle non-canonical fromAddress', () => {
+      token.privateState.injectSecretKey(OWNER.secretKey);
+
+      const nonCanonical = {
+        is_left: true,
+        left: OWNER.accountId,
+        right: utils.encodeToAddress('JUNK_DATA'),
+      };
+
+      token._unsafeTransferFrom(nonCanonical, SPENDER.either, TOKENID_1);
+      expect(token.ownerOf(TOKENID_1)).toEqual(SPENDER.either);
+    });
+
+    it('should canonicalize contract address recipient', () => {
+      token.privateState.injectSecretKey(OWNER.secretKey);
+
+      const nonCanonical = {
+        is_left: false,
+        left: new Uint8Array(32).fill(1),
+        right: SOME_CONTRACT.right,
+      };
+
+      token._unsafeTransferFrom(OWNER.either, nonCanonical, TOKENID_1);
+      expect(token.ownerOf(TOKENID_1)).toEqual(SOME_CONTRACT);
+      expect(token.balanceOf(SOME_CONTRACT)).toEqual(1n);
+    });
   });
 });
 
@@ -1289,7 +1372,7 @@ const circuitsToFail: FailingCircuits[] = [
   ['_mint', [OWNER.either, TOKENID_1]],
   ['_burn', [TOKENID_1]],
   ['_transfer', [OWNER.either, RECIPIENT.either, TOKENID_1]],
-  ['_setTokenURI', [TOKENID_1]],
+  ['_setTokenURI', [TOKENID_1, EMPTY_URI]],
   ['_unsafeTransferFrom', [OWNER.either, RECIPIENT.either, TOKENID_1]],
   ['_unsafeTransfer', [OWNER.either, RECIPIENT.either, TOKENID_1]],
   ['_unsafeMint', [OWNER.either, TOKENID_1]],

--- a/contracts/src/token/test/nonFungibleToken.test.ts
+++ b/contracts/src/token/test/nonFungibleToken.test.ts
@@ -632,7 +632,9 @@ describe('NonFungibleToken', () => {
       expect(token.ownerOf(TOKENID_1)).toEqual(OWNER.either);
       expect(token.balanceOf(OWNER.either)).toEqual(1n);
       expect(token.getApproved(TOKENID_1)).toEqual(ZERO_ACCOUNT);
-      expect(token._isAuthorized(OWNER.either, SPENDER.either, TOKENID_1)).toEqual(true);
+      expect(
+        token._isAuthorized(OWNER.either, SPENDER.either, TOKENID_1),
+      ).toEqual(true);
     });
 
     it('should not transfer after approval revocation', () => {
@@ -695,7 +697,9 @@ describe('NonFungibleToken', () => {
 
       token.transferFrom(OWNER.either, OTHER.either, TOKENID_1);
       expect(token.getApproved(TOKENID_1)).toEqual(ZERO_ACCOUNT);
-      expect(token._isAuthorized(OTHER.either, SPENDER.either, TOKENID_1)).toBe(false);
+      expect(token._isAuthorized(OTHER.either, SPENDER.either, TOKENID_1)).toBe(
+        false,
+      );
 
       token.privateState.injectSecretKey(SPENDER.secretKey);
       expect(() => {
@@ -819,25 +823,35 @@ describe('NonFungibleToken', () => {
     it('should return true if spender is authorized', () => {
       token.privateState.injectSecretKey(OWNER.secretKey);
       token.approve(SPENDER.either, TOKENID_1);
-      expect(token._isAuthorized(OWNER.either, SPENDER.either, TOKENID_1)).toBe(true);
+      expect(token._isAuthorized(OWNER.either, SPENDER.either, TOKENID_1)).toBe(
+        true,
+      );
     });
 
     it('should return true if spender is authorized for all', () => {
       token.privateState.injectSecretKey(OWNER.secretKey);
       token.setApprovalForAll(SPENDER.either, true);
-      expect(token._isAuthorized(OWNER.either, SPENDER.either, TOKENID_1)).toBe(true);
+      expect(token._isAuthorized(OWNER.either, SPENDER.either, TOKENID_1)).toBe(
+        true,
+      );
     });
 
     it('should return true if spender is owner', () => {
-      expect(token._isAuthorized(OWNER.either, OWNER.either, TOKENID_1)).toBe(true);
+      expect(token._isAuthorized(OWNER.either, OWNER.either, TOKENID_1)).toBe(
+        true,
+      );
     });
 
     it('should return false if spender is zero address', () => {
-      expect(token._isAuthorized(OWNER.either, ZERO_ACCOUNT, TOKENID_1)).toBe(false);
+      expect(token._isAuthorized(OWNER.either, ZERO_ACCOUNT, TOKENID_1)).toBe(
+        false,
+      );
     });
 
     it('should return false for unauthorized', () => {
-      expect(token._isAuthorized(OWNER.either, UNAUTHORIZED.either, TOKENID_1)).toBe(false);
+      expect(
+        token._isAuthorized(OWNER.either, UNAUTHORIZED.either, TOKENID_1),
+      ).toBe(false);
     });
   });
 
@@ -1184,7 +1198,11 @@ describe('NonFungibleToken', () => {
 
     it('should throw if from does not own token', () => {
       expect(() => {
-        token._unsafeTransfer(UNAUTHORIZED.either, UNAUTHORIZED.either, TOKENID_1);
+        token._unsafeTransfer(
+          UNAUTHORIZED.either,
+          UNAUTHORIZED.either,
+          TOKENID_1,
+        );
       }).toThrow('NonFungibleToken: incorrect owner');
     });
 
@@ -1268,7 +1286,11 @@ describe('NonFungibleToken', () => {
     it('should not transfer token that has not been minted', () => {
       token.privateState.injectSecretKey(OWNER.secretKey);
       expect(() => {
-        token._unsafeTransferFrom(OWNER.either, SPENDER.either, NON_EXISTENT_TOKEN);
+        token._unsafeTransferFrom(
+          OWNER.either,
+          SPENDER.either,
+          NON_EXISTENT_TOKEN,
+        );
       }).toThrow('NonFungibleToken: nonexistent token');
     });
 

--- a/contracts/src/token/test/simulators/NonFungibleTokenSimulator.ts
+++ b/contracts/src/token/test/simulators/NonFungibleTokenSimulator.ts
@@ -7,7 +7,6 @@ import {
   type Either,
   ledger,
   Contract as MockNonFungibleToken,
-  type ZswapCoinPublicKey,
 } from '../../../../artifacts/MockNonFungibleToken/contract/index.js';
 import {
   NonFungibleTokenPrivateState,
@@ -32,7 +31,7 @@ const NonFungibleTokenSimulatorBase = createSimulator<
 >({
   contractFactory: (witnesses) =>
     new MockNonFungibleToken<NonFungibleTokenPrivateState>(witnesses),
-  defaultPrivateState: () => NonFungibleTokenPrivateState,
+  defaultPrivateState: () => NonFungibleTokenPrivateState.generate(),
   contractArgs: (name, symbol, init) => [name, symbol, init],
   ledgerExtractor: (state) => ledger(state),
   witnessesFactory: () => NonFungibleTokenWitnesses(),
@@ -76,7 +75,7 @@ export class NonFungibleTokenSimulator extends NonFungibleTokenSimulatorBase {
    * @return The number of tokens in `account`'s account.
    */
   public balanceOf(
-    account: Either<ZswapCoinPublicKey, ContractAddress>,
+    account: Either<Uint8Array, ContractAddress>,
   ): bigint {
     return this.circuits.impure.balanceOf(account);
   }
@@ -86,7 +85,7 @@ export class NonFungibleTokenSimulator extends NonFungibleTokenSimulatorBase {
    * @param tokenId The identifier for a token.
    * @return The public key that owns the token.
    */
-  public ownerOf(tokenId: bigint): Either<ZswapCoinPublicKey, ContractAddress> {
+  public ownerOf(tokenId: bigint): Either<Uint8Array, ContractAddress> {
     return this.circuits.impure.ownerOf(tokenId);
   }
 
@@ -119,7 +118,7 @@ export class NonFungibleTokenSimulator extends NonFungibleTokenSimulatorBase {
    * @param tokenId The token `to` may be permitted to transfer
    */
   public approve(
-    to: Either<ZswapCoinPublicKey, ContractAddress>,
+    to: Either<Uint8Array, ContractAddress>,
     tokenId: bigint,
   ) {
     this.circuits.impure.approve(to, tokenId);
@@ -132,7 +131,7 @@ export class NonFungibleTokenSimulator extends NonFungibleTokenSimulatorBase {
    */
   public getApproved(
     tokenId: bigint,
-  ): Either<ZswapCoinPublicKey, ContractAddress> {
+  ): Either<Uint8Array, ContractAddress> {
     return this.circuits.impure.getApproved(tokenId);
   }
 
@@ -148,7 +147,7 @@ export class NonFungibleTokenSimulator extends NonFungibleTokenSimulatorBase {
    * @param approved A boolean determining if `operator` may manage all tokens of the caller
    */
   public setApprovalForAll(
-    operator: Either<ZswapCoinPublicKey, ContractAddress>,
+    operator: Either<Uint8Array, ContractAddress>,
     approved: boolean,
   ) {
     this.circuits.impure.setApprovalForAll(operator, approved);
@@ -162,8 +161,8 @@ export class NonFungibleTokenSimulator extends NonFungibleTokenSimulatorBase {
    * @return A boolean determining if `operator` is allowed to manage all of the tokens of `owner`
    */
   public isApprovedForAll(
-    owner: Either<ZswapCoinPublicKey, ContractAddress>,
-    operator: Either<ZswapCoinPublicKey, ContractAddress>,
+    owner: Either<Uint8Array, ContractAddress>,
+    operator: Either<Uint8Array, ContractAddress>,
   ): boolean {
     return this.circuits.impure.isApprovedForAll(owner, operator);
   }
@@ -178,13 +177,13 @@ export class NonFungibleTokenSimulator extends NonFungibleTokenSimulatorBase {
    * - `tokenId` token must be owned by `fromAddress`.
    * - If the caller is not `fromAddress`, it must be approved to move this token by either {approve} or {setApprovalForAll}.
    *
-   * @param {Either<ZswapCoinPublicKey, ContractAddress>} fromAddress - The source account from which the token is being transfered
-   * @param {Either<ZswapCoinPublicKey, ContractAddress>} to - The target account to transfer token to
+   * @param {Either<Uint8Array, ContractAddress>} fromAddress - The source account from which the token is being transfered
+   * @param {Either<Uint8Array, ContractAddress>} to - The target account to transfer token to
    * @param {TokenId} tokenId - The token being transfered
    */
   public transferFrom(
-    fromAddress: Either<ZswapCoinPublicKey, ContractAddress>,
-    to: Either<ZswapCoinPublicKey, ContractAddress>,
+    fromAddress: Either<Uint8Array, ContractAddress>,
+    to: Either<Uint8Array, ContractAddress>,
     tokenId: bigint,
   ) {
     this.circuits.impure.transferFrom(fromAddress, to, tokenId);
@@ -201,7 +200,7 @@ export class NonFungibleTokenSimulator extends NonFungibleTokenSimulatorBase {
    */
   public _requireOwned(
     tokenId: bigint,
-  ): Either<ZswapCoinPublicKey, ContractAddress> {
+  ): Either<Uint8Array, ContractAddress> {
     return this.circuits.impure._requireOwned(tokenId);
   }
 
@@ -213,7 +212,7 @@ export class NonFungibleTokenSimulator extends NonFungibleTokenSimulatorBase {
    */
   public _ownerOf(
     tokenId: bigint,
-  ): Either<ZswapCoinPublicKey, ContractAddress> {
+  ): Either<Uint8Array, ContractAddress> {
     return this.circuits.impure._ownerOf(tokenId);
   }
 
@@ -228,9 +227,9 @@ export class NonFungibleTokenSimulator extends NonFungibleTokenSimulatorBase {
    * @param auth An account authorized to operate on all tokens held by the owner the token
    */
   public _approve(
-    to: Either<ZswapCoinPublicKey, ContractAddress>,
+    to: Either<Uint8Array, ContractAddress>,
     tokenId: bigint,
-    auth: Either<ZswapCoinPublicKey, ContractAddress>,
+    auth: Either<Uint8Array, ContractAddress>,
   ) {
     this.circuits.impure._approve(to, tokenId, auth);
   }
@@ -249,8 +248,8 @@ export class NonFungibleTokenSimulator extends NonFungibleTokenSimulatorBase {
    * @param tokenId The token to spend
    */
   public _checkAuthorized(
-    owner: Either<ZswapCoinPublicKey, ContractAddress>,
-    spender: Either<ZswapCoinPublicKey, ContractAddress>,
+    owner: Either<Uint8Array, ContractAddress>,
+    spender: Either<Uint8Array, ContractAddress>,
     tokenId: bigint,
   ) {
     return this.circuits.impure._checkAuthorized(owner, spender, tokenId);
@@ -269,8 +268,8 @@ export class NonFungibleTokenSimulator extends NonFungibleTokenSimulatorBase {
    * @return A boolean determining if `spender` may manage `tokenId`
    */
   public _isAuthorized(
-    owner: Either<ZswapCoinPublicKey, ContractAddress>,
-    spender: Either<ZswapCoinPublicKey, ContractAddress>,
+    owner: Either<Uint8Array, ContractAddress>,
+    spender: Either<Uint8Array, ContractAddress>,
     tokenId: bigint,
   ): boolean {
     return this.circuits.impure._isAuthorized(owner, spender, tokenId);
@@ -284,7 +283,7 @@ export class NonFungibleTokenSimulator extends NonFungibleTokenSimulatorBase {
    */
   public _getApproved(
     tokenId: bigint,
-  ): Either<ZswapCoinPublicKey, ContractAddress> {
+  ): Either<Uint8Array, ContractAddress> {
     return this.circuits.impure._getApproved(tokenId);
   }
 
@@ -300,8 +299,8 @@ export class NonFungibleTokenSimulator extends NonFungibleTokenSimulatorBase {
    * @param approved A boolean determining if `operator` may operate on all of `owner` tokens
    */
   public _setApprovalForAll(
-    owner: Either<ZswapCoinPublicKey, ContractAddress>,
-    operator: Either<ZswapCoinPublicKey, ContractAddress>,
+    owner: Either<Uint8Array, ContractAddress>,
+    operator: Either<Uint8Array, ContractAddress>,
     approved: boolean,
   ) {
     this.circuits.impure._setApprovalForAll(owner, operator, approved);
@@ -319,7 +318,7 @@ export class NonFungibleTokenSimulator extends NonFungibleTokenSimulatorBase {
    * @param tokenId The token to transfer
    */
   public _mint(
-    to: Either<ZswapCoinPublicKey, ContractAddress>,
+    to: Either<Uint8Array, ContractAddress>,
     tokenId: bigint,
   ) {
     this.circuits.impure._mint(to, tokenId);
@@ -354,8 +353,8 @@ export class NonFungibleTokenSimulator extends NonFungibleTokenSimulatorBase {
    * @param tokenId The token to transfer
    */
   public _transfer(
-    fromAddress: Either<ZswapCoinPublicKey, ContractAddress>,
-    to: Either<ZswapCoinPublicKey, ContractAddress>,
+    fromAddress: Either<Uint8Array, ContractAddress>,
+    to: Either<Uint8Array, ContractAddress>,
     tokenId: bigint,
   ) {
     this.circuits.impure._transfer(fromAddress, to, tokenId);
@@ -388,13 +387,13 @@ export class NonFungibleTokenSimulator extends NonFungibleTokenSimulatorBase {
    * - `tokenId` token must be owned by `fromAddress`.
    * - If the caller is not `fromAddress`, it must be approved to move this token by either {approve} or {setApprovalForAll}.
    *
-   * @param {Either<ZswapCoinPublicKey, ContractAddress>} fromAddress - The source account from which the token is being transfered
-   * @param {Either<ZswapCoinPublicKey, ContractAddress>} to - The target account to transfer token to
+   * @param {Either<Uint8Array, ContractAddress>} fromAddress - The source account from which the token is being transfered
+   * @param {Either<Uint8Array, ContractAddress>} to - The target account to transfer token to
    * @param {TokenId} tokenId - The token being transfered
    */
   public _unsafeTransferFrom(
-    fromAddress: Either<ZswapCoinPublicKey, ContractAddress>,
-    to: Either<ZswapCoinPublicKey, ContractAddress>,
+    fromAddress: Either<Uint8Array, ContractAddress>,
+    to: Either<Uint8Array, ContractAddress>,
     tokenId: bigint,
   ) {
     this.circuits.impure._unsafeTransferFrom(fromAddress, to, tokenId);
@@ -414,13 +413,13 @@ export class NonFungibleTokenSimulator extends NonFungibleTokenSimulatorBase {
    * - `to` cannot be the zero address.
    * - `tokenId` token must be owned by `fromAddress`.
    *
-   * @param {Either<ZswapCoinPublicKey, ContractAddress>} fromAddress - The source account of the token transfer
-   * @param {Either<ZswapCoinPublicKey, ContractAddress>} to - The target account of the token transfer
+   * @param {Either<Uint8Array, ContractAddress>} fromAddress - The source account of the token transfer
+   * @param {Either<Uint8Array, ContractAddress>} to - The target account of the token transfer
    * @param {TokenId} tokenId - The token to transfer
    */
   public _unsafeTransfer(
-    fromAddress: Either<ZswapCoinPublicKey, ContractAddress>,
-    to: Either<ZswapCoinPublicKey, ContractAddress>,
+    fromAddress: Either<Uint8Array, ContractAddress>,
+    to: Either<Uint8Array, ContractAddress>,
     tokenId: bigint,
   ) {
     this.circuits.impure._unsafeTransfer(fromAddress, to, tokenId);
@@ -438,13 +437,51 @@ export class NonFungibleTokenSimulator extends NonFungibleTokenSimulatorBase {
    * - `tokenId` must not exist.
    * - `to` cannot be the zero address.
    *
-   * @param {Either<ZswapCoinPublicKey, ContractAddress>} to - The account receiving `tokenId`
+   * @param {Either<Uint8Array, ContractAddress>} to - The account receiving `tokenId`
    * @param {TokenId} tokenId - The token to transfer
    */
   public _unsafeMint(
-    to: Either<ZswapCoinPublicKey, ContractAddress>,
+    to: Either<Uint8Array, ContractAddress>,
     tokenId: bigint,
   ) {
     this.circuits.impure._unsafeMint(to, tokenId);
   }
+
+  /**
+   * @description Computes an account identifier without on-chain state, allowing a user to derive
+   * their identity commitment before submitting it in a grant or revoke operation.
+   * @param {Bytes<32>} secretKey - A 32-byte cryptographically secure random value.
+   * @returns {Bytes<32>} accountId - The computed account identifier.
+   */
+  public computeAccountId(secretKey: Uint8Array): Uint8Array {
+    return this.circuits.pure.computeAccountId(secretKey);
+  }
+
+  public readonly privateState = {
+    /**
+     * @description Replaces the secret key in the private state. Used in tests to
+     * simulate switching between different user identities or injecting incorrect
+     * keys to test failure paths.
+     * @param newSK - The new secret key to set.
+     * @returns The updated private state.
+     */
+    injectSecretKey: (newSK: Uint8Array): NonFungibleTokenPrivateState => {
+      const updatedState = NonFungibleTokenPrivateState.withSecretKey(newSK);
+      this.circuitContextManager.updatePrivateState(updatedState);
+      return updatedState;
+    },
+
+    /**
+     * @description Returns the current secret key from the private state.
+     * @returns The secret key.
+     * @throws If the secret key is undefined.
+     */
+    getCurrentSecretKey: (): Uint8Array => {
+      const sk = this.getPrivateState().secretKey;
+      if (typeof sk === 'undefined') {
+        throw new Error('Missing secret key');
+      }
+      return Uint8Array.from(sk);
+    },
+  };
 }

--- a/contracts/src/token/test/simulators/NonFungibleTokenSimulator.ts
+++ b/contracts/src/token/test/simulators/NonFungibleTokenSimulator.ts
@@ -82,9 +82,7 @@ export class NonFungibleTokenSimulator extends NonFungibleTokenSimulatorBase {
    * @param account The public key to query.
    * @return The number of tokens in `account`'s account.
    */
-  public balanceOf(
-    account: Either<Uint8Array, ContractAddress>,
-  ): bigint {
+  public balanceOf(account: Either<Uint8Array, ContractAddress>): bigint {
     return this.circuits.impure.balanceOf(account);
   }
 
@@ -125,10 +123,7 @@ export class NonFungibleTokenSimulator extends NonFungibleTokenSimulatorBase {
    * @param to The account receiving the approval
    * @param tokenId The token `to` may be permitted to transfer
    */
-  public approve(
-    to: Either<Uint8Array, ContractAddress>,
-    tokenId: bigint,
-  ) {
+  public approve(to: Either<Uint8Array, ContractAddress>, tokenId: bigint) {
     this.circuits.impure.approve(to, tokenId);
   }
 
@@ -137,9 +132,7 @@ export class NonFungibleTokenSimulator extends NonFungibleTokenSimulatorBase {
    * @param tokenId The token an account may be approved to manage
    * @return The account approved to manage the token
    */
-  public getApproved(
-    tokenId: bigint,
-  ): Either<Uint8Array, ContractAddress> {
+  public getApproved(tokenId: bigint): Either<Uint8Array, ContractAddress> {
     return this.circuits.impure.getApproved(tokenId);
   }
 
@@ -206,9 +199,7 @@ export class NonFungibleTokenSimulator extends NonFungibleTokenSimulatorBase {
    * @param tokenId The token that should be owned
    * @return The owner of `tokenId`
    */
-  public _requireOwned(
-    tokenId: bigint,
-  ): Either<Uint8Array, ContractAddress> {
+  public _requireOwned(tokenId: bigint): Either<Uint8Array, ContractAddress> {
     return this.circuits.impure._requireOwned(tokenId);
   }
 
@@ -218,9 +209,7 @@ export class NonFungibleTokenSimulator extends NonFungibleTokenSimulatorBase {
    * @param tokenId The target token of the owner query
    * @return The owner of the token
    */
-  public _ownerOf(
-    tokenId: bigint,
-  ): Either<Uint8Array, ContractAddress> {
+  public _ownerOf(tokenId: bigint): Either<Uint8Array, ContractAddress> {
     return this.circuits.impure._ownerOf(tokenId);
   }
 
@@ -289,9 +278,7 @@ export class NonFungibleTokenSimulator extends NonFungibleTokenSimulatorBase {
    * @param tokenId The token to query
    * @return An account approved to spend `tokenId`
    */
-  public _getApproved(
-    tokenId: bigint,
-  ): Either<Uint8Array, ContractAddress> {
+  public _getApproved(tokenId: bigint): Either<Uint8Array, ContractAddress> {
     return this.circuits.impure._getApproved(tokenId);
   }
 
@@ -325,10 +312,7 @@ export class NonFungibleTokenSimulator extends NonFungibleTokenSimulatorBase {
    * @param to The account receiving `tokenId`
    * @param tokenId The token to transfer
    */
-  public _mint(
-    to: Either<Uint8Array, ContractAddress>,
-    tokenId: bigint,
-  ) {
+  public _mint(to: Either<Uint8Array, ContractAddress>, tokenId: bigint) {
     this.circuits.impure._mint(to, tokenId);
   }
 
@@ -448,10 +432,7 @@ export class NonFungibleTokenSimulator extends NonFungibleTokenSimulatorBase {
    * @param {Either<Uint8Array, ContractAddress>} to - The account receiving `tokenId`
    * @param {TokenId} tokenId - The token to transfer
    */
-  public _unsafeMint(
-    to: Either<Uint8Array, ContractAddress>,
-    tokenId: bigint,
-  ) {
+  public _unsafeMint(to: Either<Uint8Array, ContractAddress>, tokenId: bigint) {
     this.circuits.impure._unsafeMint(to, tokenId);
   }
 

--- a/contracts/src/token/test/simulators/NonFungibleTokenSimulator.ts
+++ b/contracts/src/token/test/simulators/NonFungibleTokenSimulator.ts
@@ -54,6 +54,14 @@ export class NonFungibleTokenSimulator extends NonFungibleTokenSimulatorBase {
   }
 
   /**
+   * @description Returns a canonical zero Either value (left variant with zero Bytes<32>).
+   * @return The zero value.
+   */
+  public ZERO(): Either<Uint8Array, ContractAddress> {
+    return this.circuits.pure.ZERO();
+  }
+
+  /**
    * @description Returns the token name.
    * @returns The token name.
    */

--- a/contracts/src/token/witnesses/NonFungibleTokenWitnesses.ts
+++ b/contracts/src/token/witnesses/NonFungibleTokenWitnesses.ts
@@ -1,6 +1,80 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Compact Contracts v0.0.1-alpha.1 (token/witnesses/NonFungibleToken.ts)
 
-export type NonFungibleTokenPrivateState = Record<string, never>;
-export const NonFungibleTokenPrivateState: NonFungibleTokenPrivateState = {};
-export const NonFungibleTokenWitnesses = () => ({});
+import { getRandomValues } from 'node:crypto';
+import type { WitnessContext } from '@midnight-ntwrk/compact-runtime';
+
+/**
+ * @description Interface defining the witness methods for NonFungibleToken operations.
+ * @template P - The private state type.
+ */
+export interface INonFungibleTokenWitnesses<L, P> {
+  /**
+   * Retrieves the secret key from the private state.
+   * @param context - The witness context containing the private state.
+   * @returns A tuple of the private state and the secret key as a Uint8Array.
+   */
+  wit_NonFungibleTokenSK(context: WitnessContext<L, P>): [P, Uint8Array];
+}
+
+/**
+ * @description Represents the private state of an NonFungibleToken contract, storing a secret key.
+ */
+export type NonFungibleTokenPrivateState = {
+  /** @description A 32-byte secret key used for creating a public user identifier. */
+  secretKey: Uint8Array;
+};
+
+/**
+ * @description Utility object for managing the private state of an NonFungibleToken contract.
+ */
+export const NonFungibleTokenPrivateState = {
+  /**
+   * @description Generates a new private state with a random secret key.
+   * @returns A fresh NonFungibleTokenPrivateState instance.
+   */
+  generate: (): NonFungibleTokenPrivateState => {
+    return { secretKey: getRandomValues(new Uint8Array(32)) };
+  },
+
+  /**
+   * @description Generates a new private state with a user-defined secret key.
+   * Useful for deterministic key generation or advanced use cases.
+   *
+   * @param sk - The 32-byte secret key to use.
+   * @returns A fresh NonFungibleTokenPrivateState instance with the provided key.
+   *
+   * @example
+   * ```typescript
+   * // For deterministic keys (user-defined scheme)
+   * const deterministicKey = myDeterministicScheme(...);
+   * const privateState = NonFungibleTokenPrivateState.withSecretKey(deterministicKey);
+   * ```
+   */
+  withSecretKey: (sk: Uint8Array): NonFungibleTokenPrivateState => {
+    if (sk.length !== 32) {
+      throw new Error(
+        `withSecretKey: expected 32-byte secret key, received ${sk.length} bytes`,
+      );
+    }
+    return { secretKey: Uint8Array.from(sk) };
+  },
+};
+
+/**
+ * @description Factory function creating witness implementations for NonFungibleToken operations.
+ * @returns An object implementing the Witnesses interface for NonFungibleTokenPrivateState.
+ */
+export const NonFungibleTokenWitnesses = <L>(): INonFungibleTokenWitnesses<
+  L,
+  NonFungibleTokenPrivateState
+> => ({
+  wit_NonFungibleTokenSK(
+    context: WitnessContext<L, NonFungibleTokenPrivateState>,
+  ): [NonFungibleTokenPrivateState, Uint8Array] {
+    return [
+      context.privateState,
+      Uint8Array.from(context.privateState.secretKey),
+    ];
+  },
+});

--- a/contracts/src/token/witnesses/test/NonFungibleTokenWitnesses.test.ts
+++ b/contracts/src/token/witnesses/test/NonFungibleTokenWitnesses.test.ts
@@ -39,14 +39,18 @@ describe('NonFungibleTokenPrivateState', () => {
 
     it('should throw for a secret key shorter than 32 bytes', () => {
       const short = new Uint8Array(16);
-      expect(() => NonFungibleTokenPrivateState.withSecretKey(short)).toThrowError(
+      expect(() =>
+        NonFungibleTokenPrivateState.withSecretKey(short),
+      ).toThrowError(
         'withSecretKey: expected 32-byte secret key, received 16 bytes',
       );
     });
 
     it('should throw for a secret key longer than 32 bytes', () => {
       const long = new Uint8Array(64);
-      expect(() => NonFungibleTokenPrivateState.withSecretKey(long)).toThrowError(
+      expect(() =>
+        NonFungibleTokenPrivateState.withSecretKey(long),
+      ).toThrowError(
         'withSecretKey: expected 32-byte secret key, received 64 bytes',
       );
     });

--- a/contracts/src/token/witnesses/test/NonFungibleTokenWitnesses.test.ts
+++ b/contracts/src/token/witnesses/test/NonFungibleTokenWitnesses.test.ts
@@ -1,0 +1,138 @@
+import type { WitnessContext } from '@midnight-ntwrk/compact-runtime';
+import { describe, expect, it } from 'vitest';
+import type { Ledger } from '../../../../artifacts/MockNonFungibleToken/contract/index.js';
+import {
+  NonFungibleTokenPrivateState,
+  NonFungibleTokenWitnesses,
+} from '../NonFungibleTokenWitnesses.js';
+
+const SECRET_KEY = new Uint8Array(32).fill(0x34);
+
+describe('NonFungibleTokenPrivateState', () => {
+  describe('generate', () => {
+    it('should return a state with a 32-byte secretKey', () => {
+      const state = NonFungibleTokenPrivateState.generate();
+      expect(state.secretKey).toBeInstanceOf(Uint8Array);
+      expect(state.secretKey.length).toBe(32);
+    });
+
+    it('should produce unique secret key on successive calls', () => {
+      const a = NonFungibleTokenPrivateState.generate();
+      const b = NonFungibleTokenPrivateState.generate();
+      expect(a.secretKey).not.toEqual(b.secretKey);
+    });
+  });
+
+  describe('withSecretKey', () => {
+    it('should accept a valid 32-byte secret key', () => {
+      const state = NonFungibleTokenPrivateState.withSecretKey(SECRET_KEY);
+      expect(state.secretKey).toEqual(SECRET_KEY);
+    });
+
+    it('should create a defensive copy of the input secret key', () => {
+      const sk = new Uint8Array(32).fill(0xcc);
+      const state = NonFungibleTokenPrivateState.withSecretKey(sk);
+
+      sk.fill(0xff);
+      expect(state.secretKey).toEqual(new Uint8Array(32).fill(0xcc));
+    });
+
+    it('should throw for a secret key shorter than 32 bytes', () => {
+      const short = new Uint8Array(16);
+      expect(() => NonFungibleTokenPrivateState.withSecretKey(short)).toThrowError(
+        'withSecretKey: expected 32-byte secret key, received 16 bytes',
+      );
+    });
+
+    it('should throw for a secret key longer than 32 bytes', () => {
+      const long = new Uint8Array(64);
+      expect(() => NonFungibleTokenPrivateState.withSecretKey(long)).toThrowError(
+        'withSecretKey: expected 32-byte secret key, received 64 bytes',
+      );
+    });
+
+    it('should throw for an empty array', () => {
+      expect(() =>
+        NonFungibleTokenPrivateState.withSecretKey(new Uint8Array(0)),
+      ).toThrowError(
+        'withSecretKey: expected 32-byte secret key, received 0 bytes',
+      );
+    });
+  });
+});
+
+describe('NonFungibleTokenWitnesses', () => {
+  const witnesses = NonFungibleTokenWitnesses();
+
+  function makeContext(
+    privateState: NonFungibleTokenPrivateState,
+  ): WitnessContext<Ledger, NonFungibleTokenPrivateState> {
+    return { privateState } as WitnessContext<
+      Ledger,
+      NonFungibleTokenPrivateState
+    >;
+  }
+
+  describe('wit_NonFungibleTokenSK', () => {
+    it('should return a tuple of [privateState, secretKey]', () => {
+      const state = NonFungibleTokenPrivateState.withSecretKey(SECRET_KEY);
+      const ctx = makeContext(state);
+
+      const [returnedState, returnedSK] = witnesses.wit_NonFungibleTokenSK(ctx);
+
+      expect(returnedState).toBe(state);
+      expect(returnedSK).toEqual(SECRET_KEY);
+    });
+
+    it('should return the exact same privateState reference', () => {
+      const state = NonFungibleTokenPrivateState.generate();
+      const ctx = makeContext(state);
+
+      const [returnedState] = witnesses.wit_NonFungibleTokenSK(ctx);
+      expect(returnedState).toBe(state);
+    });
+
+    it('should return the secretKey as a Uint8Array', () => {
+      const state = NonFungibleTokenPrivateState.generate();
+      const ctx = makeContext(state);
+
+      const [, returnedSK] = witnesses.wit_NonFungibleTokenSK(ctx);
+      expect(returnedSK).toBeInstanceOf(Uint8Array);
+      expect(returnedSK.length).toBe(32);
+    });
+
+    it('should work with a randomly generated state', () => {
+      const state = NonFungibleTokenPrivateState.generate();
+      const ctx = makeContext(state);
+
+      const [returnedState, returnedSK] = witnesses.wit_NonFungibleTokenSK(ctx);
+
+      expect(returnedState).toBe(state);
+      expect(returnedSK).toEqual(state.secretKey);
+    });
+  });
+});
+
+describe('NonFungibleTokenWitnesses factory', () => {
+  it('should return a fresh witnesses object on each call', () => {
+    const a = NonFungibleTokenWitnesses();
+    const b = NonFungibleTokenWitnesses();
+    expect(a).not.toBe(b);
+  });
+
+  it('should produce witnesses with identical behaviour', () => {
+    const a = NonFungibleTokenWitnesses();
+    const b = NonFungibleTokenWitnesses();
+    const state = NonFungibleTokenPrivateState.generate();
+    const ctx = { privateState: state } as WitnessContext<
+      Ledger,
+      NonFungibleTokenPrivateState
+    >;
+
+    const [stateA, skA] = a.wit_NonFungibleTokenSK(ctx);
+    const [stateB, skB] = b.wit_NonFungibleTokenSK(ctx);
+
+    expect(stateA).toBe(stateB);
+    expect(skA).toEqual(skB);
+  });
+});


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

## Types of changes

What types of changes does your code introduce to OpenZeppelin Midnight Contracts?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

Fixes #456 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented a new account identification system for NFT ownership and authorization based on witness-derived 32-byte identifiers.

* **Bug Fixes**
  * Enhanced canonicalization behavior for account lookups in balance, approval, and transfer operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->