### PR TITLE
fix(security): track initialization state per module

### DIFF
--- a/contracts/package.json
+++ b/contracts/package.json
@@ -33,6 +33,8 @@
     "build": "compact-builder --hierarchical --out dist --clean-dist --exclude '*/archive/*' --exclude 'Mock*' --exclude '*.mock.compact' --copy package.json --copy ../README.md && find dist -type d -empty -delete",
     "test": "SKIP_ZK=true yarn run compact && vitest run",
     "test:coverage": "SKIP_ZK=true yarn run compact && vitest run --coverage",
+    "compact:integration": "SKIP_ZK=true compact compile test/integration/_mocks/SharedInitCollision.compact artifacts/SharedInitCollision && SKIP_ZK=true compact compile test/integration/_mocks/ComposedTokens.compact artifacts/ComposedTokens",
+    "test:integration": "yarn run compact:integration && vitest run --config vitest.integration.config.ts",
     "types": "tsc -p tsconfig.json --noEmit",
     "clean": "git clean -fXd"
   },

--- a/contracts/src/access/Ownable.compact
+++ b/contracts/src/access/Ownable.compact
@@ -85,8 +85,14 @@ pragma language_version >= 0.21.0;
  */
 module Ownable {
   import CompactStandardLibrary;
-  import "../security/Initializable" prefix Initializable_;
   import "../utils/Utils" prefix Utils_;
+
+  /**
+   * @description Initialization flag, tracked per-module to avoid the compiler's
+   * shared transitive-dependency state bug (LFDT-Minokawa/compact#270). See the
+   * Initializable module for rationale.
+   */
+  export ledger _isInitialized: Boolean;
 
   export ledger _owner: Either<Bytes<32>, ContractAddress>;
 
@@ -117,9 +123,36 @@ module Ownable {
    * @returns {[]} Empty tuple.
    */
   export circuit initialize(initialOwner: Either<Bytes<32>, ContractAddress>): [] {
-    Initializable_initialize();
+    assertNotInitialized();
+    _isInitialized = true;
     assert(!_isTargetZero(initialOwner), "Ownable: invalid initial owner");
     _transferOwnership(initialOwner);
+  }
+
+  /**
+   * @description Asserts that the contract has been initialized, throwing an error if not.
+   *
+   * Requirements:
+   *
+   * - Contract must be initialized.
+   *
+   * @return {[]} - Empty tuple.
+   */
+  circuit assertInitialized(): [] {
+    assert(_isInitialized, "Ownable: contract not initialized");
+  }
+
+  /**
+   * @description Asserts that the contract has not been initialized, throwing an error if it has.
+   *
+   * Requirements:
+   *
+   * - Contract must not be initialized.
+   *
+   * @return {[]} - Empty tuple.
+   */
+  circuit assertNotInitialized(): [] {
+    assert(!_isInitialized, "Ownable: contract already initialized");
   }
 
   /**
@@ -134,7 +167,7 @@ module Ownable {
    * @returns {Either<Bytes<32>, ContractAddress>} - The contract owner.
    */
   export circuit owner(): Either<Bytes<32>, ContractAddress> {
-    Initializable_assertInitialized();
+    assertInitialized();
     return _owner;
   }
 
@@ -158,7 +191,7 @@ module Ownable {
    * @returns {[]} Empty tuple.
    */
   export circuit transferOwnership(newOwner: Either<Bytes<32>, ContractAddress>): [] {
-    Initializable_assertInitialized();
+    assertInitialized();
     const isContractAddr = !newOwner.is_left;
     assert(!isContractAddr, "Ownable: unsafe ownership transfer");
     _unsafeTransferOwnership(newOwner);
@@ -184,7 +217,7 @@ module Ownable {
    * @returns {[]} Empty tuple.
    */
   export circuit _unsafeTransferOwnership(newOwner: Either<Bytes<32>, ContractAddress>): [] {
-    Initializable_assertInitialized();
+    assertInitialized();
     assertOnlyOwner();
     assert(!_isTargetZero(newOwner), "Ownable: invalid new owner");
     _unsafeUncheckedTransferOwnership(newOwner);
@@ -205,7 +238,7 @@ module Ownable {
    * @returns {[]} Empty tuple.
    */
   export circuit renounceOwnership(): [] {
-    Initializable_assertInitialized();
+    assertInitialized();
     assertOnlyOwner();
 
     // We use `left` here because `assertOnlyOwner` would return a misleading
@@ -233,7 +266,7 @@ module Ownable {
    * @returns {[]} Empty tuple.
    */
   export circuit assertOnlyOwner(): [] {
-    Initializable_assertInitialized();
+    assertInitialized();
     if (_owner.is_left) {
       assert(_computeAccountId() == _owner.left, "Ownable: caller is not the owner");
     } else {
@@ -260,7 +293,7 @@ module Ownable {
    * @returns {[]} Empty tuple.
    */
   export circuit _transferOwnership(newOwner: Either<Bytes<32>, ContractAddress>): [] {
-    Initializable_assertInitialized();
+    assertInitialized();
     const isContractAddr = !newOwner.is_left;
     assert(!isContractAddr, "Ownable: unsafe ownership transfer");
     _unsafeUncheckedTransferOwnership(newOwner);
@@ -286,7 +319,7 @@ module Ownable {
   export circuit _unsafeUncheckedTransferOwnership(
                    newOwner: Either<Bytes<32>, ContractAddress>
                    ): [] {
-    Initializable_assertInitialized();
+    assertInitialized();
     const canonAcct = Utils_canonicalize<Bytes<32>, ContractAddress>(newOwner);
     _owner = disclose(canonAcct);
   }

--- a/contracts/src/access/ShieldedAccessControl.compact
+++ b/contracts/src/access/ShieldedAccessControl.compact
@@ -168,7 +168,6 @@ pragma language_version >= 0.21.0;
 module ShieldedAccessControl {
   import CompactStandardLibrary;
   import "../utils/Utils" prefix Utils_;
-  import "../security/Initializable" prefix Initializable_;
 
   export enum UpdateType {
     Grant,
@@ -180,6 +179,13 @@ module ShieldedAccessControl {
   export new type RoleIdentifier = Bytes<32>;
   export new type AccountIdentifier = Bytes<32>;
   export new type RoleNullifier = Bytes<32>;
+
+  /**
+   * @description Initialization flag, tracked per-module to avoid the compiler's
+   * shared transitive-dependency state bug (LFDT-Minokawa/compact#270). See the
+   * Initializable module for rationale.
+   */
+  export ledger _isInitialized: Boolean;
 
   /**
    * @ledger _operatorRoles
@@ -259,9 +265,36 @@ module ShieldedAccessControl {
    */
   export circuit initialize(instanceSalt: Bytes<32>): [] {
     assert(instanceSalt != default<Bytes<32>>, "ShieldedAccessControl: Instance salt must not be 0");
-    Initializable_initialize();
+    assertNotInitialized();
+    _isInitialized = true;
 
     _instanceSalt = disclose(instanceSalt);
+  }
+
+  /**
+   * @description Asserts that the contract has been initialized, throwing an error if not.
+   *
+   * Requirements:
+   *
+   * - Contract must be initialized.
+   *
+   * @return {[]} - Empty tuple.
+   */
+  circuit assertInitialized(): [] {
+    assert(_isInitialized, "ShieldedAccessControl: contract not initialized");
+  }
+
+  /**
+   * @description Asserts that the contract has not been initialized, throwing an error if it has.
+   *
+   * Requirements:
+   *
+   * - Contract must not be initialized.
+   *
+   * @return {[]} - Empty tuple.
+   */
+  circuit assertNotInitialized(): [] {
+    assert(!_isInitialized, "ShieldedAccessControl: contract already initialized");
   }
 
   /**
@@ -295,7 +328,7 @@ module ShieldedAccessControl {
    * @return {[]} - Empty tuple.
    */
   export circuit assertOnlyRole(role: RoleIdentifier): [] {
-    Initializable_assertInitialized();
+    assertInitialized();
     assert(_uncheckedCanProveRole(role), "ShieldedAccessControl: unauthorized account");
   }
 
@@ -320,7 +353,7 @@ module ShieldedAccessControl {
    * @return {Boolean} - A boolean determining if a caller successfully proved ownership of `role`
    */
   export circuit canProveRole(role: RoleIdentifier): Boolean {
-    Initializable_assertInitialized();
+    assertInitialized();
     return _uncheckedCanProveRole(role);
   }
 
@@ -417,7 +450,7 @@ module ShieldedAccessControl {
    * @return {[]} - Empty tuple.
    */
   export circuit _grantRole(role: RoleIdentifier, accountId: AccountIdentifier): [] {
-    Initializable_assertInitialized();
+    assertInitialized();
     _updateRole(role, accountId, UpdateType.Grant);
   }
 
@@ -449,7 +482,7 @@ module ShieldedAccessControl {
    * @return {[]} - Empty tuple.
    */
   export circuit renounceRole(role: RoleIdentifier, accountIdConfirmation: AccountIdentifier): [] {
-    Initializable_assertInitialized();
+    assertInitialized();
 
     assert(accountIdConfirmation == _computeAccountId(),
            "ShieldedAccessControl: bad confirmation"
@@ -515,7 +548,7 @@ module ShieldedAccessControl {
    * @return {[]} - Empty tuple.
    */
   export circuit _revokeRole(role: RoleIdentifier, accountId: AccountIdentifier): [] {
-    Initializable_assertInitialized();
+    assertInitialized();
     _updateRole(role, accountId, UpdateType.Revoke);
   }
 
@@ -599,7 +632,7 @@ module ShieldedAccessControl {
    * @return {[]} - Empty tuple.
    */
   export circuit _setRoleAdmin(role: RoleIdentifier, adminId: RoleIdentifier): [] {
-    Initializable_assertInitialized();
+    assertInitialized();
     _adminRoles.insert(disclose(role), disclose(adminId));
   }
 

--- a/contracts/src/access/ZOwnablePK.compact
+++ b/contracts/src/access/ZOwnablePK.compact
@@ -47,6 +47,13 @@ module ZOwnablePK {
   import CompactStandardLibrary;
 
   /**
+   * @description Initialization flag, tracked per-module to avoid the compiler's
+   * shared transitive-dependency state bug (LFDT-Minokawa/compact#270). See the
+   * Initializable module for rationale.
+   */
+  export ledger _isInitialized: Boolean;
+
+  /**
    * @ledger _ownerCommitment
    * @description Stores the current hashed commitment representing the owner.
    * This commitment is derived from the public identifier (e.g., `SHA256(pk, nonce)`),
@@ -54,14 +61,8 @@ module ZOwnablePK {
    *
    * A commitment of `default<Bytes<32>>` (i.e., zero) indicates the contract is unowned.
    */
-  /**
-   * @description Initialization flag, tracked per-module to avoid the compiler's
-   * shared transitive-dependency state bug (LFDT-Minokawa/compact#270). See the
-   * Initializable module for rationale.
-   */
-  export ledger _isInitialized: Boolean;
-
   export ledger _ownerCommitment: Bytes<32>;
+
   /**
    * @ledger _counter
    * @description Internal transfer counter used to prevent commitment reuse.
@@ -70,6 +71,7 @@ module ZOwnablePK {
    * `instanceSalt` to compute unique owner commitments over time.
    */
   export ledger _counter: Counter;
+
   /**
    * @sealed @ledger _instanceSalt
    * @description A per-instance value provided at initialization used to namespace

--- a/contracts/src/access/ZOwnablePK.compact
+++ b/contracts/src/access/ZOwnablePK.compact
@@ -45,7 +45,6 @@ pragma language_version >= 0.21.0;
  */
 module ZOwnablePK {
   import CompactStandardLibrary;
-  import "../security/Initializable" prefix Initializable_;
 
   /**
    * @ledger _ownerCommitment
@@ -55,6 +54,13 @@ module ZOwnablePK {
    *
    * A commitment of `default<Bytes<32>>` (i.e., zero) indicates the contract is unowned.
    */
+  /**
+   * @description Initialization flag, tracked per-module to avoid the compiler's
+   * shared transitive-dependency state bug (LFDT-Minokawa/compact#270). See the
+   * Initializable module for rationale.
+   */
+  export ledger _isInitialized: Boolean;
+
   export ledger _ownerCommitment: Bytes<32>;
   /**
    * @ledger _counter
@@ -104,11 +110,38 @@ module ZOwnablePK {
    * @returns {[]} Empty tuple.
    */
   export circuit initialize(ownerId: Bytes<32>, instanceSalt: Bytes<32>): [] {
-    Initializable_initialize();
+    assertNotInitialized();
+    _isInitialized = true;
 
     assert(ownerId != default<Bytes<32>>, "ZOwnablePK: invalid id");
     _instanceSalt = disclose(instanceSalt);
     _transferOwnership(ownerId);
+  }
+
+  /**
+   * @description Asserts that the contract has been initialized, throwing an error if not.
+   *
+   * Requirements:
+   *
+   * - Contract must be initialized.
+   *
+   * @return {[]} - Empty tuple.
+   */
+  circuit assertInitialized(): [] {
+    assert(_isInitialized, "ZOwnablePK: contract not initialized");
+  }
+
+  /**
+   * @description Asserts that the contract has not been initialized, throwing an error if it has.
+   *
+   * Requirements:
+   *
+   * - Contract must not be initialized.
+   *
+   * @return {[]} - Empty tuple.
+   */
+  circuit assertNotInitialized(): [] {
+    assert(!_isInitialized, "ZOwnablePK: contract already initialized");
   }
 
   /**
@@ -124,7 +157,7 @@ module ZOwnablePK {
    * @returns {Bytes<32>} The current owner's commitment.
    */
   export circuit owner(): Bytes<32> {
-    Initializable_assertInitialized();
+    assertInitialized();
     return _ownerCommitment;
   }
 
@@ -144,7 +177,7 @@ module ZOwnablePK {
    * @returns {[]} Empty tuple.
    */
   export circuit transferOwnership(newOwnerId: Bytes<32>): [] {
-    Initializable_assertInitialized();
+    assertInitialized();
 
     assertOnlyOwner();
     assert(newOwnerId != default<Bytes<32>>, "ZOwnablePK: invalid id");
@@ -166,7 +199,7 @@ module ZOwnablePK {
    * @returns {[]} Empty tuple.
    */
   export circuit renounceOwnership(): [] {
-    Initializable_assertInitialized();
+    assertInitialized();
 
     assertOnlyOwner();
     _ownerCommitment.resetToDefault();
@@ -188,7 +221,7 @@ module ZOwnablePK {
    * @returns {[]} Empty tuple.
    */
   export circuit assertOnlyOwner(): [] {
-    Initializable_assertInitialized();
+    assertInitialized();
 
     const nonce = wit_secretNonce();
     const callerAsEither =
@@ -234,7 +267,7 @@ module ZOwnablePK {
    * @returns {Bytes<32>} The commitment derived from `id` and `counter`.
    */
   export circuit _computeOwnerCommitment(id: Bytes<32>, counter: Uint<64>,): Bytes<32> {
-    Initializable_assertInitialized();
+    assertInitialized();
     return persistentHash<Vector<4, Bytes<32>>>(
              [id, _instanceSalt, counter as Field as Bytes<32>, pad(32, "ZOwnablePK:shield:")]
              );
@@ -296,7 +329,7 @@ module ZOwnablePK {
    * @returns {[]} Empty tuple.
    */
   export circuit _transferOwnership(newOwnerId: Bytes<32>): [] {
-    Initializable_assertInitialized();
+    assertInitialized();
 
     _counter.increment(1);
     _ownerCommitment = disclose(_computeOwnerCommitment(newOwnerId, _counter));

--- a/contracts/src/access/test/Ownable.test.ts
+++ b/contracts/src/access/test/Ownable.test.ts
@@ -118,7 +118,7 @@ describe('Ownable', () => {
       });
       expect(() => {
         (ownable[circuitName] as (...args: unknown[]) => unknown)(...args);
-      }).toThrow('Initializable: contract not initialized');
+      }).toThrow('Ownable: contract not initialized');
     });
 
     it('should canonicalize initial owner', () => {

--- a/contracts/src/access/test/ShieldedAccessControl.test.ts
+++ b/contracts/src/access/test/ShieldedAccessControl.test.ts
@@ -126,18 +126,18 @@ describe('ShieldedAccessControl', () => {
             ...a: unknown[]
           ) => unknown
         )(...args);
-      }).toThrow('Initializable: contract not initialized');
+      }).toThrow('ShieldedAccessControl: contract not initialized');
     });
 
     it('_grantRole should independently check initialization', () => {
       expect(() => contract._grantRole(ROLE_OP1, OP1_ACCOUNT_ID)).toThrow(
-        'Initializable: contract not initialized',
+        'ShieldedAccessControl: contract not initialized',
       );
     });
 
     it('_revokeRole should independently check initialization', () => {
       expect(() => contract._revokeRole(ROLE_OP1, OP1_ACCOUNT_ID)).toThrow(
-        'Initializable: contract not initialized',
+        'ShieldedAccessControl: contract not initialized',
       );
     });
 

--- a/contracts/src/access/test/ZOwnablePK.test.ts
+++ b/contracts/src/access/test/ZOwnablePK.test.ts
@@ -124,7 +124,7 @@ describe('ZOwnablePK', () => {
     it.each(circuitsToFail)('%s should fail', (circuitName, args) => {
       expect(() => {
         (ownable[circuitName] as (...args: unknown[]) => unknown)(...args);
-      }).toThrow('Initializable: contract not initialized');
+      }).toThrow('ZOwnablePK: contract not initialized');
     });
 
     it('should allow pure computeOwnerId', () => {

--- a/contracts/src/security/Initializable.compact
+++ b/contracts/src/security/Initializable.compact
@@ -6,6 +6,24 @@ pragma language_version >= 0.21.0;
 /**
  * @module Initializable
  * @description Initializable provides a simple mechanism that mimics the functionality of a constructor.
+ *
+ * @notice ⚠️ TECHNICAL WARNING — DO NOT import this module into other OpenZeppelin
+ * modules, and avoid importing it into more than one module of a single contract.
+ *
+ * The Compact compiler deduplicates a shared transitive dependency's ledger state
+ * inconsistently depending on directory layout
+ * (https://github.com/LFDT-Minokawa/compact/issues/270, reproduced on compiler
+ * 0.29.0–0.31.0). When two modules in the SAME directory both import this module,
+ * their `_isInitialized` flags collapse into a SINGLE shared ledger slot: calling
+ * `initialize()` on one marks the other as initialized, and the other can never be
+ * initialized independently. Modules in different directories get separate slots.
+ * The result is unpredictable and a security hazard for composed contracts.
+ *
+ * For this reason the OpenZeppelin modules no longer use this module: each tracks
+ * its own `_isInitialized` ledger flag inline. This module is kept for direct,
+ * single-import use and can be reintroduced across modules once #270 is resolved
+ * (note: CMA upgrades cannot add/remove ledger variables, so already-deployed
+ * contracts cannot migrate their initialization layout).
  */
 module Initializable {
   import CompactStandardLibrary;

--- a/contracts/src/security/Initializable.compact
+++ b/contracts/src/security/Initializable.compact
@@ -7,8 +7,8 @@ pragma language_version >= 0.21.0;
  * @module Initializable
  * @description Initializable provides a simple mechanism that mimics the functionality of a constructor.
  *
- * @notice ⚠️ TECHNICAL WARNING — DO NOT import this module into other OpenZeppelin
- * modules, and avoid importing it into more than one module of a single contract.
+ * @notice ⚠️ TECHNICAL WARNING: only use this module at the top contract layer, and
+ * import it into at most one module per contract.
  *
  * The Compact compiler deduplicates a shared transitive dependency's ledger state
  * inconsistently depending on directory layout
@@ -21,9 +21,7 @@ pragma language_version >= 0.21.0;
  *
  * For this reason the OpenZeppelin modules no longer use this module: each tracks
  * its own `_isInitialized` ledger flag inline. This module is kept for direct,
- * single-import use and can be reintroduced across modules once #270 is resolved
- * (note: CMA upgrades cannot add/remove ledger variables, so already-deployed
- * contracts cannot migrate their initialization layout).
+ * single-import use and can be reintroduced across modules once #270 is resolved.
  */
 module Initializable {
   import CompactStandardLibrary;

--- a/contracts/src/token/FungibleToken.compact
+++ b/contracts/src/token/FungibleToken.compact
@@ -67,20 +67,21 @@ module FungibleToken {
   import "../utils/Utils" prefix Utils_;
 
   /**
-   * @description Mapping from account addresses to their token balances.
-   * @type {Either<Bytes<32>, ContractAddress>} account - The account address.
-   * @type {Uint<128>} balance - The balance of the account.
-   * @type {Map<account, balance>}
-   * @type {Map<Either<Bytes<32>, ContractAddress>, Uint<128>>} _balances
-   */
-  /**
    * @description Initialization flag, tracked per-module to avoid the compiler's
    * shared transitive-dependency state bug (LFDT-Minokawa/compact#270). See the
    * Initializable module for rationale.
    */
   export ledger _isInitialized: Boolean;
 
+  /**
+   * @description Mapping from account addresses to their token balances.
+   * @type {Either<Bytes<32>, ContractAddress>} account - The account address.
+   * @type {Uint<128>} balance - The balance of the account.
+   * @type {Map<account, balance>}
+   * @type {Map<Either<Bytes<32>, ContractAddress>, Uint<128>>} _balances
+   */
   export ledger _balances: Map<Either<Bytes<32>, ContractAddress>, Uint<128>>;
+
   /**
    * @description Mapping from owner accounts to spender accounts and their allowances.
    * @type {Either<Bytes<32>, ContractAddress>} account - The owner account address.

--- a/contracts/src/token/FungibleToken.compact
+++ b/contracts/src/token/FungibleToken.compact
@@ -64,7 +64,6 @@ pragma language_version >= 0.21.0;
  */
 module FungibleToken {
   import CompactStandardLibrary;
-  import "../security/Initializable" prefix Initializable_;
   import "../utils/Utils" prefix Utils_;
 
   /**
@@ -74,6 +73,13 @@ module FungibleToken {
    * @type {Map<account, balance>}
    * @type {Map<Either<Bytes<32>, ContractAddress>, Uint<128>>} _balances
    */
+  /**
+   * @description Initialization flag, tracked per-module to avoid the compiler's
+   * shared transitive-dependency state bug (LFDT-Minokawa/compact#270). See the
+   * Initializable module for rationale.
+   */
+  export ledger _isInitialized: Boolean;
+
   export ledger _balances: Map<Either<Bytes<32>, ContractAddress>, Uint<128>>;
   /**
    * @description Mapping from owner accounts to spender accounts and their allowances.
@@ -134,10 +140,37 @@ module FungibleToken {
                    symbol_: Opaque<"string">,
                    decimals_: Uint<8>
                    ): [] {
-    Initializable_initialize();
+    assertNotInitialized();
+    _isInitialized = true;
     _name = disclose(name_);
     _symbol = disclose(symbol_);
     _decimals = disclose(decimals_);
+  }
+
+  /**
+   * @description Asserts that the contract has been initialized, throwing an error if not.
+   *
+   * Requirements:
+   *
+   * - Contract must be initialized.
+   *
+   * @return {[]} - Empty tuple.
+   */
+  circuit assertInitialized(): [] {
+    assert(_isInitialized, "FungibleToken: contract not initialized");
+  }
+
+  /**
+   * @description Asserts that the contract has not been initialized, throwing an error if it has.
+   *
+   * Requirements:
+   *
+   * - Contract must not be initialized.
+   *
+   * @return {[]} - Empty tuple.
+   */
+  circuit assertNotInitialized(): [] {
+    assert(!_isInitialized, "FungibleToken: contract already initialized");
   }
 
   /**
@@ -152,7 +185,7 @@ module FungibleToken {
    * @return {Opaque<"string">} - The token name.
    */
   export circuit name(): Opaque<"string"> {
-    Initializable_assertInitialized();
+    assertInitialized();
     return _name;
   }
 
@@ -168,7 +201,7 @@ module FungibleToken {
    * @return {Opaque<"string">} - The token name.
    */
   export circuit symbol(): Opaque<"string"> {
-    Initializable_assertInitialized();
+    assertInitialized();
     return _symbol;
   }
 
@@ -184,7 +217,7 @@ module FungibleToken {
    * @return {Uint<8>} - The account's token balance.
    */
   export circuit decimals(): Uint<8> {
-    Initializable_assertInitialized();
+    assertInitialized();
     return _decimals;
   }
 
@@ -200,7 +233,7 @@ module FungibleToken {
    * @return {Uint<128>} - The total supply of tokens.
    */
   export circuit totalSupply(): Uint<128> {
-    Initializable_assertInitialized();
+    assertInitialized();
     return _totalSupply;
   }
 
@@ -219,7 +252,7 @@ module FungibleToken {
    * @return {Uint<128>} - The account's token balance.
    */
   export circuit balanceOf(account: Either<Bytes<32>, ContractAddress>): Uint<128> {
-    Initializable_assertInitialized();
+    assertInitialized();
     const canonAcct = Utils_canonicalize<Bytes<32>, ContractAddress>(account);
 
     if (!_balances.member(disclose(canonAcct))) {
@@ -253,7 +286,7 @@ module FungibleToken {
                    to: Either<Bytes<32>, ContractAddress>,
                    value: Uint<128>
                    ): Boolean {
-    Initializable_assertInitialized();
+    assertInitialized();
     const isContractAddr = !to.is_left;
     assert(!isContractAddr, "FungibleToken: unsafe transfer");
 
@@ -283,7 +316,7 @@ module FungibleToken {
                    to: Either<Bytes<32>, ContractAddress>,
                    value: Uint<128>
                    ): Boolean {
-    Initializable_assertInitialized();
+    assertInitialized();
     const owner = left<Bytes<32>, ContractAddress>(_computeAccountId());
     _unsafeUncheckedTransfer(owner, to, value);
     return true;
@@ -309,7 +342,7 @@ module FungibleToken {
                    owner: Either<Bytes<32>, ContractAddress>,
                    spender: Either<Bytes<32>, ContractAddress>
                    ): Uint<128> {
-    Initializable_assertInitialized();
+    assertInitialized();
     const canonOwner = Utils_canonicalize<Bytes<32>, ContractAddress>(owner);
     const canonSpender = Utils_canonicalize<Bytes<32>, ContractAddress>(spender);
 
@@ -337,7 +370,7 @@ module FungibleToken {
   export circuit approve(spender: Either<Bytes<32>, ContractAddress>,
                          value: Uint<128>
                          ): Boolean {
-    Initializable_assertInitialized();
+    assertInitialized();
 
     const owner = left<Bytes<32>, ContractAddress>(_computeAccountId());
     _approve(owner, spender, value);
@@ -373,7 +406,7 @@ module FungibleToken {
                    to: Either<Bytes<32>, ContractAddress>,
                    value: Uint<128>
                    ): Boolean {
-    Initializable_assertInitialized();
+    assertInitialized();
     const isContractAddr = !to.is_left;
     assert(!isContractAddr, "FungibleToken: unsafe transfer");
     return _unsafeTransferFrom(fromAddress, to, value);
@@ -406,7 +439,7 @@ module FungibleToken {
                    to: Either<Bytes<32>, ContractAddress>,
                    value: Uint<128>
                    ): Boolean {
-    Initializable_assertInitialized();
+    assertInitialized();
 
     const spender = left<Bytes<32>, ContractAddress>(_computeAccountId());
     _spendAllowance(fromAddress, spender, value);
@@ -443,7 +476,7 @@ module FungibleToken {
                    to: Either<Bytes<32>, ContractAddress>,
                    value: Uint<128>
                    ): [] {
-    Initializable_assertInitialized();
+    assertInitialized();
     const isContractAddr = !to.is_left;
     assert(!isContractAddr, "FungibleToken: unsafe transfer");
     _unsafeUncheckedTransfer(fromAddress, to, value);
@@ -474,7 +507,7 @@ module FungibleToken {
                    to: Either<Bytes<32>, ContractAddress>,
                    value: Uint<128>
                    ): [] {
-    Initializable_assertInitialized();
+    assertInitialized();
     assert(!_isTargetZero(fromAddress), "FungibleToken: invalid sender");
     assert(!_isTargetZero(to), "FungibleToken: invalid receiver");
 
@@ -501,7 +534,7 @@ module FungibleToken {
                   to: Either<Bytes<32>, ContractAddress>,
                   value: Uint<128>
                   ): [] {
-    Initializable_assertInitialized();
+    assertInitialized();
     const canonFrom = Utils_canonicalize<Bytes<32>, ContractAddress>(fromAddress);
     const canonTo = Utils_canonicalize<Bytes<32>, ContractAddress>(to);
 
@@ -547,7 +580,7 @@ module FungibleToken {
    * @return {[]} - Empty tuple.
    */
   export circuit _mint(account: Either<Bytes<32>, ContractAddress>, value: Uint<128>): [] {
-    Initializable_assertInitialized();
+    assertInitialized();
     const isContractAddr = !account.is_left;
     assert(!isContractAddr, "FungibleToken: unsafe transfer");
     _unsafeMint(account, value);
@@ -575,7 +608,7 @@ module FungibleToken {
                    account: Either<Bytes<32>, ContractAddress>,
                    value: Uint<128>
                    ): [] {
-    Initializable_assertInitialized();
+    assertInitialized();
     assert(!_isTargetZero(account), "FungibleToken: invalid receiver");
     _update(ZERO(), account, value);
   }
@@ -597,7 +630,7 @@ module FungibleToken {
    * @return {[]} - Empty tuple.
    */
   export circuit _burn(account: Either<Bytes<32>, ContractAddress>, value: Uint<128>): [] {
-    Initializable_assertInitialized();
+    assertInitialized();
     assert(!_isTargetZero(account), "FungibleToken: invalid sender");
     _update(account, ZERO(), value);
   }
@@ -625,7 +658,7 @@ module FungibleToken {
                    spender: Either<Bytes<32>, ContractAddress>,
                    value: Uint<128>
                    ): [] {
-    Initializable_assertInitialized();
+    assertInitialized();
     const canonOwner = Utils_canonicalize<Bytes<32>, ContractAddress>(owner);
     const canonSpender = Utils_canonicalize<Bytes<32>, ContractAddress>(spender);
 
@@ -663,7 +696,7 @@ module FungibleToken {
                    spender: Either<Bytes<32>, ContractAddress>,
                    value: Uint<128>
                    ): [] {
-    Initializable_assertInitialized();
+    assertInitialized();
     const canonOwner = Utils_canonicalize<Bytes<32>, ContractAddress>(owner);
     const canonSpender = Utils_canonicalize<Bytes<32>, ContractAddress>(spender);
 

--- a/contracts/src/token/MultiToken.compact
+++ b/contracts/src/token/MultiToken.compact
@@ -124,7 +124,6 @@ pragma language_version >= 0.21.0;
  */
 module MultiToken {
   import CompactStandardLibrary;
-  import "../security/Initializable" prefix Initializable_;
   import "../utils/Utils" prefix Utils_;
 
   /**
@@ -135,6 +134,13 @@ module MultiToken {
    * @type {Map<id, Map<account, balance>>}
    * @type {Map<Uint<128>, Map<Either<Bytes<32>, ContractAddress>, Uint<128>>>} _balances
    */
+  /**
+   * @description Initialization flag, tracked per-module to avoid the compiler's
+   * shared transitive-dependency state bug (LFDT-Minokawa/compact#270). See the
+   * Initializable module for rationale.
+   */
+  export ledger _isInitialized: Boolean;
+
   export ledger _balances: Map<Uint<128>,
                                Map<Either<Bytes<32>, ContractAddress>, Uint<128>>>;
 
@@ -199,8 +205,35 @@ module MultiToken {
    * @return {[]} - Empty tuple.
    */
   export circuit initialize(uri_: Opaque<"string">): [] {
-    Initializable_initialize();
+    assertNotInitialized();
+    _isInitialized = true;
     _setURI(uri_);
+  }
+
+  /**
+   * @description Asserts that the contract has been initialized, throwing an error if not.
+   *
+   * Requirements:
+   *
+   * - Contract must be initialized.
+   *
+   * @return {[]} - Empty tuple.
+   */
+  circuit assertInitialized(): [] {
+    assert(_isInitialized, "MultiToken: contract not initialized");
+  }
+
+  /**
+   * @description Asserts that the contract has not been initialized, throwing an error if it has.
+   *
+   * Requirements:
+   *
+   * - Contract must not be initialized.
+   *
+   * @return {[]} - Empty tuple.
+   */
+  circuit assertNotInitialized(): [] {
+    assert(!_isInitialized, "MultiToken: contract already initialized");
   }
 
   /**
@@ -220,7 +253,7 @@ module MultiToken {
    * @return {Opaque<"string">} - The base URI for all tokens.
    */
   export circuit uri(id: Uint<128>): Opaque<"string"> {
-    Initializable_assertInitialized();
+    assertInitialized();
     return _uri;
   }
 
@@ -241,7 +274,7 @@ module MultiToken {
                    account: Either<Bytes<32>, ContractAddress>,
                    id: Uint<128>
                    ): Uint<128> {
-    Initializable_assertInitialized();
+    assertInitialized();
     const canonAcct = Utils_canonicalize<Bytes<32>, ContractAddress>(account);
 
     if (!_balances.member(disclose(id)) || !_balances.lookup(id).member(disclose(canonAcct))) {
@@ -273,7 +306,7 @@ module MultiToken {
                    operator: Either<Bytes<32>, ContractAddress>,
                    approved: Boolean
                    ): [] {
-    Initializable_assertInitialized();
+    assertInitialized();
     const caller = left<Bytes<32>, ContractAddress>(_computeAccountId());
     _setApprovalForAll(caller, operator, approved);
   }
@@ -295,7 +328,7 @@ module MultiToken {
                    account: Either<Bytes<32>, ContractAddress>,
                    operator: Either<Bytes<32>, ContractAddress>
                    ): Boolean {
-    Initializable_assertInitialized();
+    assertInitialized();
     const canonAcct = Utils_canonicalize<Bytes<32>, ContractAddress>(account);
     const canonOp = Utils_canonicalize<Bytes<32>, ContractAddress>(operator);
 
@@ -404,7 +437,7 @@ module MultiToken {
                   id: Uint<128>,
                   value: Uint<128>
                   ): [] {
-    Initializable_assertInitialized();
+    assertInitialized();
     const canonFrom = Utils_canonicalize<Bytes<32>, ContractAddress>(fromAddress);
     const canonTo = Utils_canonicalize<Bytes<32>, ContractAddress>(to);
 
@@ -464,7 +497,7 @@ module MultiToken {
                    id: Uint<128>,
                    value: Uint<128>
                    ): [] {
-    Initializable_assertInitialized();
+    assertInitialized();
 
     const caller = left<Bytes<32>, ContractAddress>(_computeAccountId());
     const canonFrom = Utils_canonicalize<Bytes<32>, ContractAddress>(fromAddress);
@@ -505,7 +538,7 @@ module MultiToken {
                    id: Uint<128>,
                    value: Uint<128>
                    ): [] {
-    Initializable_assertInitialized();
+    assertInitialized();
 
     assert(!_isTargetZero(fromAddress), "MultiToken: invalid sender");
     assert(!_isTargetZero(to), "MultiToken: invalid receiver");
@@ -536,7 +569,7 @@ module MultiToken {
    * @return {[]} - Empty tuple.
    */
   export circuit _setURI(newURI: Opaque<"string">): [] {
-    Initializable_assertInitialized();
+    assertInitialized();
     _uri = disclose(newURI);
   }
 
@@ -593,7 +626,7 @@ module MultiToken {
                    id: Uint<128>,
                    value: Uint<128>
                    ): [] {
-    Initializable_assertInitialized();
+    assertInitialized();
     assert(!_isTargetZero(to), "MultiToken: invalid receiver");
     _update(ZERO(), to, id, value);
   }
@@ -618,7 +651,7 @@ module MultiToken {
                        id: Uint<128>,
                        value: Uint<128>
                        ): [] {
-    Initializable_assertInitialized();
+    assertInitialized();
     assert(!_isTargetZero(fromAddress), "MultiToken: invalid sender");
     _update(fromAddress, ZERO(), id, value);
   }
@@ -649,7 +682,7 @@ module MultiToken {
                    operator: Either<Bytes<32>, ContractAddress>,
                    approved: Boolean
                    ): [] {
-    Initializable_assertInitialized();
+    assertInitialized();
     const canonOwner = Utils_canonicalize<Bytes<32>, ContractAddress>(owner);
     assert(!_isTargetZero(canonOwner), "MultiToken: invalid owner");
 

--- a/contracts/src/token/MultiToken.compact
+++ b/contracts/src/token/MultiToken.compact
@@ -127,6 +127,13 @@ module MultiToken {
   import "../utils/Utils" prefix Utils_;
 
   /**
+   * @description Initialization flag, tracked per-module to avoid the compiler's
+   * shared transitive-dependency state bug (LFDT-Minokawa/compact#270). See the
+   * Initializable module for rationale.
+   */
+  export ledger _isInitialized: Boolean;
+
+  /**
    * @description Mapping from token ID to account balances.
    * @type {Uint<128>} id - The token identifier.
    * @type {Either<Bytes<32>, ContractAddress>} account - The account address.
@@ -134,13 +141,6 @@ module MultiToken {
    * @type {Map<id, Map<account, balance>>}
    * @type {Map<Uint<128>, Map<Either<Bytes<32>, ContractAddress>, Uint<128>>>} _balances
    */
-  /**
-   * @description Initialization flag, tracked per-module to avoid the compiler's
-   * shared transitive-dependency state bug (LFDT-Minokawa/compact#270). See the
-   * Initializable module for rationale.
-   */
-  export ledger _isInitialized: Boolean;
-
   export ledger _balances: Map<Uint<128>,
                                Map<Either<Bytes<32>, ContractAddress>, Uint<128>>>;
 

--- a/contracts/src/token/NonFungibleToken.compact
+++ b/contracts/src/token/NonFungibleToken.compact
@@ -90,19 +90,19 @@ module NonFungibleToken {
   export sealed ledger _symbol: Opaque<"string">;
 
   /**
-   * @description Mapping from token IDs to their owner addresses.
-   * @type {Uint<128>} tokenId - The unique identifier for a token.
-   * @type {Either<Bytes<32>, ContractAddress>} owner - The owner address (account ID or contract).
-   * @type {Map<tokenId, owner>}
-   * @type {Map<Uint<128>, Either<Bytes<32>, ContractAddress>>} _owners
-   */
-  /**
    * @description Initialization flag, tracked per-module to avoid the compiler's
    * shared transitive-dependency state bug (LFDT-Minokawa/compact#270). See the
    * Initializable module for rationale.
    */
   export ledger _isInitialized: Boolean;
 
+  /**
+   * @description Mapping from token IDs to their owner addresses.
+   * @type {Uint<128>} tokenId - The unique identifier for a token.
+   * @type {Either<Bytes<32>, ContractAddress>} owner - The owner address (account ID or contract).
+   * @type {Map<tokenId, owner>}
+   * @type {Map<Uint<128>, Either<Bytes<32>, ContractAddress>>} _owners
+   */
   export ledger _owners: Map<Uint<128>, Either<Bytes<32>, ContractAddress>>;
 
   /**

--- a/contracts/src/token/NonFungibleToken.compact
+++ b/contracts/src/token/NonFungibleToken.compact
@@ -83,7 +83,6 @@ pragma language_version >= 0.21.0;
 
 module NonFungibleToken {
   import CompactStandardLibrary;
-  import "../security/Initializable" prefix Initializable_;
   import "../utils/Utils" prefix Utils_;
 
   /// Public state
@@ -97,6 +96,13 @@ module NonFungibleToken {
    * @type {Map<tokenId, owner>}
    * @type {Map<Uint<128>, Either<Bytes<32>, ContractAddress>>} _owners
    */
+  /**
+   * @description Initialization flag, tracked per-module to avoid the compiler's
+   * shared transitive-dependency state bug (LFDT-Minokawa/compact#270). See the
+   * Initializable module for rationale.
+   */
+  export ledger _isInitialized: Boolean;
+
   export ledger _owners: Map<Uint<128>, Either<Bytes<32>, ContractAddress>>;
 
   /**
@@ -177,9 +183,36 @@ module NonFungibleToken {
    * @return {[]} - Empty tuple.
    */
   export circuit initialize(name_: Opaque<"string">, symbol_: Opaque<"string">): [] {
-    Initializable_initialize();
+    assertNotInitialized();
+    _isInitialized = true;
     _name = disclose(name_);
     _symbol = disclose(symbol_);
+  }
+
+  /**
+   * @description Asserts that the contract has been initialized, throwing an error if not.
+   *
+   * Requirements:
+   *
+   * - Contract must be initialized.
+   *
+   * @return {[]} - Empty tuple.
+   */
+  circuit assertInitialized(): [] {
+    assert(_isInitialized, "NonFungibleToken: contract not initialized");
+  }
+
+  /**
+   * @description Asserts that the contract has not been initialized, throwing an error if it has.
+   *
+   * Requirements:
+   *
+   * - Contract must not be initialized.
+   *
+   * @return {[]} - Empty tuple.
+   */
+  circuit assertNotInitialized(): [] {
+    assert(!_isInitialized, "NonFungibleToken: contract already initialized");
   }
 
   /**
@@ -195,7 +228,7 @@ module NonFungibleToken {
    * @return {Uint<128>} - The number of tokens in `owner`'s account.
    */
   export circuit balanceOf(owner: Either<Bytes<32>, ContractAddress>): Uint<128> {
-    Initializable_assertInitialized();
+    assertInitialized();
     const canonOwner = Utils_canonicalize<Bytes<32>, ContractAddress>(owner);
 
     if (!_balances.member(disclose(canonOwner))) {
@@ -219,7 +252,7 @@ module NonFungibleToken {
    * @return {Either<Bytes<32>, ContractAddress>} - The account that owns the token.
    */
   export circuit ownerOf(tokenId: Uint<128>): Either<Bytes<32>, ContractAddress> {
-    Initializable_assertInitialized();
+    assertInitialized();
     return _requireOwned(tokenId);
   }
 
@@ -235,7 +268,7 @@ module NonFungibleToken {
    * @return {Opaque<"string">} - The token name.
    */
   export circuit name(): Opaque<"string"> {
-    Initializable_assertInitialized();
+    assertInitialized();
     return _name;
   }
 
@@ -251,7 +284,7 @@ module NonFungibleToken {
    * @return {Opaque<"string">} - The token symbol.
    */
   export circuit symbol(): Opaque<"string"> {
-    Initializable_assertInitialized();
+    assertInitialized();
     return _symbol;
   }
 
@@ -275,7 +308,7 @@ module NonFungibleToken {
    * @return {Opaque<"string">} - the token id's URI.
    */
   export circuit tokenURI(tokenId: Uint<128>): Opaque<"string"> {
-    Initializable_assertInitialized();
+    assertInitialized();
     _requireOwned(tokenId);
 
     if (!_tokenURIs.member(disclose(tokenId))) {
@@ -302,7 +335,7 @@ module NonFungibleToken {
    * @return {[]} - Empty tuple.
    */
   export circuit _setTokenURI(tokenId: Uint<128>, tokenURI: Opaque<"string">): [] {
-    Initializable_assertInitialized();
+    assertInitialized();
     _requireOwned(tokenId);
 
     return _tokenURIs.insert(disclose(tokenId), disclose(tokenURI));
@@ -330,7 +363,7 @@ module NonFungibleToken {
    * @return {[]} - Empty tuple.
    */
   export circuit approve(to: Either<Bytes<32>, ContractAddress>, tokenId: Uint<128>): [] {
-    Initializable_assertInitialized();
+    assertInitialized();
     const auth = left<Bytes<32>, ContractAddress>(_computeAccountId());
     _approve(to, tokenId, auth);
   }
@@ -349,7 +382,7 @@ module NonFungibleToken {
    * @return {Either<Bytes<32>, ContractAddress>} - The account approved to manage the token
    */
   export circuit getApproved(tokenId: Uint<128>): Either<Bytes<32>, ContractAddress> {
-    Initializable_assertInitialized();
+    assertInitialized();
     _requireOwned(tokenId);
 
     return _getApproved(tokenId);
@@ -377,7 +410,7 @@ module NonFungibleToken {
                    operator: Either<Bytes<32>, ContractAddress>,
                    approved: Boolean
                    ): [] {
-    Initializable_assertInitialized();
+    assertInitialized();
     const owner = left<Bytes<32>, ContractAddress>(_computeAccountId());
     _setApprovalForAll(owner, operator, approved);
   }
@@ -399,7 +432,7 @@ module NonFungibleToken {
                    owner: Either<Bytes<32>, ContractAddress>,
                    operator: Either<Bytes<32>, ContractAddress>
                    ): Boolean {
-    Initializable_assertInitialized();
+    assertInitialized();
     const canonOwner = Utils_canonicalize<Bytes<32>, ContractAddress>(owner);
     const canonOp = Utils_canonicalize<Bytes<32>, ContractAddress>(operator);
 
@@ -439,7 +472,7 @@ module NonFungibleToken {
                    to: Either<Bytes<32>, ContractAddress>,
                    tokenId: Uint<128>
                    ): [] {
-    Initializable_assertInitialized();
+    assertInitialized();
     const isContractAddr = !to.is_left;
     assert(!isContractAddr, "NonFungibleToken: unsafe transfer");
 
@@ -476,7 +509,7 @@ module NonFungibleToken {
                    to: Either<Bytes<32>, ContractAddress>,
                    tokenId: Uint<128>
                    ): [] {
-    Initializable_assertInitialized();
+    assertInitialized();
     assert(!_isTargetZero(to), "NonFungibleToken: invalid receiver");
     // Setting an "auth" argument enables the `_isAuthorized` check which verifies that the token exists
     // (fromAddress != 0). Therefore, it is not needed to verify that the return value is not 0 here.
@@ -500,7 +533,7 @@ module NonFungibleToken {
    * @return {Either<Bytes<32>, ContractAddress>} - The owner of the token
    */
   export circuit _ownerOf(tokenId: Uint<128>): Either<Bytes<32>, ContractAddress> {
-    Initializable_assertInitialized();
+    assertInitialized();
     if (!_owners.member(disclose(tokenId))) {
       return ZERO();
     }
@@ -521,7 +554,7 @@ module NonFungibleToken {
    * @return {Either<Bytes<32>, ContractAddress>} - An account approved to spend `tokenId`
    */
   export circuit _getApproved(tokenId: Uint<128>): Either<Bytes<32>, ContractAddress> {
-    Initializable_assertInitialized();
+    assertInitialized();
     if (!_tokenApprovals.member(disclose(tokenId))) {
       return ZERO();
     }
@@ -551,7 +584,7 @@ module NonFungibleToken {
                    spender: Either<Bytes<32>, ContractAddress>,
                    tokenId: Uint<128>
                    ): Boolean {
-    Initializable_assertInitialized();
+    assertInitialized();
     const canonOwner = Utils_canonicalize<Bytes<32>, ContractAddress>(owner);
     const canonSpender = Utils_canonicalize<Bytes<32>, ContractAddress>(spender);
 
@@ -584,7 +617,7 @@ module NonFungibleToken {
                    spender: Either<Bytes<32>, ContractAddress>,
                    tokenId: Uint<128>
                    ): [] {
-    Initializable_assertInitialized();
+    assertInitialized();
     if (!_isAuthorized(owner, spender, tokenId)) {
       assert(!_isTargetZero(owner), "NonFungibleToken: nonexistent token");
       assert(false, "NonFungibleToken: insufficient approval");
@@ -610,7 +643,7 @@ module NonFungibleToken {
                   tokenId: Uint<128>,
                   auth: Either<Bytes<32>, ContractAddress>
                   ): Either<Bytes<32>, ContractAddress> {
-    Initializable_assertInitialized();
+    assertInitialized();
     const canonTo = Utils_canonicalize<Bytes<32>, ContractAddress>(to);
     const canonAuth = Utils_canonicalize<Bytes<32>, ContractAddress>(auth);
     const fromAddress = _ownerOf(tokenId);
@@ -659,7 +692,7 @@ module NonFungibleToken {
    * @return {[]} - Empty tuple.
    */
   export circuit _mint(to: Either<Bytes<32>, ContractAddress>, tokenId: Uint<128>): [] {
-    Initializable_assertInitialized();
+    assertInitialized();
     const isContractAddr = !to.is_left;
     assert(!isContractAddr, "NonFungibleToken: unsafe transfer");
 
@@ -689,7 +722,7 @@ module NonFungibleToken {
                    to: Either<Bytes<32>, ContractAddress>,
                    tokenId: Uint<128>
                    ): [] {
-    Initializable_assertInitialized();
+    assertInitialized();
     assert(!_isTargetZero(to), "NonFungibleToken: invalid receiver");
 
     const previousOwner = _update(to, tokenId, ZERO());
@@ -713,7 +746,7 @@ module NonFungibleToken {
    * @return {[]} - Empty tuple.
    */
   export circuit _burn(tokenId: Uint<128>): [] {
-    Initializable_assertInitialized();
+    assertInitialized();
     const previousOwner = _update(ZERO(), tokenId, ZERO());
     assert(!_isTargetZero(previousOwner), "NonFungibleToken: invalid sender");
     _tokenURIs.remove(disclose(tokenId));
@@ -746,7 +779,7 @@ module NonFungibleToken {
                    to: Either<Bytes<32>, ContractAddress>,
                    tokenId: Uint<128>
                    ): [] {
-    Initializable_assertInitialized();
+    assertInitialized();
     const isContractAddr = !to.is_left;
     assert(!isContractAddr, "NonFungibleToken: unsafe transfer");
 
@@ -780,7 +813,7 @@ module NonFungibleToken {
                    to: Either<Bytes<32>, ContractAddress>,
                    tokenId: Uint<128>
                    ): [] {
-    Initializable_assertInitialized();
+    assertInitialized();
     assert(!_isTargetZero(to), "NonFungibleToken: invalid receiver");
 
     const previousOwner = _update(to, tokenId, ZERO());
@@ -812,7 +845,7 @@ module NonFungibleToken {
                    tokenId: Uint<128>,
                    auth: Either<Bytes<32>, ContractAddress>
                    ): [] {
-    Initializable_assertInitialized();
+    assertInitialized();
     // Canonicalize + normalize `to`
     const canonTo = Utils_canonicalize<Bytes<32>, ContractAddress>(to);
     const normalizedTo = _isTargetZero(canonTo) ? ZERO() : canonTo;
@@ -853,7 +886,7 @@ module NonFungibleToken {
                    operator: Either<Bytes<32>, ContractAddress>,
                    approved: Boolean
                    ): [] {
-    Initializable_assertInitialized();
+    assertInitialized();
     const canonOwner = Utils_canonicalize<Bytes<32>, ContractAddress>(owner);
     assert(!_isTargetZero(canonOwner), "NonFungibleToken: invalid owner");
 
@@ -885,7 +918,7 @@ module NonFungibleToken {
    * @return {Either<Bytes<32>, ContractAddress>} - The owner of `tokenId`
    */
   export circuit _requireOwned(tokenId: Uint<128>): Either<Bytes<32>, ContractAddress> {
-    Initializable_assertInitialized();
+    assertInitialized();
     const owner = _ownerOf(tokenId);
 
     assert(!_isTargetZero(owner), "NonFungibleToken: nonexistent token");

--- a/contracts/src/token/test/FungibleToken.test.ts
+++ b/contracts/src/token/test/FungibleToken.test.ts
@@ -138,6 +138,7 @@ describe('FungibleToken', () => {
       ['_unsafeTransferFrom', [OWNER.either, RECIPIENT.either, AMOUNT]],
       ['approve', [OWNER.either, AMOUNT]],
       ['_approve', [OWNER.either, SPENDER.either, AMOUNT]],
+      ['_spendAllowance', [OWNER.either, SPENDER.either, AMOUNT]],
       ['_transfer', [OWNER.either, RECIPIENT.either, AMOUNT]],
       ['_unsafeUncheckedTransfer', [OWNER.either, RECIPIENT.either, AMOUNT]],
       ['_mint', [OWNER.either, AMOUNT]],

--- a/contracts/src/token/test/FungibleToken.test.ts
+++ b/contracts/src/token/test/FungibleToken.test.ts
@@ -148,7 +148,7 @@ describe('FungibleToken', () => {
     it.each(circuitsToFail)('%s should fail', (circuitName, args) => {
       expect(() => {
         (token[circuitName] as (...args: unknown[]) => unknown)(...args);
-      }).toThrow('Initializable: contract not initialized');
+      }).toThrow('FungibleToken: contract not initialized');
     });
   });
 

--- a/contracts/src/token/test/MultiToken.test.ts
+++ b/contracts/src/token/test/MultiToken.test.ts
@@ -142,7 +142,7 @@ describe('MultiToken', () => {
 
       expect(() => {
         token.initialize(URI);
-      }).toThrow('Initializable: contract already initialized');
+      }).toThrow('MultiToken: contract already initialized');
     });
   });
 
@@ -171,7 +171,7 @@ describe('MultiToken', () => {
     it.each(circuitsToFail)('%s should fail', (circuitName, args) => {
       expect(() => {
         (token[circuitName] as (...args: unknown[]) => unknown)(...args);
-      }).toThrow('Initializable: contract not initialized');
+      }).toThrow('MultiToken: contract not initialized');
     });
 
     it('should allow initialization post deployment', () => {

--- a/contracts/src/token/test/MultiToken.test.ts
+++ b/contracts/src/token/test/MultiToken.test.ts
@@ -164,6 +164,7 @@ describe('MultiToken', () => {
       ['_unsafeTransfer', transferArgs],
       ['_setURI', [URI]],
       ['_mint', [OWNER.either, TOKEN_ID, AMOUNT]],
+      ['_unsafeMint', [OWNER.either, TOKEN_ID, AMOUNT]],
       ['_burn', [OWNER.either, TOKEN_ID, AMOUNT]],
       ['_setApprovalForAll', [OWNER.either, SPENDER.either, true]],
     ];

--- a/contracts/src/token/test/nonFungibleToken.test.ts
+++ b/contracts/src/token/test/nonFungibleToken.test.ts
@@ -1470,7 +1470,7 @@ describe('Uninitialized NonFungibleToken', () => {
       (uninitializedToken[circuitName] as (...args: unknown[]) => unknown)(
         ...args,
       );
-    }).toThrow('Initializable: contract not initialized');
+    }).toThrow('NonFungibleToken: contract not initialized');
   });
 });
 

--- a/contracts/test/integration/README.md
+++ b/contracts/test/integration/README.md
@@ -1,33 +1,8 @@
 # Integration tests
 
-Specs that compose **multiple production modules into a single top-level
-contract** and drive it through the simulator — the surface unit tests (one
-module per mock) can't cover. Run with the current toolchain (compact 0.29.0).
+Compose multiple production modules into one top-level contract and drive it
+through the simulator, covering interactions the per-module unit tests can't.
 
 ```sh
 yarn test:integration
 ```
-
-That compiles the integration contracts and runs `vitest --config
-vitest.integration.config.ts`.
-
-## Structure
-
-- **`specs/`** — what runs. One file per scenario, named `*.spec.ts`.
-- **`fixtures/`** — per-contract simulator factories (`@openzeppelin/compact-simulator`).
-- **`_mocks/`** — test-only top-level `.compact` contracts that do the composing.
-
-## `initStateIsolation` (issue #556 / compiler#270)
-
-Proves both the bug and the fix for shared-vs-per-module initialization state:
-
-- **`SharedInitCollision`** — two modules in the same directory that both import
-  the shared, stateful `Initializable`. The compiler deduplicates the transitive
-  `_isInitialized` into one ledger slot, so initializing one module initializes
-  the other. The spec's "the bug" block asserts that collision.
-- **`ComposedTokens`** — the production `FungibleToken` + `NonFungibleToken`
-  (same directory), each now owning its `_isInitialized` flag. The "the fix"
-  block asserts the two initializations are independent.
-
-If the compiler ever isolates transitive ledger state (compiler#270 resolved),
-the "the bug" block must be inverted or removed.

--- a/contracts/test/integration/README.md
+++ b/contracts/test/integration/README.md
@@ -1,0 +1,33 @@
+# Integration tests
+
+Specs that compose **multiple production modules into a single top-level
+contract** and drive it through the simulator — the surface unit tests (one
+module per mock) can't cover. Run with the current toolchain (compact 0.29.0).
+
+```sh
+yarn test:integration
+```
+
+That compiles the integration contracts and runs `vitest --config
+vitest.integration.config.ts`.
+
+## Structure
+
+- **`specs/`** — what runs. One file per scenario, named `*.spec.ts`.
+- **`fixtures/`** — per-contract simulator factories (`@openzeppelin/compact-simulator`).
+- **`_mocks/`** — test-only top-level `.compact` contracts that do the composing.
+
+## `initStateIsolation` (issue #556 / compiler#270)
+
+Proves both the bug and the fix for shared-vs-per-module initialization state:
+
+- **`SharedInitCollision`** — two modules in the same directory that both import
+  the shared, stateful `Initializable`. The compiler deduplicates the transitive
+  `_isInitialized` into one ledger slot, so initializing one module initializes
+  the other. The spec's "the bug" block asserts that collision.
+- **`ComposedTokens`** — the production `FungibleToken` + `NonFungibleToken`
+  (same directory), each now owning its `_isInitialized` flag. The "the fix"
+  block asserts the two initializations are independent.
+
+If the compiler ever isolates transitive ledger state (compiler#270 resolved),
+the "the bug" block must be inverted or removed.

--- a/contracts/test/integration/_mocks/ComposedTokens.compact
+++ b/contracts/test/integration/_mocks/ComposedTokens.compact
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+
+// WARNING: FOR TESTING PURPOSES ONLY.
+// This contract exposes internal circuits and bypasses safety checks that the
+// corresponding production contract relies on. DO NOT deploy or use this
+// contract in any production application.
+
+// Top-level contract composing two PRODUCTION modules that live in the SAME
+// directory (FungibleToken + NonFungibleToken). Each now owns its `_isInitialized`
+// flag, so initializing one must NOT initialize the other. The
+// `initStateIsolation` spec asserts that isolation (the fix for #556).
+//
+// `initFT` / `initNFT` select which module is initialized at construction, so a
+// test can initialize one and assert the other is still uninitialized. (Both
+// initializers write `sealed` ledger fields, so they must run in the constructor.)
+pragma language_version >= 0.21.0;
+
+import CompactStandardLibrary;
+import "../../../src/token/FungibleToken" prefix FungibleToken_;
+import "../../../src/token/NonFungibleToken" prefix NonFungibleToken_;
+
+export { ContractAddress, Either, Maybe };
+
+constructor(
+  ftName_: Opaque<"string">,
+  ftSymbol_: Opaque<"string">,
+  ftDecimals_: Uint<8>,
+  nftName_: Opaque<"string">,
+  nftSymbol_: Opaque<"string">,
+  initFT: Boolean,
+  initNFT: Boolean
+) {
+  if (disclose(initFT)) {
+    FungibleToken_initialize(ftName_, ftSymbol_, ftDecimals_);
+  }
+  if (disclose(initNFT)) {
+    NonFungibleToken_initialize(nftName_, nftSymbol_);
+  }
+}
+
+// Init-guarded getters: each calls its module's `assertInitialized()`.
+export circuit ftName(): Opaque<"string"> {
+  return FungibleToken_name();
+}
+
+export circuit nftName(): Opaque<"string"> {
+  return NonFungibleToken_name();
+}

--- a/contracts/test/integration/_mocks/SharedInitCollision.compact
+++ b/contracts/test/integration/_mocks/SharedInitCollision.compact
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+
+// WARNING: FOR TESTING PURPOSES ONLY. Intentionally exhibits the compiler#270
+// bug. DO NOT use this pattern in production.
+
+// Top-level contract composing TWO modules (ModuleA, ModuleB) that both import
+// the shared, stateful `Initializable` from the SAME directory. The compiler
+// deduplicates the transitive `_isInitialized` ledger state into a single slot,
+// so initializing one module also marks the other initialized. The
+// `initStateIsolation` spec asserts this collision (the bug), justifying why the
+// production modules now track their init flag per-module instead.
+pragma language_version >= 0.21.0;
+
+import CompactStandardLibrary;
+import "./sharedInit/ModuleA" prefix A_;
+import "./sharedInit/ModuleB" prefix B_;
+
+export circuit initA(): [] { A_initA(); }
+export circuit initB(): [] { B_initB(); }
+export circuit checkA(): [] { A_checkA(); }
+export circuit checkB(): [] { B_checkB(); }

--- a/contracts/test/integration/_mocks/sharedInit/ModuleA.compact
+++ b/contracts/test/integration/_mocks/sharedInit/ModuleA.compact
@@ -1,0 +1,17 @@
+// TEST-ONLY. Demonstrates the compiler#270 collision: a module that depends on
+// the shared, stateful `Initializable` module. Paired with ModuleB (same
+// directory) so a composing contract triggers the shared-ledger-slot bug.
+pragma language_version >= 0.21.0;
+
+module ModuleA {
+  import CompactStandardLibrary;
+  import "../../../../src/security/Initializable" prefix Initializable_;
+
+  export circuit initA(): [] {
+    Initializable_initialize();
+  }
+
+  export circuit checkA(): [] {
+    Initializable_assertInitialized();
+  }
+}

--- a/contracts/test/integration/_mocks/sharedInit/ModuleB.compact
+++ b/contracts/test/integration/_mocks/sharedInit/ModuleB.compact
@@ -1,0 +1,17 @@
+// TEST-ONLY. Demonstrates the compiler#270 collision: a module that depends on
+// the shared, stateful `Initializable` module. Paired with ModuleA (same
+// directory) so a composing contract triggers the shared-ledger-slot bug.
+pragma language_version >= 0.21.0;
+
+module ModuleB {
+  import CompactStandardLibrary;
+  import "../../../../src/security/Initializable" prefix Initializable_;
+
+  export circuit initB(): [] {
+    Initializable_initialize();
+  }
+
+  export circuit checkB(): [] {
+    Initializable_assertInitialized();
+  }
+}

--- a/contracts/test/integration/fixtures/composedTokens.ts
+++ b/contracts/test/integration/fixtures/composedTokens.ts
@@ -1,0 +1,61 @@
+import { createSimulator } from '@openzeppelin/compact-simulator';
+import {
+  ledger,
+  Contract as ComposedTokens,
+} from '../../../artifacts/ComposedTokens/contract/index.js';
+
+type EmptyPrivateState = Record<string, never>;
+
+type ComposedTokensArgs = readonly [
+  ftName: string,
+  ftSymbol: string,
+  ftDecimals: bigint,
+  nftName: string,
+  nftSymbol: string,
+  initFT: boolean,
+  initNFT: boolean,
+];
+
+const ComposedTokensSimulatorBase = createSimulator<
+  EmptyPrivateState,
+  ReturnType<typeof ledger>,
+  // biome-ignore lint/complexity/noBannedTypes: the contract declares no witnesses
+  {},
+  ComposedTokens<EmptyPrivateState>,
+  ComposedTokensArgs
+>({
+  contractFactory: (witnesses) =>
+    new ComposedTokens<EmptyPrivateState>(witnesses),
+  defaultPrivateState: () => ({}),
+  contractArgs: (ftName, ftSymbol, ftDecimals, nftName, nftSymbol, initFT, initNFT) => [
+    ftName,
+    ftSymbol,
+    ftDecimals,
+    nftName,
+    nftSymbol,
+    initFT,
+    initNFT,
+  ],
+  ledgerExtractor: (state) => ledger(state),
+  witnessesFactory: () => ({}),
+});
+
+/**
+ * Drives the ComposedTokens contract: production FungibleToken + NonFungibleToken
+ * (same directory) composed in one contract. `initFT` / `initNFT` choose which
+ * module is initialized at construction, so a test can prove the two init flags
+ * are independent (the #556 fix).
+ */
+export class ComposedTokensSimulator extends ComposedTokensSimulatorBase {
+  constructor(initFT: boolean, initNFT: boolean) {
+    super(['FT', 'FTK', 18n, 'NFT', 'NFTK', initFT, initNFT], {});
+  }
+
+  public ftName(): string {
+    return this.circuits.impure.ftName();
+  }
+
+  public nftName(): string {
+    return this.circuits.impure.nftName();
+  }
+}

--- a/contracts/test/integration/fixtures/sharedInitCollision.ts
+++ b/contracts/test/integration/fixtures/sharedInitCollision.ts
@@ -1,0 +1,50 @@
+import { createSimulator } from '@openzeppelin/compact-simulator';
+import {
+  ledger,
+  Contract as SharedInitCollision,
+} from '../../../artifacts/SharedInitCollision/contract/index.js';
+
+type EmptyPrivateState = Record<string, never>;
+
+const SharedInitCollisionSimulatorBase = createSimulator<
+  EmptyPrivateState,
+  ReturnType<typeof ledger>,
+  // biome-ignore lint/complexity/noBannedTypes: the contract declares no witnesses
+  {},
+  SharedInitCollision<EmptyPrivateState>,
+  readonly []
+>({
+  contractFactory: (witnesses) =>
+    new SharedInitCollision<EmptyPrivateState>(witnesses),
+  defaultPrivateState: () => ({}),
+  contractArgs: () => [],
+  ledgerExtractor: (state) => ledger(state),
+  witnessesFactory: () => ({}),
+});
+
+/**
+ * Drives the SharedInitCollision contract: two same-directory modules that both
+ * import the shared, stateful `Initializable`. Used to assert the compiler#270
+ * collision.
+ */
+export class SharedInitCollisionSimulator extends SharedInitCollisionSimulatorBase {
+  constructor() {
+    super([], {});
+  }
+
+  public initA(): void {
+    this.circuits.impure.initA();
+  }
+
+  public initB(): void {
+    this.circuits.impure.initB();
+  }
+
+  public checkA(): void {
+    this.circuits.impure.checkA();
+  }
+
+  public checkB(): void {
+    this.circuits.impure.checkB();
+  }
+}

--- a/contracts/test/integration/specs/initStateIsolation.spec.ts
+++ b/contracts/test/integration/specs/initStateIsolation.spec.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import { ComposedTokensSimulator } from '../fixtures/composedTokens.js';
+import { SharedInitCollisionSimulator } from '../fixtures/sharedInitCollision.js';
+
+/**
+ * Integration spec for issue #556 (compiler#270).
+ *
+ * Two composed contracts, both built from two modules living in the SAME
+ * directory:
+ *
+ *  - `SharedInitCollision` — both modules import the shared, stateful
+ *    `Initializable`. This reproduces the compiler bug: the transitive
+ *    `_isInitialized` ledger state is deduplicated into ONE slot, so the two
+ *    modules' initialization flags are entangled.
+ *
+ *  - `ComposedTokens` — the production FungibleToken + NonFungibleToken, each of
+ *    which now owns its `_isInitialized` flag. This proves the fix: the two
+ *    initializations are independent.
+ *
+ * The first block documents the bug (and would have to be deleted/inverted if
+ * the compiler ever isolates transitive ledger state); the second block guards
+ * the fix against regression.
+ */
+
+describe('Initializable state isolation (#556)', () => {
+  describe('the bug — shared Initializable across same-directory modules', () => {
+    it('should treat module B as initialized after only module A is initialized', () => {
+      const c = new SharedInitCollisionSimulator();
+
+      // Only module A is initialized.
+      c.initA();
+
+      // BUG: module B was never initialized, yet its init-guard passes,
+      // because both modules share a single `_isInitialized` ledger slot.
+      expect(() => c.checkB()).not.toThrow();
+    });
+
+    it('should not allow module B to initialize once module A has set the shared slot', () => {
+      const c = new SharedInitCollisionSimulator();
+      c.initA();
+
+      // BUG: B can never be initialized — the shared slot is already set.
+      expect(() => c.initB()).toThrow('Initializable: contract already initialized');
+    });
+  });
+
+  describe('the fix — per-module flags keep production modules isolated', () => {
+    it('should not initialize NonFungibleToken when only FungibleToken is initialized', () => {
+      const c = new ComposedTokensSimulator(true, false);
+
+      // FT is usable.
+      expect(() => c.ftName()).not.toThrow();
+      // NFT is independently still uninitialized.
+      expect(() => c.nftName()).toThrow(
+        'NonFungibleToken: contract not initialized',
+      );
+    });
+
+    it('should not initialize FungibleToken when only NonFungibleToken is initialized', () => {
+      const c = new ComposedTokensSimulator(false, true);
+
+      expect(() => c.nftName()).not.toThrow();
+      expect(() => c.ftName()).toThrow('FungibleToken: contract not initialized');
+    });
+
+    it('should initialize each module independently', () => {
+      const c = new ComposedTokensSimulator(true, true);
+
+      expect(() => c.ftName()).not.toThrow();
+      expect(() => c.nftName()).not.toThrow();
+    });
+  });
+});

--- a/contracts/vitest.integration.config.ts
+++ b/contracts/vitest.integration.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+
+// Integration specs compose multiple production modules into a single contract
+// and drive them through the simulator. Kept separate from the unit `test`
+// config (which scans `src/**/*.test.ts`).
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['test/integration/specs/**/*.spec.ts'],
+    reporters: 'verbose',
+  },
+});

--- a/turbo.json
+++ b/turbo.json
@@ -16,7 +16,7 @@
       "outputs": ["artifacts/**/"]
     },
     "compact:access": {
-      "dependsOn": ["^build", "compact:security", "compact:utils"],
+      "dependsOn": ["^build", "compact:utils"],
       "env": ["COMPACT_HOME", "SKIP_ZK"],
       "inputs": ["src/access/**/*.compact"],
       "outputLogs": "new-only",
@@ -30,7 +30,7 @@
       "outputs": ["artifacts/**/"]
     },
     "compact:token": {
-      "dependsOn": ["^build", "compact:security", "compact:utils"],
+      "dependsOn": ["^build", "compact:utils"],
       "env": ["COMPACT_HOME", "SKIP_ZK"],
       "inputs": ["src/token/**/*.compact"],
       "outputLogs": "new-only",


### PR DESCRIPTION
## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

Fixes #556

Composing two modules that both import the shared `Initializable` from the **same directory** collapses their `_isInitialized` ledger state into a single slot (compiler bug [LFDT-Minokawa/compact#270](https://github.com/LFDT-Minokawa/compact/issues/270)). Initializing one module then marks the other initialized and blocks its own initialization. The behaviour is directory-layout dependent and a security hazard for any contract that composes OZ modules.

**Reproduced** on both the repo toolchain (compact 0.29.0 / runtime 0.14.0) and the latest (0.31.0 / 0.16.0): same-directory composition yields one shared `_isInitialized` slot; different-directory yields two. Not fixed upstream.

### Change

Each module now owns its `_isInitialized` ledger flag and inlines its initialization assertions, removing the shared transitive dependency. `Initializable` is kept (stateful) for direct single-import use, with a technical warning documenting #270.

- **security:** keep `Initializable` stateful; add a #270 technical warning.
- **access/token:** inline a per-module init flag + assertions in `Ownable`, `ZOwnablePK`, `ShieldedAccessControl`, `FungibleToken`, `NonFungibleToken`, `MultiToken`, with module-specific revert messages.
- **test:** update revert-message expectations to the per-module strings.
- **test(integration):** new `initStateIsolation` spec proving the collision (shared `Initializable`) and the fix (per-module flags), plus `vitest.integration.config.ts` and a `test:integration` script.

> **Breaking:** the public ledger key moves from `Initializable__isInitialized` to per-module keys (`Ownable__isInitialized`, `FungibleToken__isInitialized`, …). Targeted at the 0.2.0 release.

## PR Checklist

- [x] I have read the Contributing Guide
- [x] I have added tests that prove my fix is effective (unit suite green; new integration spec proves bug + fix)
- [x] I have added documentation for new methods or changes to existing method behavior
- [ ] CI Workflows Are Passing

#### Further comments

The map-of-modules and stateless-helper alternatives were considered. Per-module flags were chosen because each module's init state is semantically independent (so this is the correct terminal layout regardless of how #270 resolves), it is the cheapest on the hot path, and — under CMA, which cannot add/remove ledger variables — it is the layout deployed contracts can keep permanently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added integration test suite for validating composed contracts with independent module initialization.

* **Bug Fixes**
  * Improved initialization state management to ensure modules maintain independent initialization status when composed together.

* **Tests**
  * Added comprehensive integration tests verifying initialization isolation across composed contracts.
  * Updated error message expectations in unit tests.

* **Documentation**
  * Added integration test suite documentation explaining test structure and expected behaviors.

* **Chores**
  * Added NPM scripts for running integration test workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->