### PR TITLE
ci(codeql): run analysis on post-release branch

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@ name: "CodeQL Analysis"
 
 on:
   push:
-    branches: [main]
+    branches: [main, post-release]
   pull_request:
-    branches: [main]
+    branches: [main, post-release]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Types of changes

What types of changes does your code introduce to OpenZeppelin Midnight Contracts?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

Add the `post-release` branch to the CodeQL `push` and `pull_request` triggers so security analysis runs there the same as on `main`.

Previously the [CodeQL workflow](https://github.com/OpenZeppelin/compact-contracts/blob/main/.github/workflows/codeql.yml#L4) only scanned `main`, leaving the `post-release` branch without CodeQL coverage.

## PR Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md#your-first-code-contribution)
- [ ] I have added tests that prove my fix is effective or that my feature works. See [GUIDELINES.md#testing](../GUIDELINES.md#testing) for more information.
- [ ] I have added documentation for new methods or changes to existing method behavior. See [GUIDELINES.md#documentation](../GUIDELINES.md#documentation) for more information.
- [ ] CI Workflows Are Passing

#### Further comments

CI-only change. No tests or docs apply.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CodeQL analysis workflow to run on additional branches, expanding code scanning coverage for improved quality assurance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->