### PR TITLE
ci(test): fix test-suite timeout cancellations

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -15,7 +15,7 @@ runs:
       run: corepack enable
 
     - name: Cache turbo build setup
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: .turbo
         key: ${{ runner.os }}-turbo-${{ github.sha }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
-    timeout-minutes: 15
+    timeout-minutes: 30
 
     steps:
       - name: Harden Runner


### PR DESCRIPTION
## Types of changes

What types of changes does your code introduce to OpenZeppelin Midnight Contracts?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

Fixes #??? <!-- no tracking issue -->

Port of #554 onto `post-release`.

The `Run Test Suite` job is cancelled with "The job has exceeded the maximum execution time of 15m0s" → "The operation was canceled." This reads like a failure but is a timeout. The `turbo compact` step now consumes ~14 of the 15-minute budget compiling ZK circuits (the `multisig/` group alone is ~8 minutes), so the test step never meaningfully runs before the limit hits.

This PR, against `post-release`:
- Raises `timeout-minutes` from 15 to 30 in `test.yml`.
- Pins `actions/cache` from v4.3.0 (Node 20, deprecated on runners from 2026-06-16) to v5.0.5 (Node 24).

## PR Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md#your-first-code-contribution)
- [ ] I have added tests that prove my fix is effective or that my feature works. See [GUIDELINES.md#testing](../GUIDELINES.md#testing) for more information.
- [ ] I have added documentation for new methods or changes to existing method behavior. See [GUIDELINES.md#documentation](../GUIDELINES.md#documentation) for more information.
- [ ] CI Workflows Are Passing

#### Further comments

CI-only change targeting `post-release`. Same two commits as #554 (already merged to `main`).