### PR TITLE
MultiToken refactor -> replace pk with sk

### DIFF
--- a/contracts/src/token/MultiToken.compact
+++ b/contracts/src/token/MultiToken.compact
@@ -160,6 +160,8 @@ module MultiToken {
   /**
    * @description Initializes the contract by setting the base URI for all tokens.
    *
+   * @circuitInfo k=6, rows=33
+   *
    * Requirements:
    *
    * - Must be called in the contract's constructor.
@@ -179,6 +181,8 @@ module MultiToken {
    * Clients calling this function must replace the `\{id\}` substring with the
    * actual token type ID.
    *
+   * @circuitInfo k=8, rows=176
+   *
    * Requirements:
    *
    * - Contract is initialized.
@@ -193,6 +197,8 @@ module MultiToken {
 
   /**
    * @description Returns the amount of `id` tokens owned by `account`.
+   *
+   * @circuitInfo k=10, rows=875
    *
    * Requirements:
    *
@@ -221,6 +227,8 @@ module MultiToken {
    * The caller's identity is derived from the `wit_MultiTokenSK` witness as
    * `persistentHash(secretKey)`.
    *
+   * @circuitInfo k=13, rows=2944
+   *
    * Requirements:
    *
    * - Contract is initialized.
@@ -243,6 +251,8 @@ module MultiToken {
 
   /**
    * @description Queries if `operator` is an authorized operator for `account`.
+   *
+   * @circuitInfo k=11, rows=1343
    *
    * Requirements:
    *
@@ -279,6 +289,8 @@ module MultiToken {
    * interactions are supported in Compact. This restriction prevents assets from
    * being inadvertently locked in contracts that cannot currently handle token receipt.
    *
+   * @circuitInfo k=13, rows=4926
+   *
    * Requirements:
    *
    * - Contract is initialized.
@@ -313,6 +325,8 @@ module MultiToken {
    * @notice Transfers to contract addresses are currently disallowed until contract-to-contract
    * interactions are supported in Compact. This restriction prevents assets from
    * being inadvertently locked in contracts that cannot currently handle token receipt.
+   *
+   * @circuitInfo k=12, rows=2450
    *
    * Requirements:
    *
@@ -397,6 +411,8 @@ module MultiToken {
    * calls are not currently supported. Tokens sent to a contract address may become irretrievable.
    * Once contract-to-contract calls are supported, this circuit may be deprecated.
    *
+   * @circuitInfo k=13, rows=4925
+   *
    * Requirements:
    *
    * - Contract is initialized.
@@ -436,6 +452,8 @@ module MultiToken {
    * @warning Transfers to contract addresses are considered unsafe because contract-to-contract
    * calls are not currently supported. Tokens sent to a contract address may become irretrievable.
    * Once contract-to-contract calls are supported, this circuit may be deprecated.
+   *
+   * @circuitInfo k=12, rows=2449
    *
    * Requirements:
    *
@@ -477,6 +495,8 @@ module MultiToken {
    * `https://token-cdn-domain/000000000000000000000000000000000000000000000000000000000004cce0.json`
    * for token type ID 0x4cce0.
    *
+   * @circuitInfo k=6, rows=28
+   *
    * Requirements:
    *
    * - Contract is initialized.
@@ -495,6 +515,8 @@ module MultiToken {
    * @notice Transfers to contract addresses are currently disallowed until contract-to-contract
    * interactions are supported in Compact. This restriction prevents assets from
    * being inadvertently locked in contracts that cannot currently handle token receipt.
+   *
+   * @circuitInfo k=11, rows=1531
    *
    * Requirements:
    *
@@ -523,6 +545,8 @@ module MultiToken {
    * calls are not currently supported. Tokens sent to a contract address may become irretrievable.
    * Once contract-to-contract calls are supported, this circuit may be deprecated.
    *
+   * @circuitInfo k=11, rows=1530
+   *
    * Requirements:
    *
    * - Contract is initialized.
@@ -545,6 +569,8 @@ module MultiToken {
 
   /**
    * @description Destroys a `value` amount of tokens of type `id` from `fromAddress`.
+   *
+   * @circuitInfo k=11, rows=1222
    *
    * Requirements:
    *
@@ -571,6 +597,8 @@ module MultiToken {
    *
    * @notice This circuit does not check for access permissions but can be useful as a building block
    * for more complex contract logic.
+   *
+   * @circuitInfo k=11, rows=1279
    *
    * Requirements:
    *

--- a/contracts/src/token/MultiToken.compact
+++ b/contracts/src/token/MultiToken.compact
@@ -10,13 +10,24 @@ pragma language_version >= 0.21.0;
  * therefore, the MultiToken module should be treated as an approximation of
  * the ERC1155 standard and not necessarily a compliant implementation.
  *
+ * Authorization is based on a witness-derived identity scheme. Each caller proves knowledge
+ * of a secret key by injecting it via the `wit_MultiTokenSK` witness. The module computes
+ * an account identifier as `persistentHash(secretKey)` which is a commitment that hides the key
+ * while providing a stable, pseudonymous on-chain identity.
+ *
+ * Because the account identifier is `H(secretKey)` with no per-deployment salt or domain
+ * separator, the same secret key produces the same identity across all contracts. This is
+ * intentional. It provides a linkable pseudonymous identity analogous to Solidity's
+ * `msg.sender`. Users who desire cross-contract unlinkability can use different secret keys
+ * per contract at the wallet layer.
+ *
  * @notice One notable difference regarding this implementation and the EIP1155 spec
  * consists of the token size. Uint<128> is used as the token size because Uint<256>
  * cannot be supported. This is true for both token IDs and for amounts.
  * This is due to encoding limits on the midnight circuit backend:
  * https://github.com/midnightntwrk/compactc/issues/929
  *
- * @notice Some features defined in th EIP1155 spec are NOT included.
+ * @notice Some features defined in the EIP1155 spec are NOT included.
  * Such features include:
  *
  * 1. Batch mint, burn, transfer - Without support for dynamic arrays,
@@ -31,7 +42,7 @@ pragma language_version >= 0.21.0;
  * explicitly define the number of balances to query in the circuit i.e.
  *
  * balanceOfBatch_10(
- *    accounts: Vector<10, Either<ZswapCoinPublicKey, ContractAddress>>,
+ *    accounts: Vector<10, Either<Bytes<32>, ContractAddress>>,
  *    ids: Vector<10, Uint<128>>
  * ): Vector<10, Uint<128>>
  *
@@ -57,6 +68,25 @@ pragma language_version >= 0.21.0;
  * - Introspection.
  * - Contract-to-contract calls for acceptance callback.
  *
+ * @dev Canonicalization
+ * All `Either<Bytes<32>, ContractAddress>` values are canonicalized before use as map keys
+ * or in ledger writes. Canonicalization zeroes out the inactive branch of the Either,
+ * ensuring that two values with the same active branch always resolve to the same map key
+ * regardless of what data the inactive branch carries. Write paths are canonicalized in
+ * `_update` (for `_balances`) and `_setApprovalForAll` (for `_operatorApprovals`).
+ * Read paths are canonicalized in `balanceOf` and `isApprovedForAll`.
+ * `_unsafeTransferFrom` canonicalizes `fromAddress` before comparing against the caller identity.
+ *
+ * @dev Security Considerations:
+ * - The `secretKey` must be kept private. Loss of the key prevents token holders
+ *   from proving ownership or authorization. Key exposure allows impersonation.
+ * - It is strongly recommended to use cryptographically secure random values for the secret key
+ *   (e.g., `crypto.getRandomValues()`). Weak or predictable keys can be brute-forced.
+ * - The `secretKey` is provided via the `wit_MultiTokenSK` witness. As with all witnesses,
+ *   the contract must not assume that the witness implementation matches the developer's code.
+ *   Any DApp may provide any implementation. The ZK proof system constrains what values
+ *   can produce valid proofs.
+ *
  * @notice Further discussion and consideration required:
  *
  * - Consider changing the underscore in the internal methods to `unsafe` or
@@ -71,24 +101,24 @@ module MultiToken {
   /**
    * @description Mapping from token ID to account balances.
    * @type {Uint<128>} id - The token identifier.
-   * @type {Either<ZswapCoinPublicKey, ContractAddress>} account - The account address.
+   * @type {Either<Bytes<32>, ContractAddress>} account - The account address.
    * @type {Uint<128>} balance - The balance of the account for the token.
    * @type {Map<id, Map<account, balance>>}
-   * @type {Map<Uint<128>, Map<Either<ZswapCoinPublicKey, ContractAddress>, Uint<128>>>} _balances
+   * @type {Map<Uint<128>, Map<Either<Bytes<32>, ContractAddress>, Uint<128>>>} _balances
    */
   export ledger _balances: Map<Uint<128>,
-                               Map<Either<ZswapCoinPublicKey, ContractAddress>, Uint<128>>>;
+                               Map<Either<Bytes<32>, ContractAddress>, Uint<128>>>;
 
   /**
    * @description Mapping from account to operator approvals.
-   * @type {Either<ZswapCoinPublicKey, ContractAddress>} account - The account address.
-   * @type {Either<ZswapCoinPublicKey, ContractAddress>} operator - The operator address.
+   * @type {Either<Bytes<32>, ContractAddress>} account - The account address.
+   * @type {Either<Bytes<32>, ContractAddress>} operator - The operator address.
    * @type {Boolean} approved - The approval status of the operator for the account.
    * @type {Map<account, Map<operator, approved>>}
-   * @type {Map<Either<ZswapCoinPublicKey, ContractAddress>, Map<Either<ZswapCoinPublicKey, ContractAddress>, Boolean>>}
+   * @type {Map<Either<Bytes<32>, ContractAddress>, Map<Either<Bytes<32>, ContractAddress>, Boolean>>}
    */
-  export ledger _operatorApprovals: Map<Either<ZswapCoinPublicKey, ContractAddress>,
-                                        Map<Either<ZswapCoinPublicKey, ContractAddress>, Boolean>>;
+  export ledger _operatorApprovals: Map<Either<Bytes<32>, ContractAddress>,
+                                        Map<Either<Bytes<32>, ContractAddress>, Boolean>>;
 
   /**
    * @description Base URI for computing token URIs.
@@ -98,9 +128,37 @@ module MultiToken {
   export ledger _uri: Opaque<"string">;
 
   /**
-   * @description Initializes the contract by setting the base URI for all tokens.
+   * @witness wit_MultiTokenSK
+   * @description Returns the caller's secret key used in deriving the account identifier.
    *
-   * @circuitInfo k=10, rows=45
+   * The same key produces the same account identifier across all contracts. Users who
+   * desire cross-contract unlinkability should use different keys per contract.
+   *
+   * @returns {Bytes<32>} secretKey - A 32-byte cryptographically secure random value.
+   */
+  witness wit_MultiTokenSK(): Bytes<32>;
+
+  /**
+   * @description Returns a canonical zero Either value (left variant with zero Bytes<32>).
+   * Used as the zero value for mint/burn operations in `_update`, where a zero
+   * `fromAddress` signals a mint and a zero `to` signals a burn.
+   *
+   * The left variant is chosen so that `_isTargetZero` checks against `default<Bytes<32>>`,
+   * which is consistent with how `_update` dispatches on the zero check. A right variant
+   * with `default<ContractAddress>` would also pass `_isTargetZero`, but using the left
+   * variant avoids triggering contract address guards in circuits like `_mint` that check
+   * `!to.is_left` before delegating to `_unsafeMint`.
+   *
+   * @return {Either<Bytes<32>, ContractAddress>} - The zero value.
+   */
+  export pure circuit ZERO(): Either<Bytes<32>, ContractAddress> {
+    return Either<Bytes<32>, ContractAddress> {
+      is_left: true, left: default<Bytes<32>>, right: default<ContractAddress>
+    };
+  }
+
+  /**
+   * @description Initializes the contract by setting the base URI for all tokens.
    *
    * Requirements:
    *
@@ -121,135 +179,129 @@ module MultiToken {
    * Clients calling this function must replace the `\{id\}` substring with the
    * actual token type ID.
    *
-   * @circuitInfo k=10, rows=90
-   *
    * Requirements:
    *
    * - Contract is initialized.
    *
    * @param {Uint<128>} id - The token identifier to query.
-   * return {Opaque<"string">} - The base URI for all tokens.
+   * @return {Opaque<"string">} - The base URI for all tokens.
    */
   export circuit uri(id: Uint<128>): Opaque<"string"> {
     Initializable_assertInitialized();
-
     return _uri;
   }
 
   /**
    * @description Returns the amount of `id` tokens owned by `account`.
    *
-   * @circuitInfo k=10, rows=439
-   *
    * Requirements:
    *
    * - Contract is initialized.
    *
-   * @param {Either<ZswapCoinPublicKey, ContractAddress>} account - The account balance to query.
+   * @param {Either<Bytes<32>, ContractAddress>} account - The account balance to query.
    * @param {Uint<128>} id - The token identifier to query.
-   * return {Uint<128>} - The quantity of `id` tokens that `account` owns.
+   * @return {Uint<128>} - The quantity of `id` tokens that `account` owns.
    */
   export circuit balanceOf(
-                   account: Either<ZswapCoinPublicKey, ContractAddress>,
+                   account: Either<Bytes<32>, ContractAddress>,
                    id: Uint<128>
                    ): Uint<128> {
     Initializable_assertInitialized();
+    const canonAcct = Utils_canonicalize<Bytes<32>, ContractAddress>(account);
 
-    if (!_balances.member(disclose(id)) || !_balances.lookup(id).member(disclose(account))) {
+    if (!_balances.member(disclose(id)) || !_balances.lookup(id).member(disclose(canonAcct))) {
       return 0;
     }
-    return _balances.lookup(id).lookup(disclose(account));
+    return _balances.lookup(id).lookup(disclose(canonAcct));
   }
 
   /**
    * @description Enables or disables approval for `operator` to manage all of the caller's assets.
    *
-   * @circuitInfo k=10, rows=404
+   * The caller's identity is derived from the `wit_MultiTokenSK` witness as
+   * `persistentHash(secretKey)`.
    *
    * Requirements:
    *
    * - Contract is initialized.
-   * - `operator` is not the zero address.
+   * - `operator` is not zero.
    *
-   * @param {Either<ZswapCoinPublicKey, ContractAddress>} operator - The ZswapCoinPublicKey or ContractAddress
-   * whose approval is set for the caller's assets.
+   * @param {Either<Bytes<32>, ContractAddress>} operator - The account whose approval is set
+   * for the caller's assets.
    * @param {Boolean} approved - The boolean value determining if the operator may or may not handle the
    * caller's assets.
    * @return {[]} - Empty tuple.
    */
   export circuit setApprovalForAll(
-                   operator: Either<ZswapCoinPublicKey, ContractAddress>,
+                   operator: Either<Bytes<32>, ContractAddress>,
                    approved: Boolean
                    ): [] {
     Initializable_assertInitialized();
-
-    // TODO: Contract-to-contract calls not yet supported.
-    const caller = left<ZswapCoinPublicKey, ContractAddress>(ownPublicKey());
+    const caller = left<Bytes<32>, ContractAddress>(_computeAccountId());
     _setApprovalForAll(caller, operator, approved);
   }
 
   /**
-   * @description Queries if `operator` is an authorized operator for `owner`.
-   *
-   * @circuitInfo k=10, rows=619
+   * @description Queries if `operator` is an authorized operator for `account`.
    *
    * Requirements:
    *
    * - Contract is initialized.
    *
-   * @param {Either<ZswapCoinPublicKey, ContractAddress>} account - The queried possessor of assets.
-   * @param {Either<ZswapCoinPublicKey, ContractAddress>} operator - The queried handler of `account`'s assets.
+   * @param {Either<Bytes<32>, ContractAddress>} account - The queried possessor of assets.
+   * @param {Either<Bytes<32>, ContractAddress>} operator - The queried handler of `account`'s assets.
    * @return {Boolean} - Whether or not `operator` has permission to handle `account`'s assets.
    */
   export circuit isApprovedForAll(
-                   account: Either<ZswapCoinPublicKey, ContractAddress>,
-                   operator: Either<ZswapCoinPublicKey, ContractAddress>
+                   account: Either<Bytes<32>, ContractAddress>,
+                   operator: Either<Bytes<32>, ContractAddress>
                    ): Boolean {
     Initializable_assertInitialized();
+    const canonAcct = Utils_canonicalize<Bytes<32>, ContractAddress>(account);
+    const canonOp = Utils_canonicalize<Bytes<32>, ContractAddress>(operator);
 
-    if (!_operatorApprovals.member(disclose(account)) ||
-        !_operatorApprovals.lookup(account).member(disclose(operator))) {
+    if (!_operatorApprovals.member(disclose(canonAcct)) ||
+        !_operatorApprovals.lookup(canonAcct).member(disclose(canonOp))) {
       return false;
     }
 
-    return _operatorApprovals.lookup(account).lookup(disclose(operator));
+    return _operatorApprovals.lookup(canonAcct).lookup(disclose(canonOp));
   }
 
   /**
    * @description Transfers ownership of `value` amount of `id` tokens from `fromAddress` to `to`.
    * The caller must be `fromAddress` or approved to transfer on their behalf.
    *
-   * @circuitInfo k=11, rows=1882
+   * The caller's identity is derived from the `wit_MultiTokenSK` witness as
+   * `persistentHash(secretKey)`.
    *
    * @notice Transfers to contract addresses are currently disallowed until contract-to-contract
    * interactions are supported in Compact. This restriction prevents assets from
    * being inadvertently locked in contracts that cannot currently handle token receipt.
    *
-   * @extensibility External circuit. Can be used directly by consumers of this module.
-   * See **Extensibility** documentation for usage patterns.
-   *
    * Requirements:
    *
    * - Contract is initialized.
    * - `to` is not a ContractAddress.
-   * - `to` is not the zero address.
-   * - `fromAddress` is not the zero address.
+   * - `to` is not zero.
+   * - `fromAddress` is not zero.
    * - Caller must be `fromAddress` or approved via `setApprovalForAll`.
    * - `fromAddress` must have an `id` balance of at least `value`.
    *
-   * @param {Either<ZswapCoinPublicKey, ContractAddress>} fromAddress - The owner from which the transfer originates.
-   * @param {Either<ZswapCoinPublicKey, ContractAddress>} to - The recipient of the transferred assets.
+   * @param {Either<Bytes<32>, ContractAddress>} fromAddress - The owner from which the transfer originates.
+   * @param {Either<Bytes<32>, ContractAddress>} to - The recipient of the transferred assets.
    * @param {Uint<128>} id - The unique identifier of the asset type.
    * @param {Uint<128>} value - The quantity of `id` tokens to transfer.
    * @return {[]} - Empty tuple.
    */
   export circuit transferFrom(
-                   fromAddress: Either<ZswapCoinPublicKey, ContractAddress>,
-                   to: Either<ZswapCoinPublicKey, ContractAddress>,
+                   fromAddress: Either<Bytes<32>, ContractAddress>,
+                   to: Either<Bytes<32>, ContractAddress>,
                    id: Uint<128>,
                    value: Uint<128>
                    ): [] {
-    assert(!Utils_isContractAddress(to), "MultiToken: unsafe transfer");
+    const isContractAddr = !to.is_left;
+    assert(!isContractAddr, "MultiToken: unsafe transfer");
     _unsafeTransferFrom(fromAddress, to, id, value);
   }
 
@@ -258,8 +310,6 @@ module MultiToken {
    * Does not impose restrictions on the caller, making it suitable for composition
    * in higher-level contract logic.
    *
-   * @circuitInfo k=11, rows=1487
-   *
    * @notice Transfers to contract addresses are currently disallowed until contract-to-contract
    * interactions are supported in Compact. This restriction prevents assets from
    * being inadvertently locked in contracts that cannot currently handle token receipt.
@@ -268,70 +318,70 @@ module MultiToken {
    *
    * - Contract is initialized.
    * - `to` is not a ContractAddress.
-   * - `to` is not the zero address.
-   * - `fromAddress` is not the zero address.
+   * - `to` is not zero.
+   * - `fromAddress` is not zero.
    * - `fromAddress` must have an `id` balance of at least `value`.
    *
-   * @param {Either<ZswapCoinPublicKey, ContractAddress>} fromAddress - The owner from which the transfer originates.
-   * @param {Either<ZswapCoinPublicKey, ContractAddress>} to - The recipient of the transferred assets.
+   * @param {Either<Bytes<32>, ContractAddress>} fromAddress - The owner from which the transfer originates.
+   * @param {Either<Bytes<32>, ContractAddress>} to - The recipient of the transferred assets.
    * @param {Uint<128>} id - The unique identifier of the asset type.
    * @param {Uint<128>} value - The quantity of `id` tokens to transfer.
    * @return {[]} - Empty tuple.
    */
   export circuit _transfer(
-                   fromAddress: Either<ZswapCoinPublicKey, ContractAddress>,
-                   to: Either<ZswapCoinPublicKey, ContractAddress>,
+                   fromAddress: Either<Bytes<32>, ContractAddress>,
+                   to: Either<Bytes<32>, ContractAddress>,
                    id: Uint<128>,
                    value: Uint<128>
                    ): [] {
-    assert(!Utils_isContractAddress(to), "MultiToken: unsafe transfer");
+    const isContractAddr = !to.is_left;
+    assert(!isContractAddr, "MultiToken: unsafe transfer");
     _unsafeTransfer(fromAddress, to, id, value);
   }
 
   /**
    * @description Transfers a value amount of tokens of type id from fromAddress to to.
-   * This circuit will mint (or burn) if `fromAddress` (or `to`) is the zero address.
-   *
-   * @circuitInfo k=11, rows=1482
+   * This circuit will mint (or burn) if `fromAddress` (or `to`) is zero.
    *
    * Requirements:
    *
    * - Contract is initialized.
    * - If `fromAddress` is not zero, the balance of `id` of `fromAddress` must be >= `value`.
    *
-   * @param {Either<ZswapCoinPublicKey, ContractAddress>} fromAddress - The origin of the transfer.
-   * @param {Either<ZswapCoinPublicKey, ContractAddress>} to - The destination of the transfer.
+   * @param {Either<Bytes<32>, ContractAddress>} fromAddress - The origin of the transfer.
+   * @param {Either<Bytes<32>, ContractAddress>} to - The destination of the transfer.
    * @param {Uint<128>} id - The unique identifier of the asset type.
    * @param {Uint<128>} value - The quantity of `id` tokens to transfer.
    * @return {[]} - Empty tuple.
    */
-  circuit _update(fromAddress: Either<ZswapCoinPublicKey, ContractAddress>,
-                  to: Either<ZswapCoinPublicKey, ContractAddress>,
+  circuit _update(fromAddress: Either<Bytes<32>, ContractAddress>,
+                  to: Either<Bytes<32>, ContractAddress>,
                   id: Uint<128>,
                   value: Uint<128>
                   ): [] {
     Initializable_assertInitialized();
+    const canonFrom = Utils_canonicalize<Bytes<32>, ContractAddress>(fromAddress);
+    const canonTo = Utils_canonicalize<Bytes<32>, ContractAddress>(to);
 
-    if (!Utils_isKeyOrAddressZero(disclose(fromAddress))) {
-      const fromBalance = balanceOf(fromAddress, id);
+    if (!_isTargetZero(disclose(canonFrom))) {
+      const fromBalance = balanceOf(canonFrom, id);
       assert(fromBalance >= value, "MultiToken: insufficient balance");
-      // overflow not possible
       const newBalance = fromBalance - value;
-      _balances.lookup(id).insert(disclose(fromAddress), disclose(newBalance));
+      _balances.lookup(id).insert(disclose(canonFrom), disclose(newBalance));
     }
 
-    if (!Utils_isKeyOrAddressZero(disclose(to))) {
-      // id not initialized
+    if (!_isTargetZero(disclose(canonTo))) {
       if (!_balances.member(disclose(id))) {
         _balances.insert(
           disclose(id),
-          default<Map<Either<ZswapCoinPublicKey, ContractAddress>, Uint<128>>>
+          default<Map<Either<Bytes<32>, ContractAddress>, Uint<128>>>
           );
-        _balances.lookup(id).insert(disclose(to), disclose(value as Uint<128>));
+        _balances.lookup(id).insert(disclose(canonTo), disclose(value as Uint<128>));
       } else {
-        const toBalance = balanceOf(to, id), MAX_UINT128 = 340282366920938463463374607431768211455;
+        const toBalance = balanceOf(canonTo, id);
+        const MAX_UINT128 = 340282366920938463463374607431768211455;
         assert(MAX_UINT128 - toBalance >= value, "MultiToken: arithmetic overflow");
-        _balances.lookup(id).insert(disclose(to), disclose(toBalance + value as Uint<128>));
+        _balances.lookup(id).insert(disclose(canonTo), disclose(toBalance + value as Uint<128>));
       }
     }
   }
@@ -340,7 +390,8 @@ module MultiToken {
    * @description Unsafe variant of `transferFrom` which allows transfers to contract addresses.
    * The caller must be `fromAddress` or approved to transfer on their behalf.
    *
-   * @circuitInfo k=11, rows=1881
+   * The caller's identity is derived from the `wit_MultiTokenSK` witness as
+   * `persistentHash(secretKey)`.
    *
    * @warning Transfers to contract addresses are considered unsafe because contract-to-contract
    * calls are not currently supported. Tokens sent to a contract address may become irretrievable.
@@ -349,33 +400,32 @@ module MultiToken {
    * Requirements:
    *
    * - Contract is initialized.
-   * - `to` is not the zero address.
-   * - `fromAddress` is not the zero address.
+   * - `to` is not zero.
+   * - `fromAddress` is not zero.
    * - Caller must be `fromAddress` or approved via `setApprovalForAll`.
    * - `fromAddress` must have an `id` balance of at least `value`.
    *
-   * @param {Either<ZswapCoinPublicKey, ContractAddress>} fromAddress - The owner from which the transfer originates.
-   * @param {Either<ZswapCoinPublicKey, ContractAddress>} to - The recipient of the transferred assets.
+   * @param {Either<Bytes<32>, ContractAddress>} fromAddress - The owner from which the transfer originates.
+   * @param {Either<Bytes<32>, ContractAddress>} to - The recipient of the transferred assets.
    * @param {Uint<128>} id - The unique identifier of the asset type.
    * @param {Uint<128>} value - The quantity of `id` tokens to transfer.
    * @return {[]} - Empty tuple.
    */
   export circuit _unsafeTransferFrom(
-                   fromAddress: Either<ZswapCoinPublicKey, ContractAddress>,
-                   to: Either<ZswapCoinPublicKey, ContractAddress>,
+                   fromAddress: Either<Bytes<32>, ContractAddress>,
+                   to: Either<Bytes<32>, ContractAddress>,
                    id: Uint<128>,
                    value: Uint<128>
                    ): [] {
     Initializable_assertInitialized();
 
-    // TODO: Contract-to-contract calls not yet supported.
-    // Once available, handle ContractAddress recipients here.
-    const caller = left<ZswapCoinPublicKey, ContractAddress>(ownPublicKey());
-    if (disclose(fromAddress) != caller) {
-      assert(isApprovedForAll(fromAddress, caller), "MultiToken: unauthorized operator");
+    const caller = left<Bytes<32>, ContractAddress>(_computeAccountId());
+    const canonFrom = Utils_canonicalize<Bytes<32>, ContractAddress>(fromAddress);
+    if (disclose(canonFrom) != disclose(caller)) {
+      assert(isApprovedForAll(canonFrom, caller), "MultiToken: unauthorized operator");
     }
 
-    _unsafeTransfer(fromAddress, to, id, value);
+    _unsafeTransfer(canonFrom, to, id, value);
   }
 
   /**
@@ -383,8 +433,6 @@ module MultiToken {
    * Does not impose restrictions on the caller, making it suitable as a low-level
    * building block for advanced contract logic.
    *
-   * @circuitInfo k=11, rows=1486
-   *
    * @warning Transfers to contract addresses are considered unsafe because contract-to-contract
    * calls are not currently supported. Tokens sent to a contract address may become irretrievable.
    * Once contract-to-contract calls are supported, this circuit may be deprecated.
@@ -392,26 +440,26 @@ module MultiToken {
    * Requirements:
    *
    * - Contract is initialized.
-   * - `fromAddress` is not the zero address.
-   * - `to` is not the zero address.
+   * - `fromAddress` is not zero.
+   * - `to` is not zero.
    * - `fromAddress` must have an `id` balance of at least `value`.
    *
-   * @param {Either<ZswapCoinPublicKey, ContractAddress>} fromAddress - The owner from which the transfer originates.
-   * @param {Either<ZswapCoinPublicKey, ContractAddress>} to - The recipient of the transferred assets.
+   * @param {Either<Bytes<32>, ContractAddress>} fromAddress - The owner from which the transfer originates.
+   * @param {Either<Bytes<32>, ContractAddress>} to - The recipient of the transferred assets.
    * @param {Uint<128>} id - The unique identifier of the asset type.
    * @param {Uint<128>} value - The quantity of `id` tokens to transfer.
    * @return {[]} - Empty tuple.
    */
   export circuit _unsafeTransfer(
-                   fromAddress: Either<ZswapCoinPublicKey, ContractAddress>,
-                   to: Either<ZswapCoinPublicKey, ContractAddress>,
+                   fromAddress: Either<Bytes<32>, ContractAddress>,
+                   to: Either<Bytes<32>, ContractAddress>,
                    id: Uint<128>,
                    value: Uint<128>
                    ): [] {
     Initializable_assertInitialized();
 
-    assert(!Utils_isKeyOrAddressZero(fromAddress), "MultiToken: invalid sender");
-    assert(!Utils_isKeyOrAddressZero(to), "MultiToken: invalid receiver");
+    assert(!_isTargetZero(fromAddress), "MultiToken: invalid sender");
+    assert(!_isTargetZero(to), "MultiToken: invalid receiver");
     _update(fromAddress, to, id, value);
   }
 
@@ -419,8 +467,6 @@ module MultiToken {
    * @description Sets a new URI for all token types, by relying on the token type ID
    * substitution mechanism defined in the MultiToken standard.
    * See https://eips.ethereum.org/EIPS/eip-1155#metadata.
-   *
-   * @circuitInfo k=10, rows=39
    *
    * @notice By this mechanism, any occurrence of the `\{id\}` substring in either the
    * URI or any of the values in the JSON file at said URI will be replaced by
@@ -440,14 +486,11 @@ module MultiToken {
    */
   export circuit _setURI(newURI: Opaque<"string">): [] {
     Initializable_assertInitialized();
-
     _uri = disclose(newURI);
   }
 
   /**
-   * @description Creates a `value` amount of tokens of type `token_id`, and assigns them to `to`.
-   *
-   * @circuitInfo k=10, rows=912
+   * @description Creates a `value` amount of tokens of type `id`, and assigns them to `to`.
    *
    * @notice Transfers to contract addresses are currently disallowed until contract-to-contract
    * interactions are supported in Compact. This restriction prevents assets from
@@ -456,26 +499,25 @@ module MultiToken {
    * Requirements:
    *
    * - Contract is initialized.
-   * - `to` is not the zero address.
+   * - `to` is not zero.
    * - `to` is not a ContractAddress.
    *
-   * @param {Either<ZswapCoinPublicKey, ContractAddress>} to - The recipient of the minted tokens.
+   * @param {Either<Bytes<32>, ContractAddress>} to - The recipient of the minted tokens.
    * @param {Uint<128>} id - The unique identifier for the token type.
    * @param {Uint<128>} value - The quantity of `id` tokens that are minted to `to`.
    * @return {[]} - Empty tuple.
    */
-  export circuit _mint(to: Either<ZswapCoinPublicKey, ContractAddress>,
+  export circuit _mint(to: Either<Bytes<32>, ContractAddress>,
                        id: Uint<128>,
                        value: Uint<128>
                        ): [] {
-    assert(!Utils_isContractAddress(to), "MultiToken: unsafe transfer");
+    const isContractAddr = !to.is_left;
+    assert(!isContractAddr, "MultiToken: unsafe transfer");
     _unsafeMint(to, id, value);
   }
 
   /**
    * @description Unsafe variant of `_mint` which allows transfers to contract addresses.
-   *
-   * @circuitInfo k=10, rows=911
    *
    * @warning Transfers to contract addresses are considered unsafe because contract-to-contract
    * calls are not currently supported. Tokens sent to a contract address may become irretrievable.
@@ -484,54 +526,48 @@ module MultiToken {
    * Requirements:
    *
    * - Contract is initialized.
-   * - `to` is not the zero address.
+   * - `to` is not zero.
    *
-   * @param {Either<ZswapCoinPublicKey, ContractAddress>} to - The recipient of the minted tokens.
+   * @param {Either<Bytes<32>, ContractAddress>} to - The recipient of the minted tokens.
    * @param {Uint<128>} id - The unique identifier for the token type.
    * @param {Uint<128>} value - The quantity of `id` tokens that are minted to `to`.
    * @return {[]} - Empty tuple.
    */
   export circuit _unsafeMint(
-                   to: Either<ZswapCoinPublicKey, ContractAddress>,
+                   to: Either<Bytes<32>, ContractAddress>,
                    id: Uint<128>,
                    value: Uint<128>
                    ): [] {
     Initializable_assertInitialized();
-
-    assert(!Utils_isKeyOrAddressZero(to), "MultiToken: invalid receiver");
-    _update(shieldedBurnAddress(), to, id, value);
+    assert(!_isTargetZero(to), "MultiToken: invalid receiver");
+    _update(ZERO(), to, id, value);
   }
 
   /**
-   * @description Destroys a `value` amount of tokens of type `token_id` from `fromAddress`.
-   *
-   * @circuitInfo k=10, rows=688
+   * @description Destroys a `value` amount of tokens of type `id` from `fromAddress`.
    *
    * Requirements:
    *
    * - Contract is initialized.
-   * - `fromAddress` is not the zero address.
+   * - `fromAddress` is not zero.
    * - `fromAddress` must have an `id` balance of at least `value`.
    *
-   * @param {Either<ZswapCoinPublicKey, ContractAddress>} fromAddress - The owner whose tokens will be destroyed.
+   * @param {Either<Bytes<32>, ContractAddress>} fromAddress - The owner whose tokens will be destroyed.
    * @param {Uint<128>} id - The unique identifier of the token type.
    * @param {Uint<128>} value - The quantity of `id` tokens that will be destroyed from `fromAddress`.
    * @return {[]} - Empty tuple.
    */
-  export circuit _burn(fromAddress: Either<ZswapCoinPublicKey, ContractAddress>,
+  export circuit _burn(fromAddress: Either<Bytes<32>, ContractAddress>,
                        id: Uint<128>,
                        value: Uint<128>
                        ): [] {
     Initializable_assertInitialized();
-
-    assert(!Utils_isKeyOrAddressZero(fromAddress), "MultiToken: invalid sender");
-    _update(fromAddress, shieldedBurnAddress(), id, value);
+    assert(!_isTargetZero(fromAddress), "MultiToken: invalid sender");
+    _update(fromAddress, ZERO(), id, value);
   }
 
   /**
-   * @description Enables or disables approval for `operator` to manage all of the caller's assets.
-   *
-   * @circuitInfo k=10, rows=518
+   * @description Enables or disables approval for `operator` to manage all of `owner`'s assets.
    *
    * @notice This circuit does not check for access permissions but can be useful as a building block
    * for more complex contract logic.
@@ -539,30 +575,95 @@ module MultiToken {
    * Requirements:
    *
    * - Contract is initialized.
-   * - `operator` is not the zero address.
+   * - `owner` is not zero.
+   * - `operator` is not zero.
    *
-   * @param {Either<ZswapCoinPublicKey, ContractAddress>} owner - The ZswapCoinPublicKey or ContractAddress of the target owner.
-   * @param {Either<ZswapCoinPublicKey, ContractAddress>} operator - The ZswapCoinPublicKey or ContractAddress whose approval is set for the
-   * `owner`'s assets.
+   * @param {Either<Bytes<32>, ContractAddress>} owner - The account whose assets are managed.
+   * @param {Either<Bytes<32>, ContractAddress>} operator - The account whose approval is set for
+   * the `owner`'s assets.
    * @param {Boolean} approved - The boolean value determining if the operator may or may not handle the
    * `owner`'s assets.
    * @return {[]} - Empty tuple.
    */
   export circuit _setApprovalForAll(
-                   owner: Either<ZswapCoinPublicKey, ContractAddress>,
-                   operator: Either<ZswapCoinPublicKey, ContractAddress>,
+                   owner: Either<Bytes<32>, ContractAddress>,
+                   operator: Either<Bytes<32>, ContractAddress>,
                    approved: Boolean
                    ): [] {
     Initializable_assertInitialized();
+    const canonOwner = Utils_canonicalize<Bytes<32>, ContractAddress>(owner);
+    assert(!_isTargetZero(canonOwner), "MultiToken: invalid owner");
 
-    assert(!Utils_isKeyOrAddressZero(operator), "MultiToken: invalid operator");
-    if (!_operatorApprovals.member(disclose(owner))) {
+    const canonOp = Utils_canonicalize<Bytes<32>, ContractAddress>(operator);
+    assert(!_isTargetZero(canonOp), "MultiToken: invalid operator");
+
+    if (!_operatorApprovals.member(disclose(canonOwner))) {
       _operatorApprovals.insert(
-        disclose(owner),
-        default<Map<Either<ZswapCoinPublicKey, ContractAddress>, Boolean>>
+        disclose(canonOwner),
+        default<Map<Either<Bytes<32>, ContractAddress>, Boolean>>
         );
     }
 
-    _operatorApprovals.lookup(owner).insert(disclose(operator), disclose(approved));
+    _operatorApprovals.lookup(canonOwner).insert(disclose(canonOp), disclose(approved));
+  }
+
+  /**
+   * @description Computes the caller's account identifier from the `wit_MultiTokenSK` witness.
+   *
+   * ## ID Derivation
+   * `accountId = persistentHash(secretKey)`
+   *
+   * The result is a 32-byte commitment that uniquely identifies the caller.
+   *
+   * @returns {Bytes<32>} accountId - The computed account identifier.
+   */
+  circuit _computeAccountId(): Bytes<32> {
+    return computeAccountId(wit_MultiTokenSK());
+  }
+
+  /**
+   * @description Computes an account identifier without on-chain state, allowing a user to derive
+   * their identity commitment before submitting it in a token operation.
+   * This is the off-chain counterpart to {_computeAccountId} and produces an identical result
+   * given the same inputs.
+   *
+   * @warning OpSec: The `secretKey` parameter is a sensitive secret. Mishandling it can
+   * permanently compromise the security of this system:
+   *
+   * - **Never log or persist** the `secretKey` in plaintext — avoid browser devtools,
+   *   application logs, analytics pipelines, or any observable side-channel.
+   * - **Store offline or in secure enclaves** — hardware security modules (HSMs),
+   *   air-gapped devices, or encrypted vaults are strongly preferred over hot storage.
+   * - **Use cryptographically secure randomness** — generate keys with `crypto.getRandomValues()`
+   *   or equivalent; weak or predictable keys can be brute-forced to reveal your identity.
+   * - **Treat key loss as identity loss** — a lost key cannot be recovered.
+   * - **Avoid calling this circuit in untrusted environments** — executing this in an
+   *   unverified browser extension, compromised runtime, or shared machine may expose
+   *   the key to a malicious observer.
+   *
+   * ## ID Derivation
+   * `accountId = persistentHash(secretKey)`
+   *
+   * @param {Bytes<32>} secretKey - A 32-byte cryptographically secure random value.
+   *
+   * @returns {Bytes<32>} accountId - The computed account identifier.
+   */
+  export pure circuit computeAccountId(secretKey: Bytes<32>): Bytes<32> {
+    return persistentHash<Vector<1, Bytes<32>>>([secretKey]);
+  }
+
+  /**
+   * @description Returns `true` if `target`'s active branch (as indicated by `is_left`)
+   * holds the zero value.
+   *
+   * @param {Either<Bytes<32>, ContractAddress>} target - The value to check.
+   * @returns {Boolean} - `true` if the active branch is zero, `false` otherwise.
+   */
+  circuit _isTargetZero(target: Either<Bytes<32>, ContractAddress>): Boolean {
+    if (target.is_left) {
+      return target.left == default<Bytes<32>>;
+    } else {
+      return target.right == default<ContractAddress>;
+    }
   }
 }

--- a/contracts/src/token/MultiToken.compact
+++ b/contracts/src/token/MultiToken.compact
@@ -357,6 +357,8 @@ module MultiToken {
    * @description Transfers a value amount of tokens of type id from fromAddress to to.
    * This circuit will mint (or burn) if `fromAddress` (or `to`) is zero.
    *
+   * @notice Both `fromAddress` and `to` are canonicalized internally before use as map keys.
+   *
    * Requirements:
    *
    * - Contract is initialized.

--- a/contracts/src/token/MultiToken.compact
+++ b/contracts/src/token/MultiToken.compact
@@ -224,8 +224,8 @@ module MultiToken {
   /**
    * @description Enables or disables approval for `operator` to manage all of the caller's assets.
    *
-   * The caller's identity is derived from the `wit_MultiTokenSK` witness as
-   * `persistentHash(secretKey)`.
+   * In the case of an external (non-contract) caller, the caller's identity is derived from the `wit_MultiTokenSK`
+   * witness as `persistentHash(secretKey)`.
    *
    * @circuitInfo k=13, rows=2944
    *
@@ -282,8 +282,8 @@ module MultiToken {
    * @description Transfers ownership of `value` amount of `id` tokens from `fromAddress` to `to`.
    * The caller must be `fromAddress` or approved to transfer on their behalf.
    *
-   * The caller's identity is derived from the `wit_MultiTokenSK` witness as
-   * `persistentHash(secretKey)`.
+   * In the case of an external (non-contract) caller, the caller's identity is derived from the `wit_MultiTokenSK`
+   * witness as `persistentHash(secretKey)`.
    *
    * @notice Transfers to contract addresses are currently disallowed until contract-to-contract
    * interactions are supported in Compact. This restriction prevents assets from
@@ -406,8 +406,8 @@ module MultiToken {
    * @description Unsafe variant of `transferFrom` which allows transfers to contract addresses.
    * The caller must be `fromAddress` or approved to transfer on their behalf.
    *
-   * The caller's identity is derived from the `wit_MultiTokenSK` witness as
-   * `persistentHash(secretKey)`.
+   * In the case of an external (non-contract) caller, the caller's identity is derived from the `wit_MultiTokenSK`
+   * witness as `persistentHash(secretKey)`.
    *
    * @warning Transfers to contract addresses are considered unsafe because contract-to-contract
    * calls are not currently supported. Tokens sent to a contract address may become irretrievable.

--- a/contracts/src/token/test/MultiToken.test.ts
+++ b/contracts/src/token/test/MultiToken.test.ts
@@ -52,7 +52,9 @@ const nonCanonicalLeft = (accountId: Uint8Array) => ({
   right: utils.encodeToAddress('JUNK_DATA'),
 });
 
-const nonCanonicalRight = (address: ReturnType<typeof utils.encodeToAddress>) => ({
+const nonCanonicalRight = (
+  address: ReturnType<typeof utils.encodeToAddress>,
+) => ({
   is_left: false as const,
   left: new Uint8Array(32).fill(1),
   right: address,
@@ -257,52 +259,44 @@ describe('MultiToken', () => {
 
     describe('isApprovedForAll', () => {
       it('should return false when not set', () => {
-        expect(
-          token.isApprovedForAll(OWNER.either, SPENDER.either),
-        ).toBe(false);
+        expect(token.isApprovedForAll(OWNER.either, SPENDER.either)).toBe(
+          false,
+        );
       });
 
       it('should handle approving owner as operator', () => {
         token.privateState.injectSecretKey(OWNER.secretKey);
         token.setApprovalForAll(OWNER.either, true);
-        expect(
-          token.isApprovedForAll(OWNER.either, OWNER.either),
-        ).toBe(true);
+        expect(token.isApprovedForAll(OWNER.either, OWNER.either)).toBe(true);
       });
 
       it('should handle multiple approvals of same operator', () => {
         token.privateState.injectSecretKey(OWNER.secretKey);
         token.setApprovalForAll(SPENDER.either, true);
         token.setApprovalForAll(SPENDER.either, true);
-        expect(
-          token.isApprovedForAll(OWNER.either, SPENDER.either),
-        ).toBe(true);
+        expect(token.isApprovedForAll(OWNER.either, SPENDER.either)).toBe(true);
       });
 
       it('should handle revoking non-existent approval', () => {
         token.privateState.injectSecretKey(OWNER.secretKey);
         token.setApprovalForAll(SPENDER.either, false);
-        expect(
-          token.isApprovedForAll(OWNER.either, SPENDER.either),
-        ).toBe(false);
+        expect(token.isApprovedForAll(OWNER.either, SPENDER.either)).toBe(
+          false,
+        );
       });
 
       it('should return correct result with non-canonical owner lookup', () => {
         token._setApprovalForAll(OWNER.either, SPENDER.either, true);
         const nonCanonical = nonCanonicalLeft(OWNER.accountId);
 
-        expect(
-          token.isApprovedForAll(nonCanonical, SPENDER.either),
-        ).toBe(true);
+        expect(token.isApprovedForAll(nonCanonical, SPENDER.either)).toBe(true);
       });
 
       it('should return correct result with non-canonical operator lookup', () => {
         token._setApprovalForAll(OWNER.either, SPENDER.either, true);
         const nonCanonical = nonCanonicalLeft(SPENDER.accountId);
 
-        expect(
-          token.isApprovedForAll(OWNER.either, nonCanonical),
-        ).toBe(true);
+        expect(token.isApprovedForAll(OWNER.either, nonCanonical)).toBe(true);
       });
     });
 
@@ -310,9 +304,9 @@ describe('MultiToken', () => {
       it('should return false when set to false', () => {
         token.privateState.injectSecretKey(OWNER.secretKey);
         token.setApprovalForAll(SPENDER.either, false);
-        expect(
-          token.isApprovedForAll(OWNER.either, SPENDER.either),
-        ).toBe(false);
+        expect(token.isApprovedForAll(OWNER.either, SPENDER.either)).toBe(
+          false,
+        );
       });
 
       it('should fail when attempting to approve zero address as an operator', () => {
@@ -329,26 +323,26 @@ describe('MultiToken', () => {
         });
 
         it('should return true when set to true', () => {
-          expect(
-            token.isApprovedForAll(OWNER.either, SPENDER.either),
-          ).toBe(true);
+          expect(token.isApprovedForAll(OWNER.either, SPENDER.either)).toBe(
+            true,
+          );
         });
 
         it('should unset → set → unset operator', () => {
           token.setApprovalForAll(SPENDER.either, false);
-          expect(
-            token.isApprovedForAll(OWNER.either, SPENDER.either),
-          ).toBe(false);
+          expect(token.isApprovedForAll(OWNER.either, SPENDER.either)).toBe(
+            false,
+          );
 
           token.setApprovalForAll(SPENDER.either, true);
-          expect(
-            token.isApprovedForAll(OWNER.either, SPENDER.either),
-          ).toBe(true);
+          expect(token.isApprovedForAll(OWNER.either, SPENDER.either)).toBe(
+            true,
+          );
 
           token.setApprovalForAll(SPENDER.either, false);
-          expect(
-            token.isApprovedForAll(OWNER.either, SPENDER.either),
-          ).toBe(false);
+          expect(token.isApprovedForAll(OWNER.either, SPENDER.either)).toBe(
+            false,
+          );
         });
       });
     });
@@ -361,176 +355,140 @@ describe('MultiToken', () => {
         expect(token.balanceOf(RECIPIENT.either, TOKEN_ID)).toEqual(0n);
       });
 
-      describe.each(callerTypes)(
-        'when the caller is the %s',
-        (_, caller) => {
-          beforeEach(() => {
-            if (caller === SPENDER) {
-              token._setApprovalForAll(
-                OWNER.either,
-                SPENDER.either,
-                true,
-              );
-            }
-            token.privateState.injectSecretKey(caller.secretKey);
-          });
+      describe.each(callerTypes)('when the caller is the %s', (_, caller) => {
+        beforeEach(() => {
+          if (caller === SPENDER) {
+            token._setApprovalForAll(OWNER.either, SPENDER.either, true);
+          }
+          token.privateState.injectSecretKey(caller.secretKey);
+        });
 
-          it('should transfer whole', () => {
+        it('should transfer whole', () => {
+          token.transferFrom(OWNER.either, RECIPIENT.either, TOKEN_ID, AMOUNT);
+
+          expect(token.balanceOf(OWNER.either, TOKEN_ID)).toEqual(0n);
+          expect(token.balanceOf(RECIPIENT.either, TOKEN_ID)).toEqual(AMOUNT);
+        });
+
+        it('should transfer partial', () => {
+          const partialAmt = AMOUNT - 1n;
+          token.transferFrom(
+            OWNER.either,
+            RECIPIENT.either,
+            TOKEN_ID,
+            partialAmt,
+          );
+
+          expect(token.balanceOf(OWNER.either, TOKEN_ID)).toEqual(
+            AMOUNT - partialAmt,
+          );
+          expect(token.balanceOf(RECIPIENT.either, TOKEN_ID)).toEqual(
+            partialAmt,
+          );
+        });
+
+        it('should allow transfer of 0 tokens', () => {
+          token.transferFrom(OWNER.either, RECIPIENT.either, TOKEN_ID, 0n);
+
+          expect(token.balanceOf(OWNER.either, TOKEN_ID)).toEqual(AMOUNT);
+          expect(token.balanceOf(RECIPIENT.either, TOKEN_ID)).toEqual(0n);
+        });
+
+        it('should handle self-transfer', () => {
+          token.transferFrom(OWNER.either, OWNER.either, TOKEN_ID, AMOUNT);
+          expect(token.balanceOf(OWNER.either, TOKEN_ID)).toEqual(AMOUNT);
+        });
+
+        it('should handle MAX_UINT128 transfer amount', () => {
+          token._mint(OWNER.either, TOKEN_ID, MAX_UINT128 - AMOUNT);
+
+          token.transferFrom(
+            OWNER.either,
+            RECIPIENT.either,
+            TOKEN_ID,
+            MAX_UINT128,
+          );
+          expect(token.balanceOf(RECIPIENT.either, TOKEN_ID)).toEqual(
+            MAX_UINT128,
+          );
+        });
+
+        it('should handle rapid state changes', () => {
+          token.privateState.injectSecretKey(OWNER.secretKey);
+          token.setApprovalForAll(SPENDER.either, true);
+
+          token.privateState.injectSecretKey(SPENDER.secretKey);
+          token.transferFrom(OWNER.either, RECIPIENT.either, TOKEN_ID, AMOUNT);
+          expect(token.balanceOf(RECIPIENT.either, TOKEN_ID)).toEqual(AMOUNT);
+
+          token.privateState.injectSecretKey(OWNER.secretKey);
+          token.setApprovalForAll(SPENDER.either, false);
+          expect(token.isApprovedForAll(OWNER.either, SPENDER.either)).toBe(
+            false,
+          );
+
+          token.setApprovalForAll(SPENDER.either, true);
+          expect(token.isApprovedForAll(OWNER.either, SPENDER.either)).toBe(
+            true,
+          );
+        });
+
+        it('should fail with insufficient balance', () => {
+          expect(() => {
             token.transferFrom(
               OWNER.either,
+              RECIPIENT.either,
+              TOKEN_ID,
+              AMOUNT + 1n,
+            );
+          }).toThrow('MultiToken: insufficient balance');
+        });
+
+        it('should fail with nonexistent id', () => {
+          expect(() => {
+            token.transferFrom(
+              OWNER.either,
+              RECIPIENT.either,
+              NONEXISTENT_ID,
+              AMOUNT,
+            );
+          }).toThrow('MultiToken: insufficient balance');
+        });
+
+        it('should fail with transfer from zero', () => {
+          expect(() => {
+            token.transferFrom(
+              ZERO_ACCOUNT,
               RECIPIENT.either,
               TOKEN_ID,
               AMOUNT,
             );
+          }).toThrow('MultiToken: unauthorized operator');
+        });
 
-            expect(token.balanceOf(OWNER.either, TOKEN_ID)).toEqual(0n);
-            expect(token.balanceOf(RECIPIENT.either, TOKEN_ID)).toEqual(
-              AMOUNT,
-            );
-          });
+        it('should fail with transfer to zero (id)', () => {
+          expect(() => {
+            token.transferFrom(OWNER.either, ZERO_ACCOUNT, TOKEN_ID, AMOUNT);
+          }).toThrow('MultiToken: invalid receiver');
+        });
 
-          it('should transfer partial', () => {
-            const partialAmt = AMOUNT - 1n;
+        it('should fail with transfer to zero (contract)', () => {
+          expect(() => {
+            token.transferFrom(OWNER.either, ZERO_CONTRACT, TOKEN_ID, AMOUNT);
+          }).toThrow('MultiToken: unsafe transfer');
+        });
+
+        it('should fail when transferring to a contract address', () => {
+          expect(() => {
             token.transferFrom(
               OWNER.either,
-              RECIPIENT.either,
-              TOKEN_ID,
-              partialAmt,
-            );
-
-            expect(token.balanceOf(OWNER.either, TOKEN_ID)).toEqual(
-              AMOUNT - partialAmt,
-            );
-            expect(token.balanceOf(RECIPIENT.either, TOKEN_ID)).toEqual(
-              partialAmt,
-            );
-          });
-
-          it('should allow transfer of 0 tokens', () => {
-            token.transferFrom(
-              OWNER.either,
-              RECIPIENT.either,
-              TOKEN_ID,
-              0n,
-            );
-
-            expect(token.balanceOf(OWNER.either, TOKEN_ID)).toEqual(AMOUNT);
-            expect(token.balanceOf(RECIPIENT.either, TOKEN_ID)).toEqual(0n);
-          });
-
-          it('should handle self-transfer', () => {
-            token.transferFrom(OWNER.either, OWNER.either, TOKEN_ID, AMOUNT);
-            expect(token.balanceOf(OWNER.either, TOKEN_ID)).toEqual(AMOUNT);
-          });
-
-          it('should handle MAX_UINT128 transfer amount', () => {
-            token._mint(OWNER.either, TOKEN_ID, MAX_UINT128 - AMOUNT);
-
-            token.transferFrom(
-              OWNER.either,
-              RECIPIENT.either,
-              TOKEN_ID,
-              MAX_UINT128,
-            );
-            expect(token.balanceOf(RECIPIENT.either, TOKEN_ID)).toEqual(
-              MAX_UINT128,
-            );
-          });
-
-          it('should handle rapid state changes', () => {
-            token.privateState.injectSecretKey(OWNER.secretKey);
-            token.setApprovalForAll(SPENDER.either, true);
-
-            token.privateState.injectSecretKey(SPENDER.secretKey);
-            token.transferFrom(
-              OWNER.either,
-              RECIPIENT.either,
+              RECIPIENT_CONTRACT,
               TOKEN_ID,
               AMOUNT,
             );
-            expect(token.balanceOf(RECIPIENT.either, TOKEN_ID)).toEqual(
-              AMOUNT,
-            );
-
-            token.privateState.injectSecretKey(OWNER.secretKey);
-            token.setApprovalForAll(SPENDER.either, false);
-            expect(
-              token.isApprovedForAll(OWNER.either, SPENDER.either),
-            ).toBe(false);
-
-            token.setApprovalForAll(SPENDER.either, true);
-            expect(
-              token.isApprovedForAll(OWNER.either, SPENDER.either),
-            ).toBe(true);
-          });
-
-          it('should fail with insufficient balance', () => {
-            expect(() => {
-              token.transferFrom(
-                OWNER.either,
-                RECIPIENT.either,
-                TOKEN_ID,
-                AMOUNT + 1n,
-              );
-            }).toThrow('MultiToken: insufficient balance');
-          });
-
-          it('should fail with nonexistent id', () => {
-            expect(() => {
-              token.transferFrom(
-                OWNER.either,
-                RECIPIENT.either,
-                NONEXISTENT_ID,
-                AMOUNT,
-              );
-            }).toThrow('MultiToken: insufficient balance');
-          });
-
-          it('should fail with transfer from zero', () => {
-            expect(() => {
-              token.transferFrom(
-                ZERO_ACCOUNT,
-                RECIPIENT.either,
-                TOKEN_ID,
-                AMOUNT,
-              );
-            }).toThrow('MultiToken: unauthorized operator');
-          });
-
-          it('should fail with transfer to zero (id)', () => {
-            expect(() => {
-              token.transferFrom(
-                OWNER.either,
-                ZERO_ACCOUNT,
-                TOKEN_ID,
-                AMOUNT,
-              );
-            }).toThrow('MultiToken: invalid receiver');
-          });
-
-          it('should fail with transfer to zero (contract)', () => {
-            expect(() => {
-              token.transferFrom(
-                OWNER.either,
-                ZERO_CONTRACT,
-                TOKEN_ID,
-                AMOUNT,
-              );
-            }).toThrow('MultiToken: unsafe transfer');
-          });
-
-          it('should fail when transferring to a contract address', () => {
-            expect(() => {
-              token.transferFrom(
-                OWNER.either,
-                RECIPIENT_CONTRACT,
-                TOKEN_ID,
-                AMOUNT,
-              );
-            }).toThrow('MultiToken: unsafe transfer');
-          });
-        },
-      );
+          }).toThrow('MultiToken: unsafe transfer');
+        });
+      });
 
       it('should handle concurrent operations on same token ID', () => {
         token._mint(OWNER.either, TOKEN_ID, AMOUNT * 2n);
@@ -541,22 +499,12 @@ describe('MultiToken', () => {
 
         // First spender transfers half
         token.privateState.injectSecretKey(SPENDER.secretKey);
-        token.transferFrom(
-          OWNER.either,
-          RECIPIENT.either,
-          TOKEN_ID,
-          AMOUNT,
-        );
+        token.transferFrom(OWNER.either, RECIPIENT.either, TOKEN_ID, AMOUNT);
         expect(token.balanceOf(RECIPIENT.either, TOKEN_ID)).toEqual(AMOUNT);
 
         // Second spender transfers remaining
         token.privateState.injectSecretKey(OTHER.secretKey);
-        token.transferFrom(
-          OWNER.either,
-          RECIPIENT.either,
-          TOKEN_ID,
-          AMOUNT,
-        );
+        token.transferFrom(OWNER.either, RECIPIENT.either, TOKEN_ID, AMOUNT);
         expect(token.balanceOf(RECIPIENT.either, TOKEN_ID)).toEqual(
           AMOUNT * 2n,
         );
@@ -613,12 +561,7 @@ describe('MultiToken', () => {
 
         it('should fail when transfer zero', () => {
           expect(() => {
-            token.transferFrom(
-              OWNER.either,
-              RECIPIENT.either,
-              TOKEN_ID,
-              0n,
-            );
+            token.transferFrom(OWNER.either, RECIPIENT.either, TOKEN_ID, 0n);
           }).toThrow('MultiToken: unauthorized operator');
         });
 
@@ -662,173 +605,152 @@ describe('MultiToken', () => {
         token._mint(OWNER.either, TOKEN_ID, AMOUNT);
       });
 
-      describe.each(callerTypes)(
-        'when the caller is the %s',
-        (_, caller) => {
-          beforeEach(() => {
-            if (caller === SPENDER) {
-              token._setApprovalForAll(
-                OWNER.either,
-                SPENDER.either,
-                true,
-              );
-            }
-            token.privateState.injectSecretKey(caller.secretKey);
+      describe.each(callerTypes)('when the caller is the %s', (_, caller) => {
+        beforeEach(() => {
+          if (caller === SPENDER) {
+            token._setApprovalForAll(OWNER.either, SPENDER.either, true);
+          }
+          token.privateState.injectSecretKey(caller.secretKey);
+        });
+
+        describe.each(
+          recipientTypes,
+        )('when the recipient is a %s', (_, recipient) => {
+          it('should transfer whole', () => {
+            token._unsafeTransferFrom(
+              OWNER.either,
+              recipient,
+              TOKEN_ID,
+              AMOUNT,
+            );
+
+            expect(token.balanceOf(OWNER.either, TOKEN_ID)).toEqual(0n);
+            expect(token.balanceOf(recipient, TOKEN_ID)).toEqual(AMOUNT);
           });
 
-          describe.each(recipientTypes)(
-            'when the recipient is a %s',
-            (_, recipient) => {
-              it('should transfer whole', () => {
-                token._unsafeTransferFrom(
-                  OWNER.either,
-                  recipient,
-                  TOKEN_ID,
-                  AMOUNT,
-                );
+          it('should transfer partial', () => {
+            const partialAmt = AMOUNT - 1n;
+            token._unsafeTransferFrom(
+              OWNER.either,
+              recipient,
+              TOKEN_ID,
+              partialAmt,
+            );
 
-                expect(token.balanceOf(OWNER.either, TOKEN_ID)).toEqual(0n);
-                expect(token.balanceOf(recipient, TOKEN_ID)).toEqual(AMOUNT);
-              });
+            expect(token.balanceOf(OWNER.either, TOKEN_ID)).toEqual(
+              AMOUNT - partialAmt,
+            );
+            expect(token.balanceOf(recipient, TOKEN_ID)).toEqual(partialAmt);
+          });
 
-              it('should transfer partial', () => {
-                const partialAmt = AMOUNT - 1n;
-                token._unsafeTransferFrom(
-                  OWNER.either,
-                  recipient,
-                  TOKEN_ID,
-                  partialAmt,
-                );
+          it('should allow transfer of 0 tokens', () => {
+            token._unsafeTransferFrom(OWNER.either, recipient, TOKEN_ID, 0n);
 
-                expect(token.balanceOf(OWNER.either, TOKEN_ID)).toEqual(
-                  AMOUNT - partialAmt,
-                );
-                expect(token.balanceOf(recipient, TOKEN_ID)).toEqual(
-                  partialAmt,
-                );
-              });
+            expect(token.balanceOf(OWNER.either, TOKEN_ID)).toEqual(AMOUNT);
+            expect(token.balanceOf(recipient, TOKEN_ID)).toEqual(0n);
+          });
 
-              it('should allow transfer of 0 tokens', () => {
-                token._unsafeTransferFrom(
-                  OWNER.either,
-                  recipient,
-                  TOKEN_ID,
-                  0n,
-                );
+          it('should handle self-transfer', () => {
+            token._unsafeTransferFrom(
+              OWNER.either,
+              OWNER.either,
+              TOKEN_ID,
+              AMOUNT,
+            );
+            expect(token.balanceOf(OWNER.either, TOKEN_ID)).toEqual(AMOUNT);
+          });
 
-                expect(token.balanceOf(OWNER.either, TOKEN_ID)).toEqual(
-                  AMOUNT,
-                );
-                expect(token.balanceOf(recipient, TOKEN_ID)).toEqual(0n);
-              });
+          it('should handle MAX_UINT128 transfer amount', () => {
+            token._mint(OWNER.either, TOKEN_ID, MAX_UINT128 - AMOUNT);
 
-              it('should handle self-transfer', () => {
-                token._unsafeTransferFrom(
-                  OWNER.either,
-                  OWNER.either,
-                  TOKEN_ID,
-                  AMOUNT,
-                );
-                expect(token.balanceOf(OWNER.either, TOKEN_ID)).toEqual(
-                  AMOUNT,
-                );
-              });
+            token._unsafeTransferFrom(
+              OWNER.either,
+              recipient,
+              TOKEN_ID,
+              MAX_UINT128,
+            );
+            expect(token.balanceOf(recipient, TOKEN_ID)).toEqual(MAX_UINT128);
+          });
 
-              it('should handle MAX_UINT128 transfer amount', () => {
-                token._mint(OWNER.either, TOKEN_ID, MAX_UINT128 - AMOUNT);
+          it('should handle rapid state changes', () => {
+            token.privateState.injectSecretKey(OWNER.secretKey);
+            token.setApprovalForAll(SPENDER.either, true);
 
-                token._unsafeTransferFrom(
-                  OWNER.either,
-                  recipient,
-                  TOKEN_ID,
-                  MAX_UINT128,
-                );
-                expect(token.balanceOf(recipient, TOKEN_ID)).toEqual(
-                  MAX_UINT128,
-                );
-              });
+            token._unsafeTransferFrom(
+              OWNER.either,
+              recipient,
+              TOKEN_ID,
+              AMOUNT,
+            );
+            expect(token.balanceOf(recipient, TOKEN_ID)).toEqual(AMOUNT);
 
-              it('should handle rapid state changes', () => {
-                token.privateState.injectSecretKey(OWNER.secretKey);
-                token.setApprovalForAll(SPENDER.either, true);
+            token.setApprovalForAll(SPENDER.either, false);
+            expect(token.isApprovedForAll(OWNER.either, SPENDER.either)).toBe(
+              false,
+            );
 
-                token._unsafeTransferFrom(
-                  OWNER.either,
-                  recipient,
-                  TOKEN_ID,
-                  AMOUNT,
-                );
-                expect(token.balanceOf(recipient, TOKEN_ID)).toEqual(AMOUNT);
+            token.setApprovalForAll(SPENDER.either, true);
+            expect(token.isApprovedForAll(OWNER.either, SPENDER.either)).toBe(
+              true,
+            );
+          });
 
-                token.setApprovalForAll(SPENDER.either, false);
-                expect(
-                  token.isApprovedForAll(OWNER.either, SPENDER.either),
-                ).toBe(false);
-
-                token.setApprovalForAll(SPENDER.either, true);
-                expect(
-                  token.isApprovedForAll(OWNER.either, SPENDER.either),
-                ).toBe(true);
-              });
-
-              it('should fail with insufficient balance', () => {
-                expect(() => {
-                  token._unsafeTransferFrom(
-                    OWNER.either,
-                    recipient,
-                    TOKEN_ID,
-                    AMOUNT + 1n,
-                  );
-                }).toThrow('MultiToken: insufficient balance');
-              });
-
-              it('should fail with nonexistent id', () => {
-                expect(() => {
-                  token._unsafeTransferFrom(
-                    OWNER.either,
-                    recipient,
-                    NONEXISTENT_ID,
-                    AMOUNT,
-                  );
-                }).toThrow('MultiToken: insufficient balance');
-              });
-
-              it('should fail with transfer from zero', () => {
-                expect(() => {
-                  token._unsafeTransferFrom(
-                    ZERO_ACCOUNT,
-                    recipient,
-                    TOKEN_ID,
-                    AMOUNT,
-                  );
-                }).toThrow('MultiToken: unauthorized operator');
-              });
-            },
-          );
-
-          it('should fail with transfer to zero (id)', () => {
+          it('should fail with insufficient balance', () => {
             expect(() => {
               token._unsafeTransferFrom(
                 OWNER.either,
+                recipient,
+                TOKEN_ID,
+                AMOUNT + 1n,
+              );
+            }).toThrow('MultiToken: insufficient balance');
+          });
+
+          it('should fail with nonexistent id', () => {
+            expect(() => {
+              token._unsafeTransferFrom(
+                OWNER.either,
+                recipient,
+                NONEXISTENT_ID,
+                AMOUNT,
+              );
+            }).toThrow('MultiToken: insufficient balance');
+          });
+
+          it('should fail with transfer from zero', () => {
+            expect(() => {
+              token._unsafeTransferFrom(
                 ZERO_ACCOUNT,
+                recipient,
                 TOKEN_ID,
                 AMOUNT,
               );
-            }).toThrow('MultiToken: invalid receiver');
+            }).toThrow('MultiToken: unauthorized operator');
           });
+        });
 
-          it('should fail with transfer to zero (contract)', () => {
-            expect(() => {
-              token._unsafeTransferFrom(
-                OWNER.either,
-                ZERO_CONTRACT,
-                TOKEN_ID,
-                AMOUNT,
-              );
-            }).toThrow('MultiToken: invalid receiver');
-          });
-        },
-      );
+        it('should fail with transfer to zero (id)', () => {
+          expect(() => {
+            token._unsafeTransferFrom(
+              OWNER.either,
+              ZERO_ACCOUNT,
+              TOKEN_ID,
+              AMOUNT,
+            );
+          }).toThrow('MultiToken: invalid receiver');
+        });
+
+        it('should fail with transfer to zero (contract)', () => {
+          expect(() => {
+            token._unsafeTransferFrom(
+              OWNER.either,
+              ZERO_CONTRACT,
+              TOKEN_ID,
+              AMOUNT,
+            );
+          }).toThrow('MultiToken: invalid receiver');
+        });
+      });
 
       it('should handle concurrent operations on same token ID', () => {
         token._mint(OWNER.either, TOKEN_ID, AMOUNT * 2n);
@@ -894,12 +816,7 @@ describe('MultiToken', () => {
         token.privateState.injectSecretKey(OWNER.secretKey);
 
         const nonCanonical = nonCanonicalLeft(RECIPIENT.accountId);
-        token._unsafeTransferFrom(
-          OWNER.either,
-          nonCanonical,
-          TOKEN_ID,
-          AMOUNT,
-        );
+        token._unsafeTransferFrom(OWNER.either, nonCanonical, TOKEN_ID, AMOUNT);
         expect(token.balanceOf(RECIPIENT.either, TOKEN_ID)).toEqual(AMOUNT);
       });
 
@@ -907,12 +824,7 @@ describe('MultiToken', () => {
         token.privateState.injectSecretKey(OWNER.secretKey);
 
         const nonCanonical = nonCanonicalRight(RECIPIENT_CONTRACT.right);
-        token._unsafeTransferFrom(
-          OWNER.either,
-          nonCanonical,
-          TOKEN_ID,
-          AMOUNT,
-        );
+        token._unsafeTransferFrom(OWNER.either, nonCanonical, TOKEN_ID, AMOUNT);
         expect(token.balanceOf(RECIPIENT_CONTRACT, TOKEN_ID)).toEqual(AMOUNT);
       });
 
@@ -921,81 +833,75 @@ describe('MultiToken', () => {
           token.privateState.injectSecretKey(UNAUTHORIZED.secretKey);
         });
 
-        describe.each(recipientTypes)(
-          'when recipient is %s',
-          (_, recipient) => {
-            it('should fail when transfer whole', () => {
-              expect(() => {
-                token._unsafeTransferFrom(
-                  OWNER.either,
-                  recipient,
-                  TOKEN_ID,
-                  AMOUNT,
-                );
-              }).toThrow('MultiToken: unauthorized operator');
-            });
+        describe.each(
+          recipientTypes,
+        )('when recipient is %s', (_, recipient) => {
+          it('should fail when transfer whole', () => {
+            expect(() => {
+              token._unsafeTransferFrom(
+                OWNER.either,
+                recipient,
+                TOKEN_ID,
+                AMOUNT,
+              );
+            }).toThrow('MultiToken: unauthorized operator');
+          });
 
-            it('should fail when transfer partial', () => {
-              expect(() => {
-                const partialAmt = AMOUNT - 1n;
-                token._unsafeTransferFrom(
-                  OWNER.either,
-                  recipient,
-                  TOKEN_ID,
-                  partialAmt,
-                );
-              }).toThrow('MultiToken: unauthorized operator');
-            });
+          it('should fail when transfer partial', () => {
+            expect(() => {
+              const partialAmt = AMOUNT - 1n;
+              token._unsafeTransferFrom(
+                OWNER.either,
+                recipient,
+                TOKEN_ID,
+                partialAmt,
+              );
+            }).toThrow('MultiToken: unauthorized operator');
+          });
 
-            it('should fail when transfer zero', () => {
-              expect(() => {
-                token._unsafeTransferFrom(
-                  OWNER.either,
-                  recipient,
-                  TOKEN_ID,
-                  0n,
-                );
-              }).toThrow('MultiToken: unauthorized operator');
-            });
+          it('should fail when transfer zero', () => {
+            expect(() => {
+              token._unsafeTransferFrom(OWNER.either, recipient, TOKEN_ID, 0n);
+            }).toThrow('MultiToken: unauthorized operator');
+          });
 
-            it('should fail with insufficient balance', () => {
-              expect(() => {
-                token._unsafeTransferFrom(
-                  OWNER.either,
-                  recipient,
-                  TOKEN_ID,
-                  AMOUNT + 1n,
-                );
-              }).toThrow('MultiToken: unauthorized operator');
-            });
+          it('should fail with insufficient balance', () => {
+            expect(() => {
+              token._unsafeTransferFrom(
+                OWNER.either,
+                recipient,
+                TOKEN_ID,
+                AMOUNT + 1n,
+              );
+            }).toThrow('MultiToken: unauthorized operator');
+          });
 
-            it('should fail with nonexistent id', () => {
-              expect(() => {
-                token._unsafeTransferFrom(
-                  OWNER.either,
-                  recipient,
-                  NONEXISTENT_ID,
-                  AMOUNT,
-                );
-              }).toThrow('MultiToken: unauthorized operator');
-            });
+          it('should fail with nonexistent id', () => {
+            expect(() => {
+              token._unsafeTransferFrom(
+                OWNER.either,
+                recipient,
+                NONEXISTENT_ID,
+                AMOUNT,
+              );
+            }).toThrow('MultiToken: unauthorized operator');
+          });
 
-            it('should fail with transfer from zero', () => {
-              // With witness-based identity, the caller is H(sk) which is
-              // always non-zero. Transferring from ZERO_ACCOUNT means
-              // canonFrom != caller → isApprovedForAll(ZERO, caller) → false
-              // → "unauthorized operator"
-              expect(() => {
-                token._unsafeTransferFrom(
-                  ZERO_ACCOUNT,
-                  recipient,
-                  TOKEN_ID,
-                  AMOUNT,
-                );
-              }).toThrow('MultiToken: unauthorized operator');
-            });
-          },
-        );
+          it('should fail with transfer from zero', () => {
+            // With witness-based identity, the caller is H(sk) which is
+            // always non-zero. Transferring from ZERO_ACCOUNT means
+            // canonFrom != caller → isApprovedForAll(ZERO, caller) → false
+            // → "unauthorized operator"
+            expect(() => {
+              token._unsafeTransferFrom(
+                ZERO_ACCOUNT,
+                recipient,
+                TOKEN_ID,
+                AMOUNT,
+              );
+            }).toThrow('MultiToken: unauthorized operator');
+          });
+        });
       });
     });
 
@@ -1021,9 +927,7 @@ describe('MultiToken', () => {
         expect(token.balanceOf(OWNER.either, TOKEN_ID)).toEqual(
           AMOUNT - partialAmt,
         );
-        expect(token.balanceOf(RECIPIENT.either, TOKEN_ID)).toEqual(
-          partialAmt,
-        );
+        expect(token.balanceOf(RECIPIENT.either, TOKEN_ID)).toEqual(partialAmt);
       });
 
       it('should allow transfer of 0 tokens', () => {
@@ -1057,12 +961,7 @@ describe('MultiToken', () => {
 
       it('should fail when transfer from 0', () => {
         expect(() => {
-          token._transfer(
-            ZERO_ACCOUNT,
-            RECIPIENT.either,
-            TOKEN_ID,
-            AMOUNT,
-          );
+          token._transfer(ZERO_ACCOUNT, RECIPIENT.either, TOKEN_ID, AMOUNT);
         }).toThrow('MultiToken: invalid sender');
       });
 
@@ -1074,12 +973,7 @@ describe('MultiToken', () => {
 
       it('should fail when transfer to contract address', () => {
         expect(() => {
-          token._transfer(
-            OWNER.either,
-            RECIPIENT_CONTRACT,
-            TOKEN_ID,
-            AMOUNT,
-          );
+          token._transfer(OWNER.either, RECIPIENT_CONTRACT, TOKEN_ID, AMOUNT);
         }).toThrow('MultiToken: unsafe transfer');
       });
 
@@ -1110,88 +1004,67 @@ describe('MultiToken', () => {
         expect(token.balanceOf(RECIPIENT.either, TOKEN_ID)).toEqual(0n);
       });
 
-      describe.each(recipientTypes)(
-        'when the recipient is a %s',
-        (_, recipient) => {
-          it('should transfer whole', () => {
+      describe.each(
+        recipientTypes,
+      )('when the recipient is a %s', (_, recipient) => {
+        it('should transfer whole', () => {
+          token._unsafeTransfer(OWNER.either, recipient, TOKEN_ID, AMOUNT);
+
+          expect(token.balanceOf(OWNER.either, TOKEN_ID)).toEqual(0n);
+          expect(token.balanceOf(recipient, TOKEN_ID)).toEqual(AMOUNT);
+        });
+
+        it('should transfer partial', () => {
+          const partialAmt = AMOUNT - 1n;
+          token._unsafeTransfer(OWNER.either, recipient, TOKEN_ID, partialAmt);
+
+          expect(token.balanceOf(OWNER.either, TOKEN_ID)).toEqual(
+            AMOUNT - partialAmt,
+          );
+          expect(token.balanceOf(recipient, TOKEN_ID)).toEqual(partialAmt);
+        });
+
+        it('should allow transfer of 0 tokens', () => {
+          token._unsafeTransfer(OWNER.either, recipient, TOKEN_ID, 0n);
+
+          expect(token.balanceOf(OWNER.either, TOKEN_ID)).toEqual(AMOUNT);
+          expect(token.balanceOf(recipient, TOKEN_ID)).toEqual(0n);
+        });
+
+        it('should fail with insufficient balance', () => {
+          expect(() => {
             token._unsafeTransfer(
               OWNER.either,
               recipient,
               TOKEN_ID,
+              AMOUNT + 1n,
+            );
+          }).toThrow('MultiToken: insufficient balance');
+        });
+
+        it('should fail with nonexistent id', () => {
+          expect(() => {
+            token._unsafeTransfer(
+              OWNER.either,
+              recipient,
+              NONEXISTENT_ID,
               AMOUNT,
             );
+          }).toThrow('MultiToken: insufficient balance');
+        });
 
-            expect(token.balanceOf(OWNER.either, TOKEN_ID)).toEqual(0n);
-            expect(token.balanceOf(recipient, TOKEN_ID)).toEqual(AMOUNT);
-          });
+        it('should fail when transfer from 0 (id)', () => {
+          expect(() => {
+            token._unsafeTransfer(ZERO_ACCOUNT, recipient, TOKEN_ID, AMOUNT);
+          }).toThrow('MultiToken: invalid sender');
+        });
 
-          it('should transfer partial', () => {
-            const partialAmt = AMOUNT - 1n;
-            token._unsafeTransfer(
-              OWNER.either,
-              recipient,
-              TOKEN_ID,
-              partialAmt,
-            );
-
-            expect(token.balanceOf(OWNER.either, TOKEN_ID)).toEqual(
-              AMOUNT - partialAmt,
-            );
-            expect(token.balanceOf(recipient, TOKEN_ID)).toEqual(partialAmt);
-          });
-
-          it('should allow transfer of 0 tokens', () => {
-            token._unsafeTransfer(OWNER.either, recipient, TOKEN_ID, 0n);
-
-            expect(token.balanceOf(OWNER.either, TOKEN_ID)).toEqual(AMOUNT);
-            expect(token.balanceOf(recipient, TOKEN_ID)).toEqual(0n);
-          });
-
-          it('should fail with insufficient balance', () => {
-            expect(() => {
-              token._unsafeTransfer(
-                OWNER.either,
-                recipient,
-                TOKEN_ID,
-                AMOUNT + 1n,
-              );
-            }).toThrow('MultiToken: insufficient balance');
-          });
-
-          it('should fail with nonexistent id', () => {
-            expect(() => {
-              token._unsafeTransfer(
-                OWNER.either,
-                recipient,
-                NONEXISTENT_ID,
-                AMOUNT,
-              );
-            }).toThrow('MultiToken: insufficient balance');
-          });
-
-          it('should fail when transfer from 0 (id)', () => {
-            expect(() => {
-              token._unsafeTransfer(
-                ZERO_ACCOUNT,
-                recipient,
-                TOKEN_ID,
-                AMOUNT,
-              );
-            }).toThrow('MultiToken: invalid sender');
-          });
-
-          it('should fail when transfer from 0 (contract address)', () => {
-            expect(() => {
-              token._unsafeTransfer(
-                ZERO_CONTRACT,
-                recipient,
-                TOKEN_ID,
-                AMOUNT,
-              );
-            }).toThrow('MultiToken: invalid sender');
-          });
-        },
-      );
+        it('should fail when transfer from 0 (contract address)', () => {
+          expect(() => {
+            token._unsafeTransfer(ZERO_CONTRACT, recipient, TOKEN_ID, AMOUNT);
+          }).toThrow('MultiToken: invalid sender');
+        });
+      });
 
       it('should handle non-canonical fromAddress (id)', () => {
         const nonCanonical = nonCanonicalLeft(OWNER.accountId);
@@ -1229,23 +1102,13 @@ describe('MultiToken', () => {
 
       it('should fail when transfer to 0 (id)', () => {
         expect(() => {
-          token._unsafeTransfer(
-            OWNER.either,
-            ZERO_ACCOUNT,
-            TOKEN_ID,
-            AMOUNT,
-          );
+          token._unsafeTransfer(OWNER.either, ZERO_ACCOUNT, TOKEN_ID, AMOUNT);
         }).toThrow('MultiToken: invalid receiver');
       });
 
       it('should fail when transfer to 0 (contract address)', () => {
         expect(() => {
-          token._unsafeTransfer(
-            OWNER.either,
-            ZERO_CONTRACT,
-            TOKEN_ID,
-            AMOUNT,
-          );
+          token._unsafeTransfer(OWNER.either, ZERO_CONTRACT, TOKEN_ID, AMOUNT);
         }).toThrow('MultiToken: invalid receiver');
       });
     });
@@ -1331,32 +1194,31 @@ describe('MultiToken', () => {
     });
 
     describe('_unsafeMint', () => {
-      describe.each(recipientTypes)(
-        'when the recipient is a %s',
-        (_, recipient) => {
-          it('should update balance when minting', () => {
-            token._unsafeMint(recipient, TOKEN_ID, AMOUNT);
+      describe.each(
+        recipientTypes,
+      )('when the recipient is a %s', (_, recipient) => {
+        it('should update balance when minting', () => {
+          token._unsafeMint(recipient, TOKEN_ID, AMOUNT);
 
-            expect(token.balanceOf(recipient, TOKEN_ID)).toEqual(AMOUNT);
-          });
+          expect(token.balanceOf(recipient, TOKEN_ID)).toEqual(AMOUNT);
+        });
 
-          it('should update balance with multiple mints', () => {
-            for (let i = 0; i < 3; i++) {
-              token._unsafeMint(recipient, TOKEN_ID, 1n);
-            }
+        it('should update balance with multiple mints', () => {
+          for (let i = 0; i < 3; i++) {
+            token._unsafeMint(recipient, TOKEN_ID, 1n);
+          }
 
-            expect(token.balanceOf(recipient, TOKEN_ID)).toEqual(3n);
-          });
+          expect(token.balanceOf(recipient, TOKEN_ID)).toEqual(3n);
+        });
 
-          it('should fail when overflowing uint128', () => {
-            token._unsafeMint(recipient, TOKEN_ID, MAX_UINT128);
+        it('should fail when overflowing uint128', () => {
+          token._unsafeMint(recipient, TOKEN_ID, MAX_UINT128);
 
-            expect(() => {
-              token._unsafeMint(recipient, TOKEN_ID, 1n);
-            }).toThrow('MultiToken: arithmetic overflow');
-          });
-        },
-      );
+          expect(() => {
+            token._unsafeMint(recipient, TOKEN_ID, 1n);
+          }).toThrow('MultiToken: arithmetic overflow');
+        });
+      });
 
       it('should fail when minting to zero address (id)', () => {
         expect(() => {
@@ -1451,9 +1313,9 @@ describe('MultiToken', () => {
     describe('_setApprovalForAll', () => {
       it('should return false when set to false', () => {
         token._setApprovalForAll(OWNER.either, SPENDER.either, false);
-        expect(
-          token.isApprovedForAll(OWNER.either, SPENDER.either),
-        ).toBe(false);
+        expect(token.isApprovedForAll(OWNER.either, SPENDER.either)).toBe(
+          false,
+        );
       });
 
       it('should fail when attempting to approve zero address as an operator', () => {
@@ -1470,19 +1332,15 @@ describe('MultiToken', () => {
 
       it('should set → unset → set operator', () => {
         token._setApprovalForAll(OWNER.either, SPENDER.either, true);
-        expect(
-          token.isApprovedForAll(OWNER.either, SPENDER.either),
-        ).toBe(true);
+        expect(token.isApprovedForAll(OWNER.either, SPENDER.either)).toBe(true);
 
         token._setApprovalForAll(OWNER.either, SPENDER.either, false);
-        expect(
-          token.isApprovedForAll(OWNER.either, SPENDER.either),
-        ).toBe(false);
+        expect(token.isApprovedForAll(OWNER.either, SPENDER.either)).toBe(
+          false,
+        );
 
         token._setApprovalForAll(OWNER.either, SPENDER.either, true);
-        expect(
-          token.isApprovedForAll(OWNER.either, SPENDER.either),
-        ).toBe(true);
+        expect(token.isApprovedForAll(OWNER.either, SPENDER.either)).toBe(true);
       });
 
       it('should canonicalize owner and operator', () => {
@@ -1490,9 +1348,7 @@ describe('MultiToken', () => {
         const nonCanonicalOp = nonCanonicalLeft(SPENDER.accountId);
 
         token._setApprovalForAll(nonCanonicalOwner, nonCanonicalOp, true);
-        expect(
-          token.isApprovedForAll(OWNER.either, SPENDER.either),
-        ).toBe(true);
+        expect(token.isApprovedForAll(OWNER.either, SPENDER.either)).toBe(true);
       });
     });
 

--- a/contracts/src/token/test/MultiToken.test.ts
+++ b/contracts/src/token/test/MultiToken.test.ts
@@ -1,7 +1,81 @@
+import {
+  CompactTypeBytes,
+  CompactTypeVector,
+  persistentHash,
+} from '@midnight-ntwrk/compact-runtime';
 import { beforeEach, describe, expect, it } from 'vitest';
 import * as utils from '#test-utils/address.js';
-import type { Maybe } from '../../../artifacts/MockMultiToken/contract/index.js'; // Combined imports
+import type { Maybe } from '../../../artifacts/MockMultiToken/contract/index.js';
 import { MultiTokenSimulator } from './simulators/MultiTokenSimulator.js';
+
+// Helpers
+const buildAccountIdHash = (sk: Uint8Array): Uint8Array => {
+  const rt_type = new CompactTypeVector(1, new CompactTypeBytes(32));
+  return persistentHash(rt_type, [sk]);
+};
+
+const zeroBytes = utils.zeroUint8Array();
+
+const eitherAccountId = (accountId: Uint8Array) => {
+  return {
+    is_left: true,
+    left: accountId,
+    right: { bytes: zeroBytes },
+  };
+};
+
+const eitherContract = (address: string) => {
+  return {
+    is_left: false,
+    left: zeroBytes,
+    right: utils.encodeToAddress(address),
+  };
+};
+
+const createTestSK = (label: string): Uint8Array => {
+  const sk = new Uint8Array(32);
+  const encoded = new TextEncoder().encode(label);
+  sk.set(encoded.slice(0, 32));
+  return sk;
+};
+
+const makeUser = (label: string) => {
+  const secretKey = createTestSK(label);
+  const accountId = buildAccountIdHash(secretKey);
+  const either = eitherAccountId(accountId);
+  return { secretKey, accountId, either };
+};
+
+const nonCanonicalLeft = (accountId: Uint8Array) => ({
+  is_left: true as const,
+  left: accountId,
+  right: utils.encodeToAddress('JUNK_DATA'),
+});
+
+const nonCanonicalRight = (address: ReturnType<typeof utils.encodeToAddress>) => ({
+  is_left: false as const,
+  left: new Uint8Array(32).fill(1),
+  right: address,
+});
+
+// Users
+const OWNER = makeUser('OWNER');
+const SPENDER = makeUser('SPENDER');
+const RECIPIENT = makeUser('RECIPIENT');
+const OTHER = makeUser('OTHER');
+const UNAUTHORIZED = makeUser('UNAUTHORIZED');
+
+// Contract Addresses
+const OWNER_CONTRACT = eitherContract('OWNER_CONTRACT');
+const RECIPIENT_CONTRACT = eitherContract('RECIPIENT_CONTRACT');
+
+// Zero Values
+const ZERO_ACCOUNT = eitherAccountId(zeroBytes);
+const ZERO_CONTRACT = {
+  is_left: false,
+  left: zeroBytes,
+  right: { bytes: zeroBytes },
+};
 
 // URIs
 const NO_STRING = '';
@@ -17,20 +91,6 @@ const MAX_UINT128 = BigInt(2 ** 128) - BigInt(1);
 const TOKEN_ID: bigint = BigInt(1);
 const TOKEN_ID2: bigint = BigInt(22);
 const NONEXISTENT_ID: bigint = BigInt(987654321);
-
-// PKs
-const [OWNER, Z_OWNER] = utils.generateEitherPubKeyPair('OWNER');
-const [SPENDER, Z_SPENDER] = utils.generateEitherPubKeyPair('SPENDER');
-const [UNAUTHORIZED] = utils.generateEitherPubKeyPair('UNAUTHORIZED');
-const [ZERO] = utils.generateEitherPubKeyPair('');
-const [, Z_RECIPIENT] = utils.generateEitherPubKeyPair('RECIPIENT');
-const [OTHER, Z_OTHER] = utils.generateEitherPubKeyPair('OTHER');
-
-// Encoded contract addresses
-const Z_OWNER_CONTRACT =
-  utils.createEitherTestContractAddress('OWNER_CONTRACT');
-const Z_RECIPIENT_CONTRACT =
-  utils.createEitherTestContractAddress('RECIPIENT_CONTRACT');
 
 // Init
 const initWithURI: Maybe<string> = {
@@ -48,10 +108,10 @@ const badInit: Maybe<string> = {
   value: '',
 };
 
-// Helper types
+// Types
 const recipientTypes = [
-  ['contract', Z_RECIPIENT_CONTRACT],
-  ['pubkey', Z_RECIPIENT],
+  ['contract', RECIPIENT_CONTRACT],
+  ['accountId', RECIPIENT.either],
 ] as const;
 
 const callerTypes = [
@@ -90,21 +150,20 @@ describe('MultiToken', () => {
     });
 
     type FailingCircuits = [method: keyof MultiTokenSimulator, args: unknown[]];
-    // Circuit calls should fail before the args are used
-    const transferArgs = [Z_OWNER, Z_RECIPIENT, TOKEN_ID, AMOUNT];
+    const transferArgs = [OWNER.either, RECIPIENT.either, TOKEN_ID, AMOUNT];
     const circuitsToFail: FailingCircuits[] = [
       ['uri', [TOKEN_ID]],
-      ['balanceOf', [Z_OWNER, TOKEN_ID]],
-      ['setApprovalForAll', [Z_OWNER, true]],
-      ['isApprovedForAll', [Z_OWNER, Z_SPENDER]],
+      ['balanceOf', [OWNER.either, TOKEN_ID]],
+      ['setApprovalForAll', [OWNER.either, true]],
+      ['isApprovedForAll', [OWNER.either, SPENDER.either]],
       ['transferFrom', transferArgs],
       ['_unsafeTransferFrom', transferArgs],
       ['_transfer', transferArgs],
       ['_unsafeTransfer', transferArgs],
       ['_setURI', [URI]],
-      ['_mint', [Z_OWNER, TOKEN_ID, AMOUNT]],
-      ['_burn', [Z_OWNER, TOKEN_ID, AMOUNT]],
-      ['_setApprovalForAll', [Z_OWNER, Z_SPENDER, true]],
+      ['_mint', [OWNER.either, TOKEN_ID, AMOUNT]],
+      ['_burn', [OWNER.either, TOKEN_ID, AMOUNT]],
+      ['_setApprovalForAll', [OWNER.either, SPENDER.either, true]],
     ];
 
     it.each(circuitsToFail)('%s should fail', (circuitName, args) => {
@@ -113,14 +172,11 @@ describe('MultiToken', () => {
       }).toThrow('Initializable: contract not initialized');
     });
 
-    // Though, there is no restriction on initializing post deployment,
-    // contracts should NOT be set up this way.
-    // Always use the constructor to initialize the state.
     it('should allow initialization post deployment', () => {
       token.initialize(URI);
 
       expect(() => {
-        token.balanceOf(Z_OWNER, TOKEN_ID);
+        token.balanceOf(OWNER.either, TOKEN_ID);
       }).not.toThrow();
     });
   });
@@ -130,10 +186,31 @@ describe('MultiToken', () => {
       token = new MultiTokenSimulator(initWithURI);
     });
 
+    describe('computeAccountId', () => {
+      const users = [OWNER, SPENDER, RECIPIENT, UNAUTHORIZED];
+
+      it('should match the test helper derivation', () => {
+        for (const user of users) {
+          expect(token.computeAccountId(user.secretKey)).toEqual(
+            user.accountId,
+          );
+        }
+      });
+
+      it('should produce distinct identifiers for distinct keys', () => {
+        const ids = users.map((u) => token.computeAccountId(u.secretKey));
+        for (let i = 0; i < ids.length; i++) {
+          for (let j = i + 1; j < ids.length; j++) {
+            expect(ids[i]).not.toEqual(ids[j]);
+          }
+        }
+      });
+    });
+
     describe('balanceOf', () => {
       const ownerTypes = [
-        ['contract', Z_OWNER_CONTRACT],
-        ['pubkey', Z_OWNER],
+        ['contract', OWNER_CONTRACT],
+        ['accountId', OWNER.either],
       ] as const;
 
       describe.each(ownerTypes)('when the owner is a %s', (_, owner) => {
@@ -162,609 +239,1013 @@ describe('MultiToken', () => {
           expect(token.balanceOf(owner, MAX_ID)).toEqual(AMOUNT);
         });
       });
+
+      it('should return correct balance with non-canonical lookup (left)', () => {
+        token._unsafeMint(OWNER.either, TOKEN_ID, AMOUNT);
+        const nonCanonical = nonCanonicalLeft(OWNER.accountId);
+
+        expect(token.balanceOf(nonCanonical, TOKEN_ID)).toEqual(AMOUNT);
+      });
+
+      it('should return correct balance with non-canonical lookup (right)', () => {
+        token._unsafeMint(OWNER_CONTRACT, TOKEN_ID, AMOUNT);
+        const nonCanonical = nonCanonicalRight(OWNER_CONTRACT.right);
+
+        expect(token.balanceOf(nonCanonical, TOKEN_ID)).toEqual(AMOUNT);
+      });
     });
 
     describe('isApprovedForAll', () => {
       it('should return false when not set', () => {
-        expect(token.isApprovedForAll(Z_OWNER, Z_SPENDER)).toBe(false);
+        expect(
+          token.isApprovedForAll(OWNER.either, SPENDER.either),
+        ).toBe(false);
       });
 
       it('should handle approving owner as operator', () => {
-        token.as(OWNER).setApprovalForAll(Z_OWNER, true);
-        expect(token.isApprovedForAll(Z_OWNER, Z_OWNER)).toBe(true);
+        token.privateState.injectSecretKey(OWNER.secretKey);
+        token.setApprovalForAll(OWNER.either, true);
+        expect(
+          token.isApprovedForAll(OWNER.either, OWNER.either),
+        ).toBe(true);
       });
 
       it('should handle multiple approvals of same operator', () => {
-        token.as(OWNER).setApprovalForAll(Z_SPENDER, true);
-        token.as(OWNER).setApprovalForAll(Z_SPENDER, true);
-        expect(token.isApprovedForAll(Z_OWNER, Z_SPENDER)).toBe(true);
+        token.privateState.injectSecretKey(OWNER.secretKey);
+        token.setApprovalForAll(SPENDER.either, true);
+        token.setApprovalForAll(SPENDER.either, true);
+        expect(
+          token.isApprovedForAll(OWNER.either, SPENDER.either),
+        ).toBe(true);
       });
 
       it('should handle revoking non-existent approval', () => {
-        token.as(OWNER).setApprovalForAll(Z_SPENDER, false);
-        expect(token.isApprovedForAll(Z_OWNER, Z_SPENDER)).toBe(false);
+        token.privateState.injectSecretKey(OWNER.secretKey);
+        token.setApprovalForAll(SPENDER.either, false);
+        expect(
+          token.isApprovedForAll(OWNER.either, SPENDER.either),
+        ).toBe(false);
+      });
+
+      it('should return correct result with non-canonical owner lookup', () => {
+        token._setApprovalForAll(OWNER.either, SPENDER.either, true);
+        const nonCanonical = nonCanonicalLeft(OWNER.accountId);
+
+        expect(
+          token.isApprovedForAll(nonCanonical, SPENDER.either),
+        ).toBe(true);
+      });
+
+      it('should return correct result with non-canonical operator lookup', () => {
+        token._setApprovalForAll(OWNER.either, SPENDER.either, true);
+        const nonCanonical = nonCanonicalLeft(SPENDER.accountId);
+
+        expect(
+          token.isApprovedForAll(OWNER.either, nonCanonical),
+        ).toBe(true);
       });
     });
 
     describe('setApprovalForAll', () => {
       it('should return false when set to false', () => {
-        token.as(OWNER).setApprovalForAll(Z_SPENDER, false);
-        expect(token.isApprovedForAll(Z_OWNER, Z_SPENDER)).toBe(false);
+        token.privateState.injectSecretKey(OWNER.secretKey);
+        token.setApprovalForAll(SPENDER.either, false);
+        expect(
+          token.isApprovedForAll(OWNER.either, SPENDER.either),
+        ).toBe(false);
       });
 
       it('should fail when attempting to approve zero address as an operator', () => {
+        token.privateState.injectSecretKey(OWNER.secretKey);
         expect(() => {
-          token.as(OWNER).setApprovalForAll(utils.ZERO_KEY, true);
+          token.setApprovalForAll(ZERO_ACCOUNT, true);
         }).toThrow('MultiToken: invalid operator');
       });
 
       describe('when spender is approved as an operator', () => {
         beforeEach(() => {
-          token.as(OWNER).setApprovalForAll(Z_SPENDER, true);
+          token.privateState.injectSecretKey(OWNER.secretKey);
+          token.setApprovalForAll(SPENDER.either, true);
         });
 
         it('should return true when set to true', () => {
-          expect(token.isApprovedForAll(Z_OWNER, Z_SPENDER)).toBe(true);
+          expect(
+            token.isApprovedForAll(OWNER.either, SPENDER.either),
+          ).toBe(true);
         });
 
         it('should unset → set → unset operator', () => {
-          token.setApprovalForAll(Z_SPENDER, false);
-          expect(token.isApprovedForAll(Z_OWNER, Z_SPENDER)).toBe(false);
+          token.setApprovalForAll(SPENDER.either, false);
+          expect(
+            token.isApprovedForAll(OWNER.either, SPENDER.either),
+          ).toBe(false);
 
-          token.setApprovalForAll(Z_SPENDER, true);
-          expect(token.isApprovedForAll(Z_OWNER, Z_SPENDER)).toBe(true);
+          token.setApprovalForAll(SPENDER.either, true);
+          expect(
+            token.isApprovedForAll(OWNER.either, SPENDER.either),
+          ).toBe(true);
 
-          token.setApprovalForAll(Z_SPENDER, false);
-          expect(token.isApprovedForAll(Z_OWNER, Z_SPENDER)).toBe(false);
+          token.setApprovalForAll(SPENDER.either, false);
+          expect(
+            token.isApprovedForAll(OWNER.either, SPENDER.either),
+          ).toBe(false);
         });
       });
     });
 
     describe('transferFrom', () => {
       beforeEach(() => {
-        token._mint(Z_OWNER, TOKEN_ID, AMOUNT);
+        token._mint(OWNER.either, TOKEN_ID, AMOUNT);
 
-        expect(token.balanceOf(Z_OWNER, TOKEN_ID)).toEqual(AMOUNT);
-        expect(token.balanceOf(Z_RECIPIENT, TOKEN_ID)).toEqual(0n);
+        expect(token.balanceOf(OWNER.either, TOKEN_ID)).toEqual(AMOUNT);
+        expect(token.balanceOf(RECIPIENT.either, TOKEN_ID)).toEqual(0n);
       });
 
-      describe.each(callerTypes)('when the caller is the %s', (_, caller) => {
-        beforeEach(() => {
-          if (caller === SPENDER) {
-            token._setApprovalForAll(Z_OWNER, Z_SPENDER, true);
-          }
-        });
+      describe.each(callerTypes)(
+        'when the caller is the %s',
+        (_, caller) => {
+          beforeEach(() => {
+            if (caller === SPENDER) {
+              token._setApprovalForAll(
+                OWNER.either,
+                SPENDER.either,
+                true,
+              );
+            }
+            token.privateState.injectSecretKey(caller.secretKey);
+          });
 
-        it('should transfer whole', () => {
-          token.as(caller).transferFrom(Z_OWNER, Z_RECIPIENT, TOKEN_ID, AMOUNT);
+          it('should transfer whole', () => {
+            token.transferFrom(
+              OWNER.either,
+              RECIPIENT.either,
+              TOKEN_ID,
+              AMOUNT,
+            );
 
-          expect(token.balanceOf(Z_OWNER, TOKEN_ID)).toEqual(0n);
-          expect(token.balanceOf(Z_RECIPIENT, TOKEN_ID)).toEqual(AMOUNT);
-        });
+            expect(token.balanceOf(OWNER.either, TOKEN_ID)).toEqual(0n);
+            expect(token.balanceOf(RECIPIENT.either, TOKEN_ID)).toEqual(
+              AMOUNT,
+            );
+          });
 
-        it('should transfer partial', () => {
-          const partialAmt = AMOUNT - 1n;
-          token
-            .as(caller)
-            .transferFrom(Z_OWNER, Z_RECIPIENT, TOKEN_ID, partialAmt);
+          it('should transfer partial', () => {
+            const partialAmt = AMOUNT - 1n;
+            token.transferFrom(
+              OWNER.either,
+              RECIPIENT.either,
+              TOKEN_ID,
+              partialAmt,
+            );
 
-          expect(token.balanceOf(Z_OWNER, TOKEN_ID)).toEqual(
-            AMOUNT - partialAmt,
-          );
-          expect(token.balanceOf(Z_RECIPIENT, TOKEN_ID)).toEqual(partialAmt);
-        });
+            expect(token.balanceOf(OWNER.either, TOKEN_ID)).toEqual(
+              AMOUNT - partialAmt,
+            );
+            expect(token.balanceOf(RECIPIENT.either, TOKEN_ID)).toEqual(
+              partialAmt,
+            );
+          });
 
-        it('should allow transfer of 0 tokens', () => {
-          token.as(caller).transferFrom(Z_OWNER, Z_RECIPIENT, TOKEN_ID, 0n);
+          it('should allow transfer of 0 tokens', () => {
+            token.transferFrom(
+              OWNER.either,
+              RECIPIENT.either,
+              TOKEN_ID,
+              0n,
+            );
 
-          expect(token.balanceOf(Z_OWNER, TOKEN_ID)).toEqual(AMOUNT);
-          expect(token.balanceOf(Z_RECIPIENT, TOKEN_ID)).toEqual(0n);
-        });
+            expect(token.balanceOf(OWNER.either, TOKEN_ID)).toEqual(AMOUNT);
+            expect(token.balanceOf(RECIPIENT.either, TOKEN_ID)).toEqual(0n);
+          });
 
-        it('should handle self-transfer', () => {
-          token.as(caller).transferFrom(Z_OWNER, Z_OWNER, TOKEN_ID, AMOUNT);
-          expect(token.balanceOf(Z_OWNER, TOKEN_ID)).toEqual(AMOUNT);
-        });
+          it('should handle self-transfer', () => {
+            token.transferFrom(OWNER.either, OWNER.either, TOKEN_ID, AMOUNT);
+            expect(token.balanceOf(OWNER.either, TOKEN_ID)).toEqual(AMOUNT);
+          });
 
-        it('should handle MAX_UINT128 transfer amount', () => {
-          // Mint rest of tokens to == MAX_UINT128
-          token._mint(Z_OWNER, TOKEN_ID, MAX_UINT128 - AMOUNT);
+          it('should handle MAX_UINT128 transfer amount', () => {
+            token._mint(OWNER.either, TOKEN_ID, MAX_UINT128 - AMOUNT);
 
-          token
-            .as(caller)
-            .transferFrom(Z_OWNER, Z_RECIPIENT, TOKEN_ID, MAX_UINT128);
-          expect(token.balanceOf(Z_RECIPIENT, TOKEN_ID)).toEqual(MAX_UINT128);
-        });
+            token.transferFrom(
+              OWNER.either,
+              RECIPIENT.either,
+              TOKEN_ID,
+              MAX_UINT128,
+            );
+            expect(token.balanceOf(RECIPIENT.either, TOKEN_ID)).toEqual(
+              MAX_UINT128,
+            );
+          });
 
-        it('should handle rapid state changes', () => {
-          // Approve -> Transfer -> Revoke -> Approve
-          token.as(OWNER).setApprovalForAll(Z_SPENDER, true);
+          it('should handle rapid state changes', () => {
+            token.privateState.injectSecretKey(OWNER.secretKey);
+            token.setApprovalForAll(SPENDER.either, true);
 
-          token
-            .as(SPENDER)
-            .transferFrom(Z_OWNER, Z_RECIPIENT, TOKEN_ID, AMOUNT);
-          expect(token.balanceOf(Z_RECIPIENT, TOKEN_ID)).toEqual(AMOUNT);
+            token.privateState.injectSecretKey(SPENDER.secretKey);
+            token.transferFrom(
+              OWNER.either,
+              RECIPIENT.either,
+              TOKEN_ID,
+              AMOUNT,
+            );
+            expect(token.balanceOf(RECIPIENT.either, TOKEN_ID)).toEqual(
+              AMOUNT,
+            );
 
-          token.as(OWNER).setApprovalForAll(Z_SPENDER, false);
-          expect(token.isApprovedForAll(Z_OWNER, Z_SPENDER)).toBe(false);
+            token.privateState.injectSecretKey(OWNER.secretKey);
+            token.setApprovalForAll(SPENDER.either, false);
+            expect(
+              token.isApprovedForAll(OWNER.either, SPENDER.either),
+            ).toBe(false);
 
-          token.as(OWNER).setApprovalForAll(Z_SPENDER, true);
-          expect(token.isApprovedForAll(Z_OWNER, Z_SPENDER)).toBe(true);
-        });
+            token.setApprovalForAll(SPENDER.either, true);
+            expect(
+              token.isApprovedForAll(OWNER.either, SPENDER.either),
+            ).toBe(true);
+          });
 
-        it('should fail with insufficient balance', () => {
-          expect(() => {
-            token
-              .as(caller)
-              .transferFrom(Z_OWNER, Z_RECIPIENT, TOKEN_ID, AMOUNT + 1n);
-          }).toThrow('MultiToken: insufficient balance');
-        });
+          it('should fail with insufficient balance', () => {
+            expect(() => {
+              token.transferFrom(
+                OWNER.either,
+                RECIPIENT.either,
+                TOKEN_ID,
+                AMOUNT + 1n,
+              );
+            }).toThrow('MultiToken: insufficient balance');
+          });
 
-        it('should fail with nonexistent id', () => {
-          expect(() => {
-            token
-              .as(caller)
-              .transferFrom(Z_OWNER, Z_RECIPIENT, NONEXISTENT_ID, AMOUNT);
-          }).toThrow('MultiToken: insufficient balance');
-        });
+          it('should fail with nonexistent id', () => {
+            expect(() => {
+              token.transferFrom(
+                OWNER.either,
+                RECIPIENT.either,
+                NONEXISTENT_ID,
+                AMOUNT,
+              );
+            }).toThrow('MultiToken: insufficient balance');
+          });
 
-        it('should fail with transfer from zero', () => {
-          expect(() => {
-            token
-              .as(caller)
-              .transferFrom(utils.ZERO_KEY, Z_RECIPIENT, TOKEN_ID, AMOUNT);
-          }).toThrow('MultiToken: unauthorized operator');
-        });
+          it('should fail with transfer from zero', () => {
+            expect(() => {
+              token.transferFrom(
+                ZERO_ACCOUNT,
+                RECIPIENT.either,
+                TOKEN_ID,
+                AMOUNT,
+              );
+            }).toThrow('MultiToken: unauthorized operator');
+          });
 
-        it('should fail with transfer to zero (pk)', () => {
-          expect(() => {
-            token
-              .as(caller)
-              .transferFrom(Z_OWNER, utils.ZERO_KEY, TOKEN_ID, AMOUNT);
-          }).toThrow('MultiToken: invalid receiver');
-        });
+          it('should fail with transfer to zero (id)', () => {
+            expect(() => {
+              token.transferFrom(
+                OWNER.either,
+                ZERO_ACCOUNT,
+                TOKEN_ID,
+                AMOUNT,
+              );
+            }).toThrow('MultiToken: invalid receiver');
+          });
 
-        it('should fail with transfer to zero (contract)', () => {
-          expect(() => {
-            token
-              .as(caller)
-              .transferFrom(Z_OWNER, utils.ZERO_ADDRESS, TOKEN_ID, AMOUNT);
-          }).toThrow('MultiToken: unsafe transfer');
-        });
+          it('should fail with transfer to zero (contract)', () => {
+            expect(() => {
+              token.transferFrom(
+                OWNER.either,
+                ZERO_CONTRACT,
+                TOKEN_ID,
+                AMOUNT,
+              );
+            }).toThrow('MultiToken: unsafe transfer');
+          });
 
-        it('should fail when transferring to a contract address', () => {
-          expect(() => {
-            token
-              .as(caller)
-              .transferFrom(Z_OWNER, Z_RECIPIENT_CONTRACT, TOKEN_ID, AMOUNT);
-          }).toThrow('MultiToken: unsafe transfer');
-        });
-      });
+          it('should fail when transferring to a contract address', () => {
+            expect(() => {
+              token.transferFrom(
+                OWNER.either,
+                RECIPIENT_CONTRACT,
+                TOKEN_ID,
+                AMOUNT,
+              );
+            }).toThrow('MultiToken: unsafe transfer');
+          });
+        },
+      );
 
       it('should handle concurrent operations on same token ID', () => {
-        token._mint(Z_OWNER, TOKEN_ID, AMOUNT * 2n);
+        token._mint(OWNER.either, TOKEN_ID, AMOUNT * 2n);
 
-        // Set up two spenders
-        token.as(OWNER).setApprovalForAll(Z_SPENDER, true);
-        token.as(OWNER).setApprovalForAll(Z_OTHER, true);
+        token.privateState.injectSecretKey(OWNER.secretKey);
+        token.setApprovalForAll(SPENDER.either, true);
+        token.setApprovalForAll(OTHER.either, true);
 
         // First spender transfers half
-        token.as(SPENDER).transferFrom(Z_OWNER, Z_RECIPIENT, TOKEN_ID, AMOUNT);
-        expect(token.balanceOf(Z_RECIPIENT, TOKEN_ID)).toEqual(AMOUNT);
+        token.privateState.injectSecretKey(SPENDER.secretKey);
+        token.transferFrom(
+          OWNER.either,
+          RECIPIENT.either,
+          TOKEN_ID,
+          AMOUNT,
+        );
+        expect(token.balanceOf(RECIPIENT.either, TOKEN_ID)).toEqual(AMOUNT);
 
         // Second spender transfers remaining
-        token.as(OTHER).transferFrom(Z_OWNER, Z_RECIPIENT, TOKEN_ID, AMOUNT);
-        expect(token.balanceOf(Z_RECIPIENT, TOKEN_ID)).toEqual(AMOUNT * 2n);
+        token.privateState.injectSecretKey(OTHER.secretKey);
+        token.transferFrom(
+          OWNER.either,
+          RECIPIENT.either,
+          TOKEN_ID,
+          AMOUNT,
+        );
+        expect(token.balanceOf(RECIPIENT.either, TOKEN_ID)).toEqual(
+          AMOUNT * 2n,
+        );
+      });
+
+      it('should handle non-canonical fromAddress (id)', () => {
+        token.privateState.injectSecretKey(OWNER.secretKey);
+
+        const nonCanonical = nonCanonicalLeft(OWNER.accountId);
+        token.transferFrom(nonCanonical, RECIPIENT.either, TOKEN_ID, AMOUNT);
+
+        expect(token.balanceOf(RECIPIENT.either, TOKEN_ID)).toEqual(AMOUNT);
+      });
+
+      it('should handle non-canonical fromAddress (contract address)', () => {
+        token._unsafeMint(OWNER_CONTRACT, TOKEN_ID, AMOUNT);
+        token._setApprovalForAll(OWNER_CONTRACT, OWNER.either, true);
+
+        token.privateState.injectSecretKey(OWNER.secretKey);
+
+        const nonCanonical = nonCanonicalRight(OWNER_CONTRACT.right);
+        token.transferFrom(nonCanonical, RECIPIENT.either, TOKEN_ID, AMOUNT);
+
+        expect(token.balanceOf(RECIPIENT.either, TOKEN_ID)).toEqual(AMOUNT);
       });
 
       describe('when the caller is unauthorized', () => {
+        beforeEach(() => {
+          token.privateState.injectSecretKey(UNAUTHORIZED.secretKey);
+        });
+
         it('should fail when transfer whole', () => {
           expect(() => {
-            token
-              .as(UNAUTHORIZED)
-              .transferFrom(Z_OWNER, Z_RECIPIENT, TOKEN_ID, AMOUNT);
+            token.transferFrom(
+              OWNER.either,
+              RECIPIENT.either,
+              TOKEN_ID,
+              AMOUNT,
+            );
           }).toThrow('MultiToken: unauthorized operator');
         });
 
         it('should fail when transfer partial', () => {
           expect(() => {
             const partialAmt = AMOUNT - 1n;
-            token
-              .as(UNAUTHORIZED)
-              .transferFrom(Z_OWNER, Z_RECIPIENT, TOKEN_ID, partialAmt);
+            token.transferFrom(
+              OWNER.either,
+              RECIPIENT.either,
+              TOKEN_ID,
+              partialAmt,
+            );
           }).toThrow('MultiToken: unauthorized operator');
         });
 
         it('should fail when transfer zero', () => {
           expect(() => {
-            token
-              .as(UNAUTHORIZED)
-              .transferFrom(Z_OWNER, Z_RECIPIENT, TOKEN_ID, 0n);
+            token.transferFrom(
+              OWNER.either,
+              RECIPIENT.either,
+              TOKEN_ID,
+              0n,
+            );
           }).toThrow('MultiToken: unauthorized operator');
         });
 
         it('should fail with insufficient balance', () => {
           expect(() => {
-            token
-              .as(UNAUTHORIZED)
-              .transferFrom(Z_OWNER, Z_RECIPIENT, TOKEN_ID, AMOUNT + 1n);
+            token.transferFrom(
+              OWNER.either,
+              RECIPIENT.either,
+              TOKEN_ID,
+              AMOUNT + 1n,
+            );
           }).toThrow('MultiToken: unauthorized operator');
         });
 
         it('should fail with nonexistent id', () => {
           expect(() => {
-            token
-              .as(UNAUTHORIZED)
-              .transferFrom(Z_OWNER, Z_RECIPIENT, NONEXISTENT_ID, AMOUNT);
+            token.transferFrom(
+              OWNER.either,
+              RECIPIENT.either,
+              NONEXISTENT_ID,
+              AMOUNT,
+            );
           }).toThrow('MultiToken: unauthorized operator');
         });
 
         it('should fail with transfer from zero', () => {
           expect(() => {
-            token
-              .as(ZERO)
-              .transferFrom(utils.ZERO_KEY, Z_RECIPIENT, TOKEN_ID, AMOUNT);
-          }).toThrow('MultiToken: invalid sender');
+            token.transferFrom(
+              ZERO_ACCOUNT,
+              RECIPIENT.either,
+              TOKEN_ID,
+              AMOUNT,
+            );
+          }).toThrow('MultiToken: unauthorized operator');
         });
       });
     });
 
     describe('_unsafeTransferFrom', () => {
       beforeEach(() => {
-        token._mint(Z_OWNER, TOKEN_ID, AMOUNT);
+        token._mint(OWNER.either, TOKEN_ID, AMOUNT);
       });
 
-      describe.each(callerTypes)('when the caller is the %s', (_, caller) => {
+      describe.each(callerTypes)(
+        'when the caller is the %s',
+        (_, caller) => {
+          beforeEach(() => {
+            if (caller === SPENDER) {
+              token._setApprovalForAll(
+                OWNER.either,
+                SPENDER.either,
+                true,
+              );
+            }
+            token.privateState.injectSecretKey(caller.secretKey);
+          });
+
+          describe.each(recipientTypes)(
+            'when the recipient is a %s',
+            (_, recipient) => {
+              it('should transfer whole', () => {
+                token._unsafeTransferFrom(
+                  OWNER.either,
+                  recipient,
+                  TOKEN_ID,
+                  AMOUNT,
+                );
+
+                expect(token.balanceOf(OWNER.either, TOKEN_ID)).toEqual(0n);
+                expect(token.balanceOf(recipient, TOKEN_ID)).toEqual(AMOUNT);
+              });
+
+              it('should transfer partial', () => {
+                const partialAmt = AMOUNT - 1n;
+                token._unsafeTransferFrom(
+                  OWNER.either,
+                  recipient,
+                  TOKEN_ID,
+                  partialAmt,
+                );
+
+                expect(token.balanceOf(OWNER.either, TOKEN_ID)).toEqual(
+                  AMOUNT - partialAmt,
+                );
+                expect(token.balanceOf(recipient, TOKEN_ID)).toEqual(
+                  partialAmt,
+                );
+              });
+
+              it('should allow transfer of 0 tokens', () => {
+                token._unsafeTransferFrom(
+                  OWNER.either,
+                  recipient,
+                  TOKEN_ID,
+                  0n,
+                );
+
+                expect(token.balanceOf(OWNER.either, TOKEN_ID)).toEqual(
+                  AMOUNT,
+                );
+                expect(token.balanceOf(recipient, TOKEN_ID)).toEqual(0n);
+              });
+
+              it('should handle self-transfer', () => {
+                token._unsafeTransferFrom(
+                  OWNER.either,
+                  OWNER.either,
+                  TOKEN_ID,
+                  AMOUNT,
+                );
+                expect(token.balanceOf(OWNER.either, TOKEN_ID)).toEqual(
+                  AMOUNT,
+                );
+              });
+
+              it('should handle MAX_UINT128 transfer amount', () => {
+                token._mint(OWNER.either, TOKEN_ID, MAX_UINT128 - AMOUNT);
+
+                token._unsafeTransferFrom(
+                  OWNER.either,
+                  recipient,
+                  TOKEN_ID,
+                  MAX_UINT128,
+                );
+                expect(token.balanceOf(recipient, TOKEN_ID)).toEqual(
+                  MAX_UINT128,
+                );
+              });
+
+              it('should handle rapid state changes', () => {
+                token.privateState.injectSecretKey(OWNER.secretKey);
+                token.setApprovalForAll(SPENDER.either, true);
+
+                token._unsafeTransferFrom(
+                  OWNER.either,
+                  recipient,
+                  TOKEN_ID,
+                  AMOUNT,
+                );
+                expect(token.balanceOf(recipient, TOKEN_ID)).toEqual(AMOUNT);
+
+                token.setApprovalForAll(SPENDER.either, false);
+                expect(
+                  token.isApprovedForAll(OWNER.either, SPENDER.either),
+                ).toBe(false);
+
+                token.setApprovalForAll(SPENDER.either, true);
+                expect(
+                  token.isApprovedForAll(OWNER.either, SPENDER.either),
+                ).toBe(true);
+              });
+
+              it('should fail with insufficient balance', () => {
+                expect(() => {
+                  token._unsafeTransferFrom(
+                    OWNER.either,
+                    recipient,
+                    TOKEN_ID,
+                    AMOUNT + 1n,
+                  );
+                }).toThrow('MultiToken: insufficient balance');
+              });
+
+              it('should fail with nonexistent id', () => {
+                expect(() => {
+                  token._unsafeTransferFrom(
+                    OWNER.either,
+                    recipient,
+                    NONEXISTENT_ID,
+                    AMOUNT,
+                  );
+                }).toThrow('MultiToken: insufficient balance');
+              });
+
+              it('should fail with transfer from zero', () => {
+                expect(() => {
+                  token._unsafeTransferFrom(
+                    ZERO_ACCOUNT,
+                    recipient,
+                    TOKEN_ID,
+                    AMOUNT,
+                  );
+                }).toThrow('MultiToken: unauthorized operator');
+              });
+            },
+          );
+
+          it('should fail with transfer to zero (id)', () => {
+            expect(() => {
+              token._unsafeTransferFrom(
+                OWNER.either,
+                ZERO_ACCOUNT,
+                TOKEN_ID,
+                AMOUNT,
+              );
+            }).toThrow('MultiToken: invalid receiver');
+          });
+
+          it('should fail with transfer to zero (contract)', () => {
+            expect(() => {
+              token._unsafeTransferFrom(
+                OWNER.either,
+                ZERO_CONTRACT,
+                TOKEN_ID,
+                AMOUNT,
+              );
+            }).toThrow('MultiToken: invalid receiver');
+          });
+        },
+      );
+
+      it('should handle concurrent operations on same token ID', () => {
+        token._mint(OWNER.either, TOKEN_ID, AMOUNT * 2n);
+
+        token.privateState.injectSecretKey(OWNER.secretKey);
+        token.setApprovalForAll(SPENDER.either, true);
+        token.setApprovalForAll(OTHER.either, true);
+
+        // First spender transfers half
+        token.privateState.injectSecretKey(SPENDER.secretKey);
+        token._unsafeTransferFrom(
+          OWNER.either,
+          RECIPIENT.either,
+          TOKEN_ID,
+          AMOUNT,
+        );
+        expect(token.balanceOf(RECIPIENT.either, TOKEN_ID)).toEqual(AMOUNT);
+
+        // Second spender transfers remaining
+        token.privateState.injectSecretKey(OTHER.secretKey);
+        token._unsafeTransferFrom(
+          OWNER.either,
+          RECIPIENT.either,
+          TOKEN_ID,
+          AMOUNT,
+        );
+        expect(token.balanceOf(RECIPIENT.either, TOKEN_ID)).toEqual(
+          AMOUNT * 2n,
+        );
+      });
+
+      it('should handle non-canonical fromAddress (id)', () => {
+        const nonCanonical = nonCanonicalLeft(OWNER.accountId);
+
+        token.privateState.injectSecretKey(OWNER.secretKey);
+        token._unsafeTransferFrom(
+          nonCanonical,
+          RECIPIENT.either,
+          TOKEN_ID,
+          AMOUNT,
+        );
+        expect(token.balanceOf(RECIPIENT.either, TOKEN_ID)).toEqual(AMOUNT);
+      });
+
+      it('should handle non-canonical fromAddress (contract address)', () => {
+        // Mint to contract address to test the transfer of non-canonical `fromAddress`
+        token._unsafeMint(OWNER_CONTRACT, TOKEN_ID, AMOUNT);
+        // Approve owner (id) to move OWNER_CONTRACT's token
+        token._setApprovalForAll(OWNER_CONTRACT, OWNER.either, true);
+
+        token.privateState.injectSecretKey(OWNER.secretKey);
+        const nonCanonical = nonCanonicalRight(OWNER_CONTRACT.right);
+        token._unsafeTransferFrom(
+          nonCanonical,
+          RECIPIENT.either,
+          TOKEN_ID,
+          AMOUNT,
+        );
+        expect(token.balanceOf(RECIPIENT.either, TOKEN_ID)).toEqual(AMOUNT);
+      });
+
+      it('should canonicalize recipient (id)', () => {
+        token.privateState.injectSecretKey(OWNER.secretKey);
+
+        const nonCanonical = nonCanonicalLeft(RECIPIENT.accountId);
+        token._unsafeTransferFrom(
+          OWNER.either,
+          nonCanonical,
+          TOKEN_ID,
+          AMOUNT,
+        );
+        expect(token.balanceOf(RECIPIENT.either, TOKEN_ID)).toEqual(AMOUNT);
+      });
+
+      it('should canonicalize recipient (contract address)', () => {
+        token.privateState.injectSecretKey(OWNER.secretKey);
+
+        const nonCanonical = nonCanonicalRight(RECIPIENT_CONTRACT.right);
+        token._unsafeTransferFrom(
+          OWNER.either,
+          nonCanonical,
+          TOKEN_ID,
+          AMOUNT,
+        );
+        expect(token.balanceOf(RECIPIENT_CONTRACT, TOKEN_ID)).toEqual(AMOUNT);
+      });
+
+      describe('when the caller is unauthorized', () => {
         beforeEach(() => {
-          if (caller === SPENDER) {
-            token._setApprovalForAll(Z_OWNER, Z_SPENDER, true);
-          }
+          token.privateState.injectSecretKey(UNAUTHORIZED.secretKey);
         });
 
-        describe.each(
-          recipientTypes,
-        )('when the recipient is a %s', (_, recipient) => {
-          it('should transfer whole', () => {
-            token
-              .as(caller)
-              ._unsafeTransferFrom(Z_OWNER, recipient, TOKEN_ID, AMOUNT);
+        describe.each(recipientTypes)(
+          'when recipient is %s',
+          (_, recipient) => {
+            it('should fail when transfer whole', () => {
+              expect(() => {
+                token._unsafeTransferFrom(
+                  OWNER.either,
+                  recipient,
+                  TOKEN_ID,
+                  AMOUNT,
+                );
+              }).toThrow('MultiToken: unauthorized operator');
+            });
 
-            expect(token.balanceOf(Z_OWNER, TOKEN_ID)).toEqual(0n);
+            it('should fail when transfer partial', () => {
+              expect(() => {
+                const partialAmt = AMOUNT - 1n;
+                token._unsafeTransferFrom(
+                  OWNER.either,
+                  recipient,
+                  TOKEN_ID,
+                  partialAmt,
+                );
+              }).toThrow('MultiToken: unauthorized operator');
+            });
+
+            it('should fail when transfer zero', () => {
+              expect(() => {
+                token._unsafeTransferFrom(
+                  OWNER.either,
+                  recipient,
+                  TOKEN_ID,
+                  0n,
+                );
+              }).toThrow('MultiToken: unauthorized operator');
+            });
+
+            it('should fail with insufficient balance', () => {
+              expect(() => {
+                token._unsafeTransferFrom(
+                  OWNER.either,
+                  recipient,
+                  TOKEN_ID,
+                  AMOUNT + 1n,
+                );
+              }).toThrow('MultiToken: unauthorized operator');
+            });
+
+            it('should fail with nonexistent id', () => {
+              expect(() => {
+                token._unsafeTransferFrom(
+                  OWNER.either,
+                  recipient,
+                  NONEXISTENT_ID,
+                  AMOUNT,
+                );
+              }).toThrow('MultiToken: unauthorized operator');
+            });
+
+            it('should fail with transfer from zero', () => {
+              // With witness-based identity, the caller is H(sk) which is
+              // always non-zero. Transferring from ZERO_ACCOUNT means
+              // canonFrom != caller → isApprovedForAll(ZERO, caller) → false
+              // → "unauthorized operator"
+              expect(() => {
+                token._unsafeTransferFrom(
+                  ZERO_ACCOUNT,
+                  recipient,
+                  TOKEN_ID,
+                  AMOUNT,
+                );
+              }).toThrow('MultiToken: unauthorized operator');
+            });
+          },
+        );
+      });
+    });
+
+    describe('_transfer', () => {
+      beforeEach(() => {
+        token._mint(OWNER.either, TOKEN_ID, AMOUNT);
+
+        expect(token.balanceOf(OWNER.either, TOKEN_ID)).toEqual(AMOUNT);
+        expect(token.balanceOf(RECIPIENT.either, TOKEN_ID)).toEqual(0n);
+      });
+
+      it('should transfer whole', () => {
+        token._transfer(OWNER.either, RECIPIENT.either, TOKEN_ID, AMOUNT);
+
+        expect(token.balanceOf(OWNER.either, TOKEN_ID)).toEqual(0n);
+        expect(token.balanceOf(RECIPIENT.either, TOKEN_ID)).toEqual(AMOUNT);
+      });
+
+      it('should transfer partial', () => {
+        const partialAmt = AMOUNT - 1n;
+        token._transfer(OWNER.either, RECIPIENT.either, TOKEN_ID, partialAmt);
+
+        expect(token.balanceOf(OWNER.either, TOKEN_ID)).toEqual(
+          AMOUNT - partialAmt,
+        );
+        expect(token.balanceOf(RECIPIENT.either, TOKEN_ID)).toEqual(
+          partialAmt,
+        );
+      });
+
+      it('should allow transfer of 0 tokens', () => {
+        token._transfer(OWNER.either, RECIPIENT.either, TOKEN_ID, 0n);
+
+        expect(token.balanceOf(OWNER.either, TOKEN_ID)).toEqual(AMOUNT);
+        expect(token.balanceOf(RECIPIENT.either, TOKEN_ID)).toEqual(0n);
+      });
+
+      it('should fail with insufficient balance', () => {
+        expect(() => {
+          token._transfer(
+            OWNER.either,
+            RECIPIENT.either,
+            TOKEN_ID,
+            AMOUNT + 1n,
+          );
+        }).toThrow('MultiToken: insufficient balance');
+      });
+
+      it('should fail with nonexistent id', () => {
+        expect(() => {
+          token._transfer(
+            OWNER.either,
+            RECIPIENT.either,
+            NONEXISTENT_ID,
+            AMOUNT,
+          );
+        }).toThrow('MultiToken: insufficient balance');
+      });
+
+      it('should fail when transfer from 0', () => {
+        expect(() => {
+          token._transfer(
+            ZERO_ACCOUNT,
+            RECIPIENT.either,
+            TOKEN_ID,
+            AMOUNT,
+          );
+        }).toThrow('MultiToken: invalid sender');
+      });
+
+      it('should fail when transfer to 0', () => {
+        expect(() => {
+          token._transfer(OWNER.either, ZERO_ACCOUNT, TOKEN_ID, AMOUNT);
+        }).toThrow('MultiToken: invalid receiver');
+      });
+
+      it('should fail when transfer to contract address', () => {
+        expect(() => {
+          token._transfer(
+            OWNER.either,
+            RECIPIENT_CONTRACT,
+            TOKEN_ID,
+            AMOUNT,
+          );
+        }).toThrow('MultiToken: unsafe transfer');
+      });
+
+      it('should handle non-canonical fromAddress (id)', () => {
+        const nonCanonical = nonCanonicalLeft(OWNER.accountId);
+
+        token._transfer(nonCanonical, RECIPIENT.either, TOKEN_ID, AMOUNT);
+        expect(token.balanceOf(OWNER.either, TOKEN_ID)).toEqual(0n);
+        expect(token.balanceOf(RECIPIENT.either, TOKEN_ID)).toEqual(AMOUNT);
+      });
+
+      it('should handle non-canonical fromAddress (contract address)', () => {
+        token._unsafeMint(OWNER_CONTRACT, TOKEN_ID, AMOUNT);
+
+        const nonCanonical = nonCanonicalRight(OWNER_CONTRACT.right);
+        token._transfer(nonCanonical, RECIPIENT.either, TOKEN_ID, AMOUNT);
+
+        expect(token.balanceOf(OWNER_CONTRACT, TOKEN_ID)).toEqual(0n);
+        expect(token.balanceOf(RECIPIENT.either, TOKEN_ID)).toEqual(AMOUNT);
+      });
+    });
+
+    describe('_unsafeTransfer', () => {
+      beforeEach(() => {
+        token._mint(OWNER.either, TOKEN_ID, AMOUNT);
+
+        expect(token.balanceOf(OWNER.either, TOKEN_ID)).toEqual(AMOUNT);
+        expect(token.balanceOf(RECIPIENT.either, TOKEN_ID)).toEqual(0n);
+      });
+
+      describe.each(recipientTypes)(
+        'when the recipient is a %s',
+        (_, recipient) => {
+          it('should transfer whole', () => {
+            token._unsafeTransfer(
+              OWNER.either,
+              recipient,
+              TOKEN_ID,
+              AMOUNT,
+            );
+
+            expect(token.balanceOf(OWNER.either, TOKEN_ID)).toEqual(0n);
             expect(token.balanceOf(recipient, TOKEN_ID)).toEqual(AMOUNT);
           });
 
           it('should transfer partial', () => {
             const partialAmt = AMOUNT - 1n;
-            token
-              .as(caller)
-              ._unsafeTransferFrom(Z_OWNER, recipient, TOKEN_ID, partialAmt);
+            token._unsafeTransfer(
+              OWNER.either,
+              recipient,
+              TOKEN_ID,
+              partialAmt,
+            );
 
-            expect(token.balanceOf(Z_OWNER, TOKEN_ID)).toEqual(
+            expect(token.balanceOf(OWNER.either, TOKEN_ID)).toEqual(
               AMOUNT - partialAmt,
             );
             expect(token.balanceOf(recipient, TOKEN_ID)).toEqual(partialAmt);
           });
 
           it('should allow transfer of 0 tokens', () => {
-            token
-              .as(caller)
-              ._unsafeTransferFrom(Z_OWNER, recipient, TOKEN_ID, 0n);
+            token._unsafeTransfer(OWNER.either, recipient, TOKEN_ID, 0n);
 
-            expect(token.balanceOf(Z_OWNER, TOKEN_ID)).toEqual(AMOUNT);
+            expect(token.balanceOf(OWNER.either, TOKEN_ID)).toEqual(AMOUNT);
             expect(token.balanceOf(recipient, TOKEN_ID)).toEqual(0n);
           });
 
-          it('should handle self-transfer', () => {
-            token
-              .as(caller)
-              ._unsafeTransferFrom(Z_OWNER, Z_OWNER, TOKEN_ID, AMOUNT);
-            expect(token.balanceOf(Z_OWNER, TOKEN_ID)).toEqual(AMOUNT);
-          });
-
-          it('should handle MAX_UINT128 transfer amount', () => {
-            // Mint rest of tokens to == MAX_UINT128
-            token._mint(Z_OWNER, TOKEN_ID, MAX_UINT128 - AMOUNT);
-
-            token
-              .as(caller)
-              ._unsafeTransferFrom(Z_OWNER, recipient, TOKEN_ID, MAX_UINT128);
-            expect(token.balanceOf(recipient, TOKEN_ID)).toEqual(MAX_UINT128);
-          });
-
-          it('should handle rapid state changes', () => {
-            // Approve -> Transfer -> Revoke -> Approve
-            token.as(OWNER).setApprovalForAll(Z_SPENDER, true);
-
-            token
-              .as(OWNER)
-              ._unsafeTransferFrom(Z_OWNER, recipient, TOKEN_ID, AMOUNT);
-            expect(token.balanceOf(recipient, TOKEN_ID)).toEqual(AMOUNT);
-
-            token.as(OWNER).setApprovalForAll(Z_SPENDER, false);
-            expect(token.isApprovedForAll(Z_OWNER, Z_SPENDER)).toBe(false);
-
-            token.as(OWNER).setApprovalForAll(Z_SPENDER, true);
-            expect(token.isApprovedForAll(Z_OWNER, Z_SPENDER)).toBe(true);
-          });
-
           it('should fail with insufficient balance', () => {
             expect(() => {
-              token
-                .as(caller)
-                ._unsafeTransferFrom(Z_OWNER, recipient, TOKEN_ID, AMOUNT + 1n);
+              token._unsafeTransfer(
+                OWNER.either,
+                recipient,
+                TOKEN_ID,
+                AMOUNT + 1n,
+              );
             }).toThrow('MultiToken: insufficient balance');
           });
 
           it('should fail with nonexistent id', () => {
             expect(() => {
-              token
-                .as(caller)
-                ._unsafeTransferFrom(
-                  Z_OWNER,
-                  recipient,
-                  NONEXISTENT_ID,
-                  AMOUNT,
-                );
+              token._unsafeTransfer(
+                OWNER.either,
+                recipient,
+                NONEXISTENT_ID,
+                AMOUNT,
+              );
             }).toThrow('MultiToken: insufficient balance');
           });
 
-          it('should fail with transfer from zero', () => {
+          it('should fail when transfer from 0 (id)', () => {
             expect(() => {
-              token
-                .as(caller)
-                ._unsafeTransferFrom(
-                  utils.ZERO_KEY,
-                  recipient,
-                  TOKEN_ID,
-                  AMOUNT,
-                );
-            }).toThrow('MultiToken: unauthorized operator');
-          });
-        });
-
-        it('should fail with transfer to zero (pk)', () => {
-          expect(() => {
-            token
-              .as(caller)
-              ._unsafeTransferFrom(Z_OWNER, utils.ZERO_KEY, TOKEN_ID, AMOUNT);
-          }).toThrow('MultiToken: invalid receiver');
-        });
-
-        it('should fail with transfer to zero (contract)', () => {
-          expect(() => {
-            token
-              .as(caller)
-              ._unsafeTransferFrom(
-                Z_OWNER,
-                utils.ZERO_ADDRESS,
+              token._unsafeTransfer(
+                ZERO_ACCOUNT,
+                recipient,
                 TOKEN_ID,
                 AMOUNT,
               );
-          }).toThrow('MultiToken: invalid receiver');
-        });
-      });
-
-      it('should handle concurrent operations on same token ID', () => {
-        token._mint(Z_OWNER, TOKEN_ID, AMOUNT * 2n);
-
-        // Set up two spenders
-        token.as(OWNER).setApprovalForAll(Z_SPENDER, true);
-        token.as(OWNER).setApprovalForAll(Z_OTHER, true);
-
-        // First spender transfers half
-        token
-          .as(SPENDER)
-          ._unsafeTransferFrom(Z_OWNER, Z_RECIPIENT, TOKEN_ID, AMOUNT);
-        expect(token.balanceOf(Z_RECIPIENT, TOKEN_ID)).toEqual(AMOUNT);
-
-        // Second spender transfers remaining
-        token
-          .as(OTHER)
-          ._unsafeTransferFrom(Z_OWNER, Z_RECIPIENT, TOKEN_ID, AMOUNT);
-        expect(token.balanceOf(Z_RECIPIENT, TOKEN_ID)).toEqual(AMOUNT * 2n);
-      });
-
-      describe('when the caller is unauthorized', () => {
-        describe.each(
-          recipientTypes,
-        )('when recipient is %s', (_, recipient) => {
-          it('should fail when transfer whole', () => {
-            expect(() => {
-              token
-                .as(UNAUTHORIZED)
-                ._unsafeTransferFrom(Z_OWNER, recipient, TOKEN_ID, AMOUNT);
-            }).toThrow('MultiToken: unauthorized operator');
-          });
-
-          it('should fail when transfer partial', () => {
-            expect(() => {
-              const partialAmt = AMOUNT - 1n;
-              token
-                .as(UNAUTHORIZED)
-                ._unsafeTransferFrom(Z_OWNER, recipient, TOKEN_ID, partialAmt);
-            }).toThrow('MultiToken: unauthorized operator');
-          });
-
-          it('should fail when transfer zero', () => {
-            expect(() => {
-              token
-                .as(UNAUTHORIZED)
-                ._unsafeTransferFrom(Z_OWNER, recipient, TOKEN_ID, 0n);
-            }).toThrow('MultiToken: unauthorized operator');
-          });
-
-          it('should fail with insufficient balance', () => {
-            expect(() => {
-              token
-                .as(UNAUTHORIZED)
-                ._unsafeTransferFrom(Z_OWNER, recipient, TOKEN_ID, AMOUNT + 1n);
-            }).toThrow('MultiToken: unauthorized operator');
-          });
-
-          it('should fail with nonexistent id', () => {
-            expect(() => {
-              token
-                .as(UNAUTHORIZED)
-                ._unsafeTransferFrom(
-                  Z_OWNER,
-                  recipient,
-                  NONEXISTENT_ID,
-                  AMOUNT,
-                );
-            }).toThrow('MultiToken: unauthorized operator');
-          });
-
-          it('should fail with transfer from zero', () => {
-            expect(() => {
-              token
-                .as(ZERO)
-                ._unsafeTransferFrom(
-                  utils.ZERO_KEY,
-                  recipient,
-                  TOKEN_ID,
-                  AMOUNT,
-                );
             }).toThrow('MultiToken: invalid sender');
           });
-        });
-      });
-    });
 
-    describe('_transfer', () => {
-      beforeEach(() => {
-        token._mint(Z_OWNER, TOKEN_ID, AMOUNT);
+          it('should fail when transfer from 0 (contract address)', () => {
+            expect(() => {
+              token._unsafeTransfer(
+                ZERO_CONTRACT,
+                recipient,
+                TOKEN_ID,
+                AMOUNT,
+              );
+            }).toThrow('MultiToken: invalid sender');
+          });
+        },
+      );
 
-        expect(token.balanceOf(Z_OWNER, TOKEN_ID)).toEqual(AMOUNT);
-        expect(token.balanceOf(Z_RECIPIENT, TOKEN_ID)).toEqual(0n);
-      });
+      it('should handle non-canonical fromAddress (id)', () => {
+        const nonCanonical = nonCanonicalLeft(OWNER.accountId);
+        token._unsafeTransfer(nonCanonical, RECIPIENT.either, TOKEN_ID, AMOUNT);
 
-      it('should transfer whole', () => {
-        token._transfer(Z_OWNER, Z_RECIPIENT, TOKEN_ID, AMOUNT);
-
-        expect(token.balanceOf(Z_OWNER, TOKEN_ID)).toEqual(0n);
-        expect(token.balanceOf(Z_RECIPIENT, TOKEN_ID)).toEqual(AMOUNT);
-      });
-
-      it('should transfer partial', () => {
-        const partialAmt = AMOUNT - 1n;
-        token._transfer(Z_OWNER, Z_RECIPIENT, TOKEN_ID, partialAmt);
-
-        expect(token.balanceOf(Z_OWNER, TOKEN_ID)).toEqual(AMOUNT - partialAmt);
-        expect(token.balanceOf(Z_RECIPIENT, TOKEN_ID)).toEqual(partialAmt);
+        expect(token.balanceOf(OWNER.either, TOKEN_ID)).toEqual(0n);
+        expect(token.balanceOf(RECIPIENT.either, TOKEN_ID)).toEqual(AMOUNT);
       });
 
-      it('should allow transfer of 0 tokens', () => {
-        token._transfer(Z_OWNER, Z_RECIPIENT, TOKEN_ID, 0n);
+      it('should handle non-canonical fromAddress (contract address)', () => {
+        // Mint to contract address to test the transfer of non-canonical `fromAddress`
+        token._unsafeMint(OWNER_CONTRACT, TOKEN_ID, AMOUNT);
 
-        expect(token.balanceOf(Z_OWNER, TOKEN_ID)).toEqual(AMOUNT);
-        expect(token.balanceOf(Z_RECIPIENT, TOKEN_ID)).toEqual(0n);
+        const nonCanonical = nonCanonicalRight(OWNER_CONTRACT.right);
+        token._unsafeTransfer(nonCanonical, RECIPIENT.either, TOKEN_ID, AMOUNT);
+
+        expect(token.balanceOf(OWNER_CONTRACT, TOKEN_ID)).toEqual(0n);
+        expect(token.balanceOf(RECIPIENT.either, TOKEN_ID)).toEqual(AMOUNT);
       });
 
-      it('should fail with unsufficient balance', () => {
+      it('should handle non-canonical to (id)', () => {
+        const nonCanonical = nonCanonicalLeft(RECIPIENT.accountId);
+        token._unsafeTransfer(OWNER.either, nonCanonical, TOKEN_ID, AMOUNT);
+
+        expect(token.balanceOf(OWNER.either, TOKEN_ID)).toEqual(0n);
+        expect(token.balanceOf(RECIPIENT.either, TOKEN_ID)).toEqual(AMOUNT);
+      });
+
+      it('should handle non-canonical to (contract address)', () => {
+        const nonCanonical = nonCanonicalRight(RECIPIENT_CONTRACT.right);
+        token._unsafeTransfer(OWNER.either, nonCanonical, TOKEN_ID, AMOUNT);
+
+        expect(token.balanceOf(RECIPIENT_CONTRACT, TOKEN_ID)).toEqual(AMOUNT);
+      });
+
+      it('should fail when transfer to 0 (id)', () => {
         expect(() => {
-          token._transfer(Z_OWNER, Z_RECIPIENT, TOKEN_ID, AMOUNT + 1n);
-        }).toThrow('MultiToken: insufficient balance');
-      });
-
-      it('should fail with nonexistent id', () => {
-        expect(() => {
-          token._transfer(Z_OWNER, Z_RECIPIENT, NONEXISTENT_ID, AMOUNT);
-        }).toThrow('MultiToken: insufficient balance');
-      });
-
-      it('should fail when transfer from 0', () => {
-        expect(() => {
-          token._transfer(utils.ZERO_KEY, Z_RECIPIENT, TOKEN_ID, AMOUNT);
-        }).toThrow('MultiToken: invalid sender');
-      });
-
-      it('should fail when transfer to 0', () => {
-        expect(() => {
-          token._transfer(Z_OWNER, utils.ZERO_KEY, TOKEN_ID, AMOUNT);
-        }).toThrow('MultiToken: invalid receiver');
-      });
-
-      it('should fail when transfer to contract address', () => {
-        expect(() => {
-          token._transfer(Z_OWNER, Z_RECIPIENT_CONTRACT, TOKEN_ID, AMOUNT);
-        }).toThrow('MultiToken: unsafe transfer');
-      });
-    });
-
-    describe('_unsafeTransfer', () => {
-      beforeEach(() => {
-        token._mint(Z_OWNER, TOKEN_ID, AMOUNT);
-
-        expect(token.balanceOf(Z_OWNER, TOKEN_ID)).toEqual(AMOUNT);
-        expect(token.balanceOf(Z_RECIPIENT, TOKEN_ID)).toEqual(0n);
-      });
-
-      describe.each(
-        recipientTypes,
-      )('when the recipient is a %s', (_, recipient) => {
-        it('should transfer whole', () => {
-          token._unsafeTransfer(Z_OWNER, recipient, TOKEN_ID, AMOUNT);
-
-          expect(token.balanceOf(Z_OWNER, TOKEN_ID)).toEqual(0n);
-          expect(token.balanceOf(recipient, TOKEN_ID)).toEqual(AMOUNT);
-        });
-
-        it('should transfer partial', () => {
-          const partialAmt = AMOUNT - 1n;
-          token._unsafeTransfer(Z_OWNER, recipient, TOKEN_ID, partialAmt);
-
-          expect(token.balanceOf(Z_OWNER, TOKEN_ID)).toEqual(
-            AMOUNT - partialAmt,
+          token._unsafeTransfer(
+            OWNER.either,
+            ZERO_ACCOUNT,
+            TOKEN_ID,
+            AMOUNT,
           );
-          expect(token.balanceOf(recipient, TOKEN_ID)).toEqual(partialAmt);
-        });
-
-        it('should allow transfer of 0 tokens', () => {
-          token._unsafeTransfer(Z_OWNER, recipient, TOKEN_ID, 0n);
-
-          expect(token.balanceOf(Z_OWNER, TOKEN_ID)).toEqual(AMOUNT);
-          expect(token.balanceOf(recipient, TOKEN_ID)).toEqual(0n);
-        });
-
-        it('should fail with unsufficient balance', () => {
-          expect(() => {
-            token._unsafeTransfer(Z_OWNER, recipient, TOKEN_ID, AMOUNT + 1n);
-          }).toThrow('MultiToken: insufficient balance');
-        });
-
-        it('should fail with nonexistent id', () => {
-          expect(() => {
-            token._unsafeTransfer(Z_OWNER, recipient, NONEXISTENT_ID, AMOUNT);
-          }).toThrow('MultiToken: insufficient balance');
-        });
-
-        it('should fail when transfer from 0 (pk)', () => {
-          expect(() => {
-            token._unsafeTransfer(utils.ZERO_KEY, recipient, TOKEN_ID, AMOUNT);
-          }).toThrow('MultiToken: invalid sender');
-        });
-
-        it('should fail when transfer from 0 (contract address)', () => {
-          expect(() => {
-            token._unsafeTransfer(
-              utils.ZERO_ADDRESS,
-              recipient,
-              TOKEN_ID,
-              AMOUNT,
-            );
-          }).toThrow('MultiToken: invalid sender');
-        });
-      });
-
-      it('should fail when transfer to 0 (pk)', () => {
-        expect(() => {
-          token._unsafeTransfer(Z_OWNER, utils.ZERO_KEY, TOKEN_ID, AMOUNT);
         }).toThrow('MultiToken: invalid receiver');
       });
 
       it('should fail when transfer to 0 (contract address)', () => {
         expect(() => {
-          token._unsafeTransfer(Z_OWNER, utils.ZERO_ADDRESS, TOKEN_ID, AMOUNT);
+          token._unsafeTransfer(
+            OWNER.either,
+            ZERO_CONTRACT,
+            TOKEN_ID,
+            AMOUNT,
+          );
         }).toThrow('MultiToken: invalid receiver');
       });
     });
@@ -803,150 +1284,242 @@ describe('MultiToken', () => {
 
     describe('_mint', () => {
       it('should update balance when minting', () => {
-        token._mint(Z_RECIPIENT, TOKEN_ID, AMOUNT);
-        expect(token.balanceOf(Z_RECIPIENT, TOKEN_ID)).toEqual(AMOUNT);
+        token._mint(RECIPIENT.either, TOKEN_ID, AMOUNT);
+        expect(token.balanceOf(RECIPIENT.either, TOKEN_ID)).toEqual(AMOUNT);
       });
 
       it('should update balance with multiple mints', () => {
         for (let i = 0; i < 3; i++) {
-          token._mint(Z_RECIPIENT, TOKEN_ID, 1n);
+          token._mint(RECIPIENT.either, TOKEN_ID, 1n);
         }
 
-        expect(token.balanceOf(Z_RECIPIENT, TOKEN_ID)).toEqual(3n);
+        expect(token.balanceOf(RECIPIENT.either, TOKEN_ID)).toEqual(3n);
       });
 
-      it('should fail when overflowing uin128', () => {
-        token._mint(Z_RECIPIENT, TOKEN_ID, MAX_UINT128);
+      it('should fail when overflowing uint128', () => {
+        token._mint(RECIPIENT.either, TOKEN_ID, MAX_UINT128);
 
         expect(() => {
-          token._mint(Z_RECIPIENT, TOKEN_ID, 1n);
+          token._mint(RECIPIENT.either, TOKEN_ID, 1n);
         }).toThrow('MultiToken: arithmetic overflow');
       });
 
-      it('should fail when minting to zero address (pk)', () => {
+      it('should fail when minting to zero address (id))', () => {
         expect(() => {
-          token._mint(utils.ZERO_KEY, TOKEN_ID, AMOUNT);
+          token._mint(ZERO_ACCOUNT, TOKEN_ID, AMOUNT);
         }).toThrow('MultiToken: invalid receiver');
       });
 
       it('should fail when minting to zero address (contract)', () => {
         expect(() => {
-          token._mint(utils.ZERO_ADDRESS, TOKEN_ID, AMOUNT);
+          token._mint(ZERO_CONTRACT, TOKEN_ID, AMOUNT);
         }).toThrow('MultiToken: unsafe transfer');
       });
 
       it('should fail when minting to a contract address', () => {
         expect(() => {
-          token._mint(Z_RECIPIENT_CONTRACT, TOKEN_ID, AMOUNT);
+          token._mint(RECIPIENT_CONTRACT, TOKEN_ID, AMOUNT);
         }).toThrow('MultiToken: unsafe transfer');
+      });
+
+      it('should canonicalize recipient', () => {
+        const nonCanonical = nonCanonicalLeft(RECIPIENT.accountId);
+        token._mint(nonCanonical, TOKEN_ID, AMOUNT);
+
+        expect(token.balanceOf(RECIPIENT.either, TOKEN_ID)).toEqual(AMOUNT);
       });
     });
 
     describe('_unsafeMint', () => {
-      describe.each(
-        recipientTypes,
-      )('when the recipient is a %s', (_, recipient) => {
-        it('should update balance when minting', () => {
-          token._unsafeMint(recipient, TOKEN_ID, AMOUNT);
+      describe.each(recipientTypes)(
+        'when the recipient is a %s',
+        (_, recipient) => {
+          it('should update balance when minting', () => {
+            token._unsafeMint(recipient, TOKEN_ID, AMOUNT);
 
-          expect(token.balanceOf(recipient, TOKEN_ID)).toEqual(AMOUNT);
-        });
+            expect(token.balanceOf(recipient, TOKEN_ID)).toEqual(AMOUNT);
+          });
 
-        it('should update balance with multiple mints', () => {
-          for (let i = 0; i < 3; i++) {
-            token._unsafeMint(recipient, TOKEN_ID, 1n);
-          }
+          it('should update balance with multiple mints', () => {
+            for (let i = 0; i < 3; i++) {
+              token._unsafeMint(recipient, TOKEN_ID, 1n);
+            }
 
-          expect(token.balanceOf(recipient, TOKEN_ID)).toEqual(3n);
-        });
+            expect(token.balanceOf(recipient, TOKEN_ID)).toEqual(3n);
+          });
 
-        it('should fail when overflowing uint128', () => {
-          token._unsafeMint(recipient, TOKEN_ID, MAX_UINT128);
+          it('should fail when overflowing uint128', () => {
+            token._unsafeMint(recipient, TOKEN_ID, MAX_UINT128);
 
-          expect(() => {
-            token._unsafeMint(recipient, TOKEN_ID, 1n);
-          }).toThrow('MultiToken: arithmetic overflow');
-        });
-      });
+            expect(() => {
+              token._unsafeMint(recipient, TOKEN_ID, 1n);
+            }).toThrow('MultiToken: arithmetic overflow');
+          });
+        },
+      );
 
-      it('should fail when minting to zero address (pk)', () => {
+      it('should fail when minting to zero address (id)', () => {
         expect(() => {
-          token._unsafeMint(utils.ZERO_KEY, TOKEN_ID, AMOUNT);
+          token._unsafeMint(ZERO_ACCOUNT, TOKEN_ID, AMOUNT);
         }).toThrow('MultiToken: invalid receiver');
       });
 
       it('should fail when minting to zero address (contract)', () => {
         expect(() => {
-          token._unsafeMint(utils.ZERO_ADDRESS, TOKEN_ID, AMOUNT);
+          token._unsafeMint(ZERO_CONTRACT, TOKEN_ID, AMOUNT);
         }).toThrow('MultiToken: invalid receiver');
+      });
+
+      it('should canonicalize recipient', () => {
+        const nonCanonical = nonCanonicalLeft(RECIPIENT.accountId);
+        token._unsafeMint(nonCanonical, TOKEN_ID, AMOUNT);
+
+        expect(token.balanceOf(RECIPIENT.either, TOKEN_ID)).toEqual(AMOUNT);
+      });
+
+      it('should canonicalize contract address recipient', () => {
+        const nonCanonical = nonCanonicalRight(RECIPIENT_CONTRACT.right);
+        token._unsafeMint(nonCanonical, TOKEN_ID, AMOUNT);
+
+        expect(token.balanceOf(RECIPIENT_CONTRACT, TOKEN_ID)).toEqual(AMOUNT);
       });
     });
 
     describe('_burn', () => {
       beforeEach(() => {
-        token._mint(Z_OWNER, TOKEN_ID, AMOUNT);
-        expect(token.balanceOf(Z_OWNER, TOKEN_ID)).toEqual(AMOUNT);
+        token._mint(OWNER.either, TOKEN_ID, AMOUNT);
+        expect(token.balanceOf(OWNER.either, TOKEN_ID)).toEqual(AMOUNT);
       });
 
       it('should burn tokens', () => {
-        token._burn(Z_OWNER, TOKEN_ID, AMOUNT);
-        expect(token.balanceOf(Z_OWNER, TOKEN_ID)).toEqual(0n);
+        token._burn(OWNER.either, TOKEN_ID, AMOUNT);
+        expect(token.balanceOf(OWNER.either, TOKEN_ID)).toEqual(0n);
       });
 
       it('should burn partial', () => {
         const partialAmt = 1n;
-        token._burn(Z_OWNER, TOKEN_ID, partialAmt);
-        expect(token.balanceOf(Z_OWNER, TOKEN_ID)).toEqual(AMOUNT - partialAmt);
+        token._burn(OWNER.either, TOKEN_ID, partialAmt);
+        expect(token.balanceOf(OWNER.either, TOKEN_ID)).toEqual(
+          AMOUNT - partialAmt,
+        );
       });
 
       it('should update balance with multiple burns', () => {
         for (let i = 0; i < 3; i++) {
-          token._burn(Z_OWNER, TOKEN_ID, 1n);
+          token._burn(OWNER.either, TOKEN_ID, 1n);
         }
 
-        expect(token.balanceOf(Z_OWNER, TOKEN_ID)).toEqual(AMOUNT - 3n);
+        expect(token.balanceOf(OWNER.either, TOKEN_ID)).toEqual(AMOUNT - 3n);
       });
 
       it('should fail when not enough balance to burn', () => {
         expect(() => {
-          token._burn(Z_OWNER, TOKEN_ID, AMOUNT + 1n);
+          token._burn(OWNER.either, TOKEN_ID, AMOUNT + 1n);
         }).toThrow('MultiToken: insufficient balance');
       });
 
       it('should fail when burning the zero address tokens', () => {
         expect(() => {
-          token._burn(utils.ZERO_KEY, TOKEN_ID, AMOUNT);
+          token._burn(ZERO_ACCOUNT, TOKEN_ID, AMOUNT);
         }).toThrow('MultiToken: invalid sender');
       });
 
       it('should fail when burning tokens from nonexistent id', () => {
         expect(() => {
-          token._burn(Z_OWNER, NONEXISTENT_ID, AMOUNT);
+          token._burn(OWNER.either, NONEXISTENT_ID, AMOUNT);
         }).toThrow('MultiToken: insufficient balance');
+      });
+
+      it('should handle non-canonical fromAddress (id)', () => {
+        const nonCanonical = nonCanonicalLeft(OWNER.accountId);
+        token._burn(nonCanonical, TOKEN_ID, AMOUNT);
+
+        expect(token.balanceOf(OWNER.either, TOKEN_ID)).toEqual(0n);
+      });
+
+      it('should handle non-canonical fromAddress (contract address)', () => {
+        token._unsafeMint(OWNER_CONTRACT, TOKEN_ID, AMOUNT);
+        expect(token.balanceOf(OWNER_CONTRACT, TOKEN_ID)).toEqual(AMOUNT);
+
+        const nonCanonical = nonCanonicalRight(OWNER_CONTRACT.right);
+        token._burn(nonCanonical, TOKEN_ID, AMOUNT);
+
+        expect(token.balanceOf(OWNER_CONTRACT, TOKEN_ID)).toEqual(0n);
       });
     });
 
     describe('_setApprovalForAll', () => {
       it('should return false when set to false', () => {
-        token._setApprovalForAll(Z_OWNER, Z_SPENDER, false);
-        expect(token.isApprovedForAll(Z_OWNER, Z_SPENDER)).toBe(false);
+        token._setApprovalForAll(OWNER.either, SPENDER.either, false);
+        expect(
+          token.isApprovedForAll(OWNER.either, SPENDER.either),
+        ).toBe(false);
       });
 
       it('should fail when attempting to approve zero address as an operator', () => {
         expect(() => {
-          token._setApprovalForAll(Z_OWNER, utils.ZERO_KEY, true);
+          token._setApprovalForAll(OWNER.either, ZERO_ACCOUNT, true);
         }).toThrow('MultiToken: invalid operator');
       });
 
+      it('should fail when owner is zero address', () => {
+        expect(() => {
+          token._setApprovalForAll(ZERO_ACCOUNT, SPENDER.either, true);
+        }).toThrow('MultiToken: invalid owner');
+      });
+
       it('should set → unset → set operator', () => {
-        token._setApprovalForAll(Z_OWNER, Z_SPENDER, true);
-        expect(token.isApprovedForAll(Z_OWNER, Z_SPENDER)).toBe(true);
+        token._setApprovalForAll(OWNER.either, SPENDER.either, true);
+        expect(
+          token.isApprovedForAll(OWNER.either, SPENDER.either),
+        ).toBe(true);
 
-        token._setApprovalForAll(Z_OWNER, Z_SPENDER, false);
-        expect(token.isApprovedForAll(Z_OWNER, Z_SPENDER)).toBe(false);
+        token._setApprovalForAll(OWNER.either, SPENDER.either, false);
+        expect(
+          token.isApprovedForAll(OWNER.either, SPENDER.either),
+        ).toBe(false);
 
-        token._setApprovalForAll(Z_OWNER, Z_SPENDER, true);
-        expect(token.isApprovedForAll(Z_OWNER, Z_SPENDER)).toBe(true);
+        token._setApprovalForAll(OWNER.either, SPENDER.either, true);
+        expect(
+          token.isApprovedForAll(OWNER.either, SPENDER.either),
+        ).toBe(true);
+      });
+
+      it('should canonicalize owner and operator', () => {
+        const nonCanonicalOwner = nonCanonicalLeft(OWNER.accountId);
+        const nonCanonicalOp = nonCanonicalLeft(SPENDER.accountId);
+
+        token._setApprovalForAll(nonCanonicalOwner, nonCanonicalOp, true);
+        expect(
+          token.isApprovedForAll(OWNER.either, SPENDER.either),
+        ).toBe(true);
+      });
+    });
+
+    describe('ZERO', () => {
+      it('should return a left variant', () => {
+        const zero = token.ZERO();
+        expect(zero.is_left).toBe(true);
+      });
+
+      it('should have zero left branch', () => {
+        const zero = token.ZERO();
+        expect(zero.left).toEqual(zeroBytes);
+      });
+
+      it('should have zero right branch', () => {
+        const zero = token.ZERO();
+        expect(zero.right).toEqual({ bytes: zeroBytes });
+      });
+
+      it('should be canonical', () => {
+        const zero = token.ZERO();
+        expect(zero).toEqual(ZERO_ACCOUNT);
+      });
+
+      it('should not equal a right-variant zero', () => {
+        const zero = token.ZERO();
+        expect(zero).not.toEqual(ZERO_CONTRACT);
       });
     });
   });

--- a/contracts/src/token/test/MultiToken.test.ts
+++ b/contracts/src/token/test/MultiToken.test.ts
@@ -1167,7 +1167,7 @@ describe('MultiToken', () => {
         }).toThrow('MultiToken: arithmetic overflow');
       });
 
-      it('should fail when minting to zero address (id))', () => {
+      it('should fail when minting to zero address (id)', () => {
         expect(() => {
           token._mint(ZERO_ACCOUNT, TOKEN_ID, AMOUNT);
         }).toThrow('MultiToken: invalid receiver');

--- a/contracts/src/token/test/mocks/MockMultiToken.compact
+++ b/contracts/src/token/test/mocks/MockMultiToken.compact
@@ -10,7 +10,7 @@ pragma language_version >= 0.21.0;
 import CompactStandardLibrary;
 import "../../MultiToken" prefix MultiToken_;
 
-export { ZswapCoinPublicKey, ContractAddress, Either, Maybe };
+export { ContractAddress, Either, Maybe };
 export { MultiToken__balances, MultiToken__operatorApprovals, MultiToken__uri };
 
 /**
@@ -35,24 +35,24 @@ export circuit uri(id: Uint<128>): Opaque<"string"> {
   return MultiToken_uri(id);
 }
 
-export circuit balanceOf(account: Either<ZswapCoinPublicKey, ContractAddress>, id: Uint<128>): Uint<128> {
+export circuit balanceOf(account: Either<Bytes<32>, ContractAddress>, id: Uint<128>): Uint<128> {
   return MultiToken_balanceOf(account, id);
 }
 
-export circuit setApprovalForAll(operator: Either<ZswapCoinPublicKey, ContractAddress>, approved: Boolean): [] {
+export circuit setApprovalForAll(operator: Either<Bytes<32>, ContractAddress>, approved: Boolean): [] {
   return MultiToken_setApprovalForAll(operator, approved);
 }
 
 export circuit isApprovedForAll(
-  account: Either<ZswapCoinPublicKey, ContractAddress>,
-  operator: Either<ZswapCoinPublicKey, ContractAddress>
+  account: Either<Bytes<32>, ContractAddress>,
+  operator: Either<Bytes<32>, ContractAddress>
 ): Boolean {
   return MultiToken_isApprovedForAll(account, operator);
 }
 
 export circuit transferFrom(
-  fromAddress: Either<ZswapCoinPublicKey, ContractAddress>,
-  to: Either<ZswapCoinPublicKey, ContractAddress>,
+  fromAddress: Either<Bytes<32>, ContractAddress>,
+  to: Either<Bytes<32>, ContractAddress>,
   id: Uint<128>,
   value: Uint<128>
 ): [] {
@@ -60,8 +60,8 @@ export circuit transferFrom(
 }
 
 export circuit _unsafeTransferFrom(
-  fromAddress: Either<ZswapCoinPublicKey, ContractAddress>,
-  to: Either<ZswapCoinPublicKey, ContractAddress>,
+  fromAddress: Either<Bytes<32>, ContractAddress>,
+  to: Either<Bytes<32>, ContractAddress>,
   id: Uint<128>,
   value: Uint<128>
 ): [] {
@@ -69,8 +69,8 @@ export circuit _unsafeTransferFrom(
 }
 
 export circuit _transfer(
-  fromAddress: Either<ZswapCoinPublicKey, ContractAddress>,
-  to: Either<ZswapCoinPublicKey, ContractAddress>,
+  fromAddress: Either<Bytes<32>, ContractAddress>,
+  to: Either<Bytes<32>, ContractAddress>,
   id: Uint<128>,
   value: Uint<128>
 ): [] {
@@ -78,8 +78,8 @@ export circuit _transfer(
 }
 
 export circuit _unsafeTransfer(
-  fromAddress: Either<ZswapCoinPublicKey, ContractAddress>,
-  to: Either<ZswapCoinPublicKey, ContractAddress>,
+  fromAddress: Either<Bytes<32>, ContractAddress>,
+  to: Either<Bytes<32>, ContractAddress>,
   id: Uint<128>,
   value: Uint<128>
 ): [] {
@@ -90,21 +90,21 @@ export circuit _setURI(newURI: Opaque<"string">): [] {
   return MultiToken__setURI(newURI);
 }
 
-export circuit _mint(to: Either<ZswapCoinPublicKey, ContractAddress>, id: Uint<128>, value: Uint<128>): [] {
+export circuit _mint(to: Either<Bytes<32>, ContractAddress>, id: Uint<128>, value: Uint<128>): [] {
   return MultiToken__mint(to, id, value);
 }
 
-export circuit _unsafeMint(to: Either<ZswapCoinPublicKey, ContractAddress>, id: Uint<128>, value: Uint<128>): [] {
+export circuit _unsafeMint(to: Either<Bytes<32>, ContractAddress>, id: Uint<128>, value: Uint<128>): [] {
   return MultiToken__unsafeMint(to, id, value);
 }
 
-export circuit _burn(fromAddress: Either<ZswapCoinPublicKey, ContractAddress>, id: Uint<128>, value: Uint<128>): [] {
+export circuit _burn(fromAddress: Either<Bytes<32>, ContractAddress>, id: Uint<128>, value: Uint<128>): [] {
   return MultiToken__burn(fromAddress, id, value);
 }
 
 export circuit _setApprovalForAll(
-  owner: Either<ZswapCoinPublicKey, ContractAddress>,
-  operator: Either<ZswapCoinPublicKey, ContractAddress>,
+  owner: Either<Bytes<32>, ContractAddress>,
+  operator: Either<Bytes<32>, ContractAddress>,
   approved: Boolean
 ): [] {
   return MultiToken__setApprovalForAll(owner, operator, approved);

--- a/contracts/src/token/test/mocks/MockMultiToken.compact
+++ b/contracts/src/token/test/mocks/MockMultiToken.compact
@@ -27,6 +27,10 @@ constructor(
   }
 }
 
+export pure circuit ZERO(): Either<Bytes<32>, ContractAddress> {
+  return MultiToken_ZERO();
+}
+
 export circuit initialize(_uri: Opaque<"string">): [] {
   return MultiToken_initialize(_uri);
 }
@@ -108,4 +112,8 @@ export circuit _setApprovalForAll(
   approved: Boolean
 ): [] {
   return MultiToken__setApprovalForAll(owner, operator, approved);
+}
+
+export pure circuit computeAccountId(secretKey: Bytes<32>): Bytes<32> {
+  return MultiToken_computeAccountId(secretKey);
 }

--- a/contracts/src/token/test/simulators/MultiTokenSimulator.ts
+++ b/contracts/src/token/test/simulators/MultiTokenSimulator.ts
@@ -8,7 +8,6 @@ import {
   ledger,
   type Maybe,
   Contract as MockMultiToken,
-  type ZswapCoinPublicKey,
 } from '../../../../artifacts/MockMultiToken/contract/index.js';
 import {
   MultiTokenPrivateState,
@@ -29,7 +28,7 @@ const MultiTokenSimulatorBase = createSimulator<
 >({
   contractFactory: (witnesses) =>
     new MockMultiToken<MultiTokenPrivateState>(witnesses),
-  defaultPrivateState: () => MultiTokenPrivateState,
+  defaultPrivateState: () => MultiTokenPrivateState.generate(),
   contractArgs: (_uri) => [_uri],
   ledgerExtractor: (state) => ledger(state),
   witnessesFactory: () => MultiTokenWitnesses(),
@@ -47,6 +46,10 @@ export class MultiTokenSimulator extends MultiTokenSimulatorBase {
     > = {},
   ) {
     super([_uri], options);
+  }
+
+  public ZERO(): Either<Uint8Array, ContractAddress> {
+    return this.circuits.pure.ZERO();
   }
 
   /**
@@ -74,7 +77,7 @@ export class MultiTokenSimulator extends MultiTokenSimulatorBase {
    * @returns The quantity of `id` tokens that `account` owns.
    */
   public balanceOf(
-    account: Either<ZswapCoinPublicKey, ContractAddress>,
+    account: Either<Uint8Array, ContractAddress>,
     id: bigint,
   ): bigint {
     return this.circuits.impure.balanceOf(account, id);
@@ -82,12 +85,12 @@ export class MultiTokenSimulator extends MultiTokenSimulatorBase {
 
   /**
    * @description Enables or disables approval for `operator` to manage all of the caller's assets.
-   * @param operator The ZswapCoinPublicKey or ContractAddress whose approval is set for the caller's assets.
+   * @param operator The Uint8Array or ContractAddress whose approval is set for the caller's assets.
    * @param approved The boolean value determining if the operator may or may not handle the
    * caller's assets.
    */
   public setApprovalForAll(
-    operator: Either<ZswapCoinPublicKey, ContractAddress>,
+    operator: Either<Uint8Array, ContractAddress>,
     approved: boolean,
   ) {
     this.circuits.impure.setApprovalForAll(operator, approved);
@@ -100,8 +103,8 @@ export class MultiTokenSimulator extends MultiTokenSimulatorBase {
    * @returns Whether or not `operator` has permission to handle `account`'s assets.
    */
   public isApprovedForAll(
-    account: Either<ZswapCoinPublicKey, ContractAddress>,
-    operator: Either<ZswapCoinPublicKey, ContractAddress>,
+    account: Either<Uint8Array, ContractAddress>,
+    operator: Either<Uint8Array, ContractAddress>,
   ): boolean {
     return this.circuits.impure.isApprovedForAll(account, operator);
   }
@@ -115,8 +118,8 @@ export class MultiTokenSimulator extends MultiTokenSimulatorBase {
    * @param value The quantity of `id` tokens to transfer.
    */
   public transferFrom(
-    fromAddress: Either<ZswapCoinPublicKey, ContractAddress>,
-    to: Either<ZswapCoinPublicKey, ContractAddress>,
+    fromAddress: Either<Uint8Array, ContractAddress>,
+    to: Either<Uint8Array, ContractAddress>,
     id: bigint,
     value: bigint,
   ) {
@@ -132,8 +135,8 @@ export class MultiTokenSimulator extends MultiTokenSimulatorBase {
    * @param value The quantity of `id` tokens to transfer.
    */
   public _unsafeTransferFrom(
-    fromAddress: Either<ZswapCoinPublicKey, ContractAddress>,
-    to: Either<ZswapCoinPublicKey, ContractAddress>,
+    fromAddress: Either<Uint8Array, ContractAddress>,
+    to: Either<Uint8Array, ContractAddress>,
     id: bigint,
     value: bigint,
   ) {
@@ -150,8 +153,8 @@ export class MultiTokenSimulator extends MultiTokenSimulatorBase {
    * @param value The quantity of `id` tokens to transfer.
    */
   public _transfer(
-    fromAddress: Either<ZswapCoinPublicKey, ContractAddress>,
-    to: Either<ZswapCoinPublicKey, ContractAddress>,
+    fromAddress: Either<Uint8Array, ContractAddress>,
+    to: Either<Uint8Array, ContractAddress>,
     id: bigint,
     value: bigint,
   ) {
@@ -168,8 +171,8 @@ export class MultiTokenSimulator extends MultiTokenSimulatorBase {
    * @param value The quantity of `id` tokens to transfer.
    */
   public _unsafeTransfer(
-    fromAddress: Either<ZswapCoinPublicKey, ContractAddress>,
-    to: Either<ZswapCoinPublicKey, ContractAddress>,
+    fromAddress: Either<Uint8Array, ContractAddress>,
+    to: Either<Uint8Array, ContractAddress>,
     id: bigint,
     value: bigint,
   ) {
@@ -191,7 +194,7 @@ export class MultiTokenSimulator extends MultiTokenSimulatorBase {
    * @param value The quantity of `id` tokens that are minted to `to`.
    */
   public _mint(
-    to: Either<ZswapCoinPublicKey, ContractAddress>,
+    to: Either<Uint8Array, ContractAddress>,
     id: bigint,
     value: bigint,
   ) {
@@ -205,7 +208,7 @@ export class MultiTokenSimulator extends MultiTokenSimulatorBase {
    * @param value The quantity of `id` tokens that are minted to `to`.
    */
   public _unsafeMint(
-    to: Either<ZswapCoinPublicKey, ContractAddress>,
+    to: Either<Uint8Array, ContractAddress>,
     id: bigint,
     value: bigint,
   ) {
@@ -219,7 +222,7 @@ export class MultiTokenSimulator extends MultiTokenSimulatorBase {
    * @param value The quantity of `id` tokens that will be destroyed from `fromAddress`
    */
   public _burn(
-    fromAddress: Either<ZswapCoinPublicKey, ContractAddress>,
+    fromAddress: Either<Uint8Array, ContractAddress>,
     id: bigint,
     value: bigint,
   ) {
@@ -228,17 +231,55 @@ export class MultiTokenSimulator extends MultiTokenSimulatorBase {
 
   /**
    * @description Enables or disables approval for `operator` to manage all of the caller's assets.
-   * @param owner The ZswapCoinPublicKey or ContractAddress of the target owner.
-   * @param operator The ZswapCoinPublicKey or ContractAddress whose approval is set for the
+   * @param owner The Uint8Array or ContractAddress of the target owner.
+   * @param operator The Uint8Array or ContractAddress whose approval is set for the
    * `owner`'s assets.
    * @param approved The boolean value determining if the operator may or may not handle the
    * `owner`'s assets.
    */
   public _setApprovalForAll(
-    owner: Either<ZswapCoinPublicKey, ContractAddress>,
-    operator: Either<ZswapCoinPublicKey, ContractAddress>,
+    owner: Either<Uint8Array, ContractAddress>,
+    operator: Either<Uint8Array, ContractAddress>,
     approved: boolean,
   ) {
     this.circuits.impure._setApprovalForAll(owner, operator, approved);
   }
+
+  /**
+   * @description Computes an account identifier without on-chain state, allowing a user to derive
+   * their identity commitment before submitting it in a grant or revoke operation.
+   * @param {Bytes<32>} secretKey - A 32-byte cryptographically secure random value.
+   * @returns {Bytes<32>} accountId - The computed account identifier.
+   */
+  public computeAccountId(secretKey: Uint8Array): Uint8Array {
+    return this.circuits.pure.computeAccountId(secretKey);
+  }
+
+  public readonly privateState = {
+    /**
+     * @description Replaces the secret key in the private state. Used in tests to
+     * simulate switching between different user identities or injecting incorrect
+     * keys to test failure paths.
+     * @param newSK - The new secret key to set.
+     * @returns The updated private state.
+     */
+    injectSecretKey: (newSK: Uint8Array): MultiTokenPrivateState => {
+      const updatedState = MultiTokenPrivateState.withSecretKey(newSK);
+      this.circuitContextManager.updatePrivateState(updatedState);
+      return updatedState;
+    },
+
+    /**
+     * @description Returns the current secret key from the private state.
+     * @returns The secret key.
+     * @throws If the secret key is undefined.
+     */
+    getCurrentSecretKey: (): Uint8Array => {
+      const sk = this.getPrivateState().secretKey;
+      if (typeof sk === 'undefined') {
+        throw new Error('Missing secret key');
+      }
+      return Uint8Array.from(sk);
+    },
+  };
 }

--- a/contracts/src/token/witnesses/MultiTokenWitnesses.ts
+++ b/contracts/src/token/witnesses/MultiTokenWitnesses.ts
@@ -1,6 +1,80 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Compact Contracts v0.0.1-alpha.1 (token/witnesses/MultiTokenWitnesses.ts)
 
-export type MultiTokenPrivateState = Record<string, never>;
-export const MultiTokenPrivateState: MultiTokenPrivateState = {};
-export const MultiTokenWitnesses = () => ({});
+import { getRandomValues } from 'node:crypto';
+import type { WitnessContext } from '@midnight-ntwrk/compact-runtime';
+
+/**
+ * @description Interface defining the witness methods for MultiToken operations.
+ * @template P - The private state type.
+ */
+export interface IMultiTokenWitnesses<L, P> {
+  /**
+   * Retrieves the secret key from the private state.
+   * @param context - The witness context containing the private state.
+   * @returns A tuple of the private state and the secret key as a Uint8Array.
+   */
+  wit_MultiTokenSK(context: WitnessContext<L, P>): [P, Uint8Array];
+}
+
+/**
+ * @description Represents the private state of an MultiToken contract, storing a secret key.
+ */
+export type MultiTokenPrivateState = {
+  /** @description A 32-byte secret key used for creating a public user identifier. */
+  secretKey: Uint8Array;
+};
+
+/**
+ * @description Utility object for managing the private state of an MultiToken contract.
+ */
+export const MultiTokenPrivateState = {
+  /**
+   * @description Generates a new private state with a random secret key.
+   * @returns A fresh MultiTokenPrivateState instance.
+   */
+  generate: (): MultiTokenPrivateState => {
+    return { secretKey: getRandomValues(new Uint8Array(32)) };
+  },
+
+  /**
+   * @description Generates a new private state with a user-defined secret key.
+   * Useful for deterministic key generation or advanced use cases.
+   *
+   * @param sk - The 32-byte secret key to use.
+   * @returns A fresh MultiTokenPrivateState instance with the provided key.
+   *
+   * @example
+   * ```typescript
+   * // For deterministic keys (user-defined scheme)
+   * const deterministicKey = myDeterministicScheme(...);
+   * const privateState = MultiTokenPrivateState.withSecretKey(deterministicKey);
+   * ```
+   */
+  withSecretKey: (sk: Uint8Array): MultiTokenPrivateState => {
+    if (sk.length !== 32) {
+      throw new Error(
+        `withSecretKey: expected 32-byte secret key, received ${sk.length} bytes`,
+      );
+    }
+    return { secretKey: Uint8Array.from(sk) };
+  },
+};
+
+/**
+ * @description Factory function creating witness implementations for MultiToken operations.
+ * @returns An object implementing the Witnesses interface for MultiTokenPrivateState.
+ */
+export const MultiTokenWitnesses = <L>(): IMultiTokenWitnesses<
+  L,
+  MultiTokenPrivateState
+> => ({
+  wit_MultiTokenSK(
+    context: WitnessContext<L, MultiTokenPrivateState>,
+  ): [MultiTokenPrivateState, Uint8Array] {
+    return [
+      context.privateState,
+      Uint8Array.from(context.privateState.secretKey),
+    ];
+  },
+});

--- a/contracts/src/token/witnesses/test/MultiTokenWitnesses.test.ts
+++ b/contracts/src/token/witnesses/test/MultiTokenWitnesses.test.ts
@@ -1,0 +1,142 @@
+import type { WitnessContext } from '@midnight-ntwrk/compact-runtime';
+import { describe, expect, it } from 'vitest';
+import type { Ledger } from '../../../../artifacts/MockMultiToken/contract/index.js';
+import {
+  MultiTokenPrivateState,
+  MultiTokenWitnesses,
+} from '../MultiTokenWitnesses.js';
+
+const SECRET_KEY = new Uint8Array(32).fill(0x34);
+
+describe('MultiTokenPrivateState', () => {
+  describe('generate', () => {
+    it('should return a state with a 32-byte secretKey', () => {
+      const state = MultiTokenPrivateState.generate();
+      expect(state.secretKey).toBeInstanceOf(Uint8Array);
+      expect(state.secretKey.length).toBe(32);
+    });
+
+    it('should produce unique secret key on successive calls', () => {
+      const a = MultiTokenPrivateState.generate();
+      const b = MultiTokenPrivateState.generate();
+      expect(a.secretKey).not.toEqual(b.secretKey);
+    });
+  });
+
+  describe('withSecretKey', () => {
+    it('should accept a valid 32-byte secret key', () => {
+      const state = MultiTokenPrivateState.withSecretKey(SECRET_KEY);
+      expect(state.secretKey).toEqual(SECRET_KEY);
+    });
+
+    it('should create a defensive copy of the input secret key', () => {
+      const sk = new Uint8Array(32).fill(0xcc);
+      const state = MultiTokenPrivateState.withSecretKey(sk);
+
+      sk.fill(0xff);
+      expect(state.secretKey).toEqual(new Uint8Array(32).fill(0xcc));
+    });
+
+    it('should throw for a secret key shorter than 32 bytes', () => {
+      const short = new Uint8Array(16);
+      expect(() =>
+        MultiTokenPrivateState.withSecretKey(short),
+      ).toThrowError(
+        'withSecretKey: expected 32-byte secret key, received 16 bytes',
+      );
+    });
+
+    it('should throw for a secret key longer than 32 bytes', () => {
+      const long = new Uint8Array(64);
+      expect(() =>
+        MultiTokenPrivateState.withSecretKey(long),
+      ).toThrowError(
+        'withSecretKey: expected 32-byte secret key, received 64 bytes',
+      );
+    });
+
+    it('should throw for an empty array', () => {
+      expect(() =>
+        MultiTokenPrivateState.withSecretKey(new Uint8Array(0)),
+      ).toThrowError(
+        'withSecretKey: expected 32-byte secret key, received 0 bytes',
+      );
+    });
+  });
+});
+
+describe('MultiTokenWitnesses', () => {
+  const witnesses = MultiTokenWitnesses();
+
+  function makeContext(
+    privateState: MultiTokenPrivateState,
+  ): WitnessContext<Ledger, MultiTokenPrivateState> {
+    return { privateState } as WitnessContext<
+      Ledger,
+      MultiTokenPrivateState
+    >;
+  }
+
+  describe('wit_MultiTokenSK', () => {
+    it('should return a tuple of [privateState, secretKey]', () => {
+      const state = MultiTokenPrivateState.withSecretKey(SECRET_KEY);
+      const ctx = makeContext(state);
+
+      const [returnedState, returnedSK] = witnesses.wit_MultiTokenSK(ctx);
+
+      expect(returnedState).toBe(state);
+      expect(returnedSK).toEqual(SECRET_KEY);
+    });
+
+    it('should return the exact same privateState reference', () => {
+      const state = MultiTokenPrivateState.generate();
+      const ctx = makeContext(state);
+
+      const [returnedState] = witnesses.wit_MultiTokenSK(ctx);
+      expect(returnedState).toBe(state);
+    });
+
+    it('should return the secretKey as a Uint8Array', () => {
+      const state = MultiTokenPrivateState.generate();
+      const ctx = makeContext(state);
+
+      const [, returnedSK] = witnesses.wit_MultiTokenSK(ctx);
+      expect(returnedSK).toBeInstanceOf(Uint8Array);
+      expect(returnedSK.length).toBe(32);
+    });
+
+    it('should work with a randomly generated state', () => {
+      const state = MultiTokenPrivateState.generate();
+      const ctx = makeContext(state);
+
+      const [returnedState, returnedSK] = witnesses.wit_MultiTokenSK(ctx);
+
+      expect(returnedState).toBe(state);
+      expect(returnedSK).toEqual(state.secretKey);
+    });
+  });
+});
+
+describe('MultiTokenWitnesses factory', () => {
+  it('should return a fresh witnesses object on each call', () => {
+    const a = MultiTokenWitnesses();
+    const b = MultiTokenWitnesses();
+    expect(a).not.toBe(b);
+  });
+
+  it('should produce witnesses with identical behaviour', () => {
+    const a = MultiTokenWitnesses();
+    const b = MultiTokenWitnesses();
+    const state = MultiTokenPrivateState.generate();
+    const ctx = { privateState: state } as WitnessContext<
+      Ledger,
+      MultiTokenPrivateState
+    >;
+
+    const [stateA, skA] = a.wit_MultiTokenSK(ctx);
+    const [stateB, skB] = b.wit_MultiTokenSK(ctx);
+
+    expect(stateA).toBe(stateB);
+    expect(skA).toEqual(skB);
+  });
+});

--- a/contracts/src/token/witnesses/test/MultiTokenWitnesses.test.ts
+++ b/contracts/src/token/witnesses/test/MultiTokenWitnesses.test.ts
@@ -39,18 +39,14 @@ describe('MultiTokenPrivateState', () => {
 
     it('should throw for a secret key shorter than 32 bytes', () => {
       const short = new Uint8Array(16);
-      expect(() =>
-        MultiTokenPrivateState.withSecretKey(short),
-      ).toThrowError(
+      expect(() => MultiTokenPrivateState.withSecretKey(short)).toThrowError(
         'withSecretKey: expected 32-byte secret key, received 16 bytes',
       );
     });
 
     it('should throw for a secret key longer than 32 bytes', () => {
       const long = new Uint8Array(64);
-      expect(() =>
-        MultiTokenPrivateState.withSecretKey(long),
-      ).toThrowError(
+      expect(() => MultiTokenPrivateState.withSecretKey(long)).toThrowError(
         'withSecretKey: expected 32-byte secret key, received 64 bytes',
       );
     });
@@ -71,10 +67,7 @@ describe('MultiTokenWitnesses', () => {
   function makeContext(
     privateState: MultiTokenPrivateState,
   ): WitnessContext<Ledger, MultiTokenPrivateState> {
-    return { privateState } as WitnessContext<
-      Ledger,
-      MultiTokenPrivateState
-    >;
+    return { privateState } as WitnessContext<Ledger, MultiTokenPrivateState>;
   }
 
   describe('wit_MultiTokenSK', () => {


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

## Types of changes

What types of changes does your code introduce to OpenZeppelin Midnight Contracts?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

Fixes #455 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the MultiToken contract's account identifier system to use witness-derived identity instead of public key-based authentication.
  * Revised transfer, approval, minting, and burning workflows to use canonicalized account identifiers for consistency.
  * Added new utility functions for account ID computation and canonical zero-account representation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->