### PR TITLE
fix(build): exclude test files from the package build

### DIFF
--- a/contracts/tsconfig.build.json
+++ b/contracts/tsconfig.build.json
@@ -1,5 +1,5 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["src/test/**/*.ts"],
+  "exclude": ["src/archive/", "src/**/*.test.ts"],
   "compilerOptions": {}
 }


### PR DESCRIPTION
## Problem

Publishing `v0.1.0` failed at **Build contracts** (after the Compact compile succeeded). `tsc --project tsconfig.build.json` errored:

```
TS2307: Cannot find module '../../../../artifacts/MockAccessControl/contract/index.js'
... (6 witness *.test.ts files)
[BUILD] ❌ Build failed: Command failed: tsc --project tsconfig.build.json
```

### Root cause

- `tsconfig.build.json` excluded `src/test/**/*.ts`, but the tests live at `src/<module>/test/witnesses/` — the glob never matched.
- The base `tsconfig.json` include (`src/**/test/witnesses/**/*.ts`) then pulled the sibling `*.test.ts` files into the build.
- Those test files import `artifacts/Mock*`, which the builder intentionally excludes (`--exclude 'Mock*'`). On a clean release runner the mock artifacts don't exist → TS2307.
- It passes locally only because `turbo compact` has already generated the mock artifacts there.
- The build runs **only** in `release.yml` (the test workflow uses `turbo compact/types/test`, never `build`), so this stayed latent until release.

## Fix

`tsconfig.build.json` exclude → `["src/archive/", "src/**/*.test.ts"]`:

- `src/**/*.test.ts` correctly drops all test files from the dist build (keeps the production `*Witnesses.ts` helpers, which import no artifacts).
- Restores `src/archive/` — an `exclude` in an extending config *replaces* the parent's, so the base archive exclusion was being silently lost.

## Verification

Static check: the only files remaining in the build's include set are the production `*Witnesses.ts`; none import `artifacts/` or simulators. Confirmed no transitive mock dependency.

Follow-up worth considering (not in this PR): run `yarn turbo build` in CI on PRs so this build path is exercised before release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to refine which files are excluded from the build process, ensuring test files and archived code are properly handled during compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->