### PR TITLE
chore(release): v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.2.0 (2026-06-12)
+
+### Changed
+
+- **Breaking:** Each module now owns its `_isInitialized` ledger flag. The shared `Initializable__isInitialized` public ledger key is replaced by per-module keys (`Ownable__isInitialized`, `ZOwnablePK__isInitialized`, `ShieldedAccessControl__isInitialized`, `FungibleToken__isInitialized`, `NonFungibleToken__isInitialized`, `MultiToken__isInitialized`), fixing a state collision when two modules import the shared `Initializable` from the same directory (compiler [LFDT-Minokawa/compact#270](https://github.com/LFDT-Minokawa/compact/issues/270)). Fixes #556. (#562)
+- Replace the Turbo task runner with Yarn-based commands across the docs, CI workflows, and devcontainer. Fixes #572. (#576)
+- Batch Dependabot bumps for GitHub Actions and dev dependencies. (#553)
+
+## 0.1.0 (2026-06-05)
+
 ### Changes
 
 - Add defensive Buffer copy to ZOwnablePKWitnesses (#397)

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openzeppelin/compact-contracts",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "OpenZeppelin Compact contract library",
   "keywords": [
     "openzeppelin",

--- a/contracts/src/access/AccessControl.compact
+++ b/contracts/src/access/AccessControl.compact
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Compact Contracts v0.1.0 (access/AccessControl.compact)
+// OpenZeppelin Compact Contracts v0.2.0 (access/AccessControl.compact)
 
 pragma language_version >= 0.21.0;
 

--- a/contracts/src/access/Ownable.compact
+++ b/contracts/src/access/Ownable.compact
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Compact Contracts v0.1.0 (access/Ownable.compact)
+// OpenZeppelin Compact Contracts v0.2.0 (access/Ownable.compact)
 
 pragma language_version >= 0.21.0;
 

--- a/contracts/src/access/ShieldedAccessControl.compact
+++ b/contracts/src/access/ShieldedAccessControl.compact
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Compact Contracts v0.1.0 (access/ShieldedAccessControl.compact)
+// OpenZeppelin Compact Contracts v0.2.0 (access/ShieldedAccessControl.compact)
 
 pragma language_version >= 0.21.0;
 

--- a/contracts/src/access/ZOwnablePK.compact
+++ b/contracts/src/access/ZOwnablePK.compact
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Compact Contracts v0.1.0 (access/ZOwnablePK.compact)
+// OpenZeppelin Compact Contracts v0.2.0 (access/ZOwnablePK.compact)
 
 pragma language_version >= 0.21.0;
 

--- a/contracts/src/archive/ShieldedToken.compact
+++ b/contracts/src/archive/ShieldedToken.compact
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Compact Contracts v0.1.0 (archive/ShieldedToken.compact)
+// OpenZeppelin Compact Contracts v0.2.0 (archive/ShieldedToken.compact)
 
 pragma language_version >= 0.21.0;
 

--- a/contracts/src/security/Initializable.compact
+++ b/contracts/src/security/Initializable.compact
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Compact Contracts v0.1.0 (security/Initializable.compact)
+// OpenZeppelin Compact Contracts v0.2.0 (security/Initializable.compact)
 
 pragma language_version >= 0.21.0;
 

--- a/contracts/src/security/Pausable.compact
+++ b/contracts/src/security/Pausable.compact
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Compact Contracts v0.1.0 (security/Pausable.compact)
+// OpenZeppelin Compact Contracts v0.2.0 (security/Pausable.compact)
 
 pragma language_version >= 0.21.0;
 

--- a/contracts/src/token/FungibleToken.compact
+++ b/contracts/src/token/FungibleToken.compact
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Compact Contracts v0.1.0 (token/FungibleToken.compact)
+// OpenZeppelin Compact Contracts v0.2.0 (token/FungibleToken.compact)
 
 pragma language_version >= 0.21.0;
 

--- a/contracts/src/token/MultiToken.compact
+++ b/contracts/src/token/MultiToken.compact
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Compact Contracts v0.1.0 (token/MultiToken.compact)
+// OpenZeppelin Compact Contracts v0.2.0 (token/MultiToken.compact)
 
 pragma language_version >= 0.21.0;
 

--- a/contracts/src/token/NonFungibleToken.compact
+++ b/contracts/src/token/NonFungibleToken.compact
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Compact Contracts v0.1.0 (token/NonFungibleToken.compact)
+// OpenZeppelin Compact Contracts v0.2.0 (token/NonFungibleToken.compact)
 
 pragma language_version >= 0.21.0;
 

--- a/contracts/src/utils/Utils.compact
+++ b/contracts/src/utils/Utils.compact
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Compact Contracts v0.1.0 (utils/Utils.compact)
+// OpenZeppelin Compact Contracts v0.2.0 (utils/Utils.compact)
 
 pragma language_version >= 0.21.0;
 


### PR DESCRIPTION
## Types of changes

What types of changes does your code introduce to OpenZeppelin Midnight Contracts?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

Release **v0.2.0**, cutting the changes already merged to `main` since `v0.1.0`.

> **Why minor, not the originally-planned 0.1.1 patch:** #562 renames public ledger
> keys (`Initializable__isInitialized` → per-module keys). That is a breaking change
> for deployed contracts and consumers, so per semver this is a minor release. The
> release train (board + milestones) was renumbered accordingly.

### Included (release train: 0.2.0)

- **Breaking** — `fix(security)`: each module now owns its `_isInitialized` ledger flag;
  the shared `Initializable__isInitialized` key is replaced by per-module keys, fixing a
  same-directory state collision (compiler [#270](https://github.com/LFDT-Minokawa/compact/issues/270)). Ships #556. (#562)
- `docs`/`build`: replace the Turbo task runner with Yarn commands across docs, CI, and the devcontainer. Ships #572. (#576)
- `chore(deps)`: batched Dependabot bumps — GitHub Actions + dev dependencies. (#553)
- `ci`: run CodeQL on the post-release branch (#563); fix test-suite timeout cancellations (#554).

### Changes in this PR

- `CHANGELOG.md`: add the `0.2.0` section and backfill the missing `0.1.0` entry
  (its notes were stranded under "Unreleased" when v0.1.0 shipped).
- `Bump version to 0.2.0` — automated by `prepare-release.yml`: `contracts/package.json`
  plus version strings across `contracts/src/`.

## PR Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md#your-first-code-contribution)
- [x] I have added tests that prove my fix is effective or that my feature works. _(N/A for the release cut; feature tests landed with #562.)_
- [x] I have added documentation for new methods or changes to existing method behavior. _(CHANGELOG; docs cleanup in #576.)_
- [ ] CI Workflows Are Passing

#### Further comments

Release procedure per `RELEASING.md`. After merge: pull `main`, create and push tag
`v0.2.0`, then publish the GitHub Release (triggers the npm publish workflow), and push
`docs-v0.2.0` to deploy the docs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changed**
  * Bumped version to 0.2.0
  * **Breaking change**: Module-specific initialization flags now replace the shared initialization key
  * Migrated documentation and CI workflows from Turbo task runner to Yarn-based commands
  * Updated GitHub Actions and development dependencies via automated updates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->