### PR TITLE
ci(release): install Compact compiler before build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,11 @@ jobs:
       - name: Install dependencies
         run: yarn install --immutable
 
+      - name: Setup Compact Compiler
+        uses: midnightntwrk/setup-compact-action@836895c8fffbbea6bd986af2b17e8941ff29d1f8 # v1
+        with:
+          compact-version: "0.29.0"
+
       - name: Build contracts
         run: yarn turbo build
 


### PR DESCRIPTION
## Problem

Publishing the `v0.1.0` release failed at the **Build contracts** step:

```
✖ [BUILD] Unexpected error: 'compact' CLI not found in PATH.
  Please install the Compact developer tools.
```

`release.yml` runs `yarn turbo build`, which needs the `compact` compiler, but it sets up its environment manually (corepack, setup-node, yarn install) and never installs the Compact toolchain. The test workflow avoids this by using the shared `./.github/actions/setup` composite action, which installs Compact via `midnightntwrk/setup-compact-action`. The release job was missing that step, so the publish build could never succeed.

## Fix

Add the `Setup Compact Compiler` step before `Build contracts`, pinned to Compact `0.29.0` to match `.github/actions/setup`.

## Re-publishing v0.1.0 after merge

A `release`-triggered run uses the workflow file at the tag's commit, so re-running the failed run will not pick up this fix. After merge:

1. Delete the `v0.1.0` release and the `v0.1.0` tag.
2. Recreate the release on the updated `main` (now containing this fix) to re-fire the publish workflow.

The version-consistency check still passes: `main` is `0.1.0` and the tag is `v0.1.0`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow to integrate compiler version 0.29.0, improving the build and validation process during releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->