### PR TITLE
Fix turbo in docs, remove global turbo install in CI and devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -20,6 +20,3 @@ RUN curl --proto '=https' --tlsv1.2 -LsSf https://github.com/midnightntwrk/compa
 
 # Add Compact CLI to the PATH
 ENV PATH="/root/.compact/bin:$PATH"
-
-# Install turbo for monorepo management
-RUN npm install --location=global turbo

--- a/.github/ISSUE_TEMPLATE/01_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/01_bug_report.yml
@@ -31,7 +31,7 @@ body:
       label: What are the steps to reproduce this issue?
       placeholder: |
         1. Clone repo
-        2. Run `turbo compact`
+        2. Run `yarn compact`
         3. …
         4. See error
     validations:

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -32,13 +32,6 @@ runs:
       shell: bash
       run: yarn install --immutable
 
-    - name: Install Turbo Globally
-      shell: bash
-      env:
-        TURBO_MAJOR_VERSION: 2
-        TURBO_TELEMETRY_DISABLED: 1
-      run: npm install turbo@${{ env.TURBO_MAJOR_VERSION }} -g
-
     - name: Setup Compact Compiler
       if: ${{ inputs.skip-compact != 'true' }}
       uses: midnightntwrk/setup-compact-action@836895c8fffbbea6bd986af2b17e8941ff29d1f8 # v1

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -33,4 +33,4 @@ jobs:
           skip-compact: "true"
 
       - name: Format & Lint
-        run: turbo fmt-and-lint:ci
+        run: yarn fmt-and-lint:ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
           compact-version: "0.29.0"
 
       - name: Build contracts
-        run: yarn turbo build
+        run: yarn build
 
       - name: Validate version consistency
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,10 +39,10 @@ jobs:
         uses: ./.github/actions/setup
 
       - name: Compile contracts
-        run: turbo compact --filter=@openzeppelin/compact-contracts
+        run: yarn compact --filter=@openzeppelin/compact-contracts
 
       - name: Run type checks
-        run: turbo types
+        run: yarn types
 
       - name: Run tests
-        run: turbo test
+        run: yarn test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
         uses: ./.github/actions/setup
 
       - name: Compile contracts
-        run: yarn compact --filter=@openzeppelin/compact-contracts
+        run: yarn compact
 
       - name: Run type checks
         run: yarn types

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -158,7 +158,7 @@ While the prerequisites above must be satisfied prior to having your pull reques
 
 All TypeScript code is linted with [Biomejs](https://biomejs.dev/).
 
-Quickly fix all formatting and linting errors with the `turbo fmt:fix` and `turbo lint:fix` commands.
+Quickly fix all formatting and linting errors with the `yarn fmt-and-lint:fix` command.
 
 ## Opening an issue
 

--- a/README.md
+++ b/README.md
@@ -199,7 +199,6 @@ make sure to check out the [contribution guide](CONTRIBUTING.md) in advance.
 >
 > - [Node.js](https://nodejs.org/)
 > - [Yarn](https://yarnpkg.com/getting-started/install)
-> - [Turbo](https://turborepo.com/docs/getting-started/installation)
 > - [Compact](https://docs.midnight.network/blog/compact-developer-tools)
 
 ### Set up the project
@@ -215,20 +214,20 @@ git clone git@github.com:OpenZeppelin/compact-contracts.git
 ```bash
 nvm install && \
 yarn && \
-turbo compact
+yarn compact
 ```
 
 ### Run tests
 
 ```bash
-turbo test
+yarn test
 ```
 
 ### Check/apply Biome formatter
 
 ```bash
-turbo fmt-and-lint
-turbo fmt-and-lint:fix
+yarn fmt-and-lint
+yarn fmt-and-lint:fix
 ```
 
 ### Advanced
@@ -236,8 +235,8 @@ turbo fmt-and-lint:fix
 #### Targeted compilation
 
 ```bash
-turbo compact:access
-turbo compact:archive
+yarn compact:access
+yarn compact:archive
 ...
 ```
 
@@ -246,11 +245,11 @@ turbo compact:archive
 ZK key generation is slow and usually unnecessary during development.
 
 ```bash
-# Individual module compilation (recommended for development)
-turbo compact:token  --filter=@openzeppelin/compact-contracts -- --skip-zk
-
 # Full compilation with skip-zk (use environment variable)
-SKIP_ZK=true turbo compact
+SKIP_ZK=true yarn compact
+
+# Access compilation with skip-zk (this compiles security first as a dependency)
+SKIP_ZK=true yarn compact:access
 ```
 
 #### Clean environment
@@ -258,13 +257,13 @@ SKIP_ZK=true turbo compact
 ```bash
 # WARNING!
 # These are destructive commands
-turbo clean
+yarn clean
 rm -rf .turbo/
 ```
 
 ### Troubleshooting
 
-- **Issues with turbo's cache?** Try cleaning: `turbo clean && rm -rf .turbo/`
+- **Issues with turbo's cache?** Try cleaning: `yarn clean && rm -rf .turbo/`
 - **Node version issues?** Use `nvm use` to switch to the correct version
 
 ## Security

--- a/package.json
+++ b/package.json
@@ -9,6 +9,11 @@
   ],
   "scripts": {
     "compact": "turbo run compact --filter=@openzeppelin/compact-contracts --log-prefix=none",
+    "compact:access": "turbo run compact:access --filter=@openzeppelin/compact-contracts --log-prefix=none",
+    "compact:archive": "turbo run compact:archive --filter=@openzeppelin/compact-contracts --log-prefix=none",
+    "compact:security": "turbo run compact:security --filter=@openzeppelin/compact-contracts --log-prefix=none",
+    "compact:token": "turbo run compact:token --filter=@openzeppelin/compact-contracts --log-prefix=none",
+    "compact:utils": "turbo run compact:utils --filter=@openzeppelin/compact-contracts --log-prefix=none",
     "build": "turbo run build --log-prefix=none",
     "test": "turbo run test --filter=@openzeppelin/compact-contracts --log-prefix=none",
     "fmt-and-lint": "biome check . --changed",


### PR DESCRIPTION
Fixes #572 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Replaced Turbo task runner with Yarn-based commands across development workflows, CI/CD pipelines, and container setup.

* **Documentation**
  * Updated development guides to use Yarn commands (`yarn compact`, `yarn test`, `yarn fmt-and-lint`) instead of Turbo equivalents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->