### PR TITLE
ci(codeql): run analysis on post-release branch

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@ name: "CodeQL Analysis"
 
 on:
   push:
-    branches: [main]
+    branches: [main, post-release]
   pull_request:
-    branches: [main]
+    branches: [main, post-release]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Types of changes

What types of changes does your code introduce to OpenZeppelin Midnight Contracts?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

Add the `post-release` branch to the CodeQL `push` and `pull_request` triggers **on the `post-release` branch itself**.

For `pull_request` events, GitHub evaluates the workflow file from the PR's base branch. So for CodeQL to run on PRs targeting `post-release`, the trigger has to exist on `post-release`, not just `main`. This PR adds it here.

Companion to #563, which makes the same change on `main`.

## PR Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md#your-first-code-contribution)
- [ ] I have added tests that prove my fix is effective or that my feature works. See [GUIDELINES.md#testing](../GUIDELINES.md#testing) for more information.
- [ ] I have added documentation for new methods or changes to existing method behavior. See [GUIDELINES.md#documentation](../GUIDELINES.md#documentation) for more information.
- [ ] CI Workflows Are Passing

#### Further comments

CI-only change. No tests or docs apply.