### PR TITLE
Remove witnesses from dist

### DIFF
--- a/packages/compact/src/Builder.ts
+++ b/packages/compact/src/Builder.ts
@@ -73,7 +73,14 @@ export class CompactBuilder {
         msg: 'Compiling TypeScript',
       },
 
-      // Step 3: Copy .compact files preserving structure (excludes Mock* files and archive/)
+      // Step 3: Remove witness directories from dist
+      {
+        cmd: 'find dist -type d -name "witnesses" -exec rm -rf {} +',
+        msg: 'Removing witness directories from dist',
+        shell: '/bin/bash',
+      },
+
+      // Step 4: Copy .compact files preserving structure (excludes Mock* files and archive/)
       {
         // biome-ignore-start lint/suspicious/noUselessEscapeInString: Needed inside JS template literal
         cmd: `
@@ -89,7 +96,7 @@ export class CompactBuilder {
         shell: '/bin/bash',
       },
 
-      // Step 4: Copy essential files for distribution
+      // Step 5: Copy essential files for distribution
       {
         cmd: `
         # Copy package.json and README


### PR DESCRIPTION
(if releasing without compact-tools dep)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized the build pipeline to remove unused witness directories after compilation, resulting in cleaner distribution artifacts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenZeppelin/compact-contracts/pull/520?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->