### PR TITLE
feat(multisig): merge post-release suite to main

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -15,7 +15,7 @@ runs:
       run: corepack enable
 
     - name: Cache turbo build setup
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: .turbo
         key: ${{ runner.os }}-turbo-${{ github.sha }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@ name: "CodeQL Analysis"
 
 on:
   push:
-    branches: [main]
+    branches: [main, post-release]
   pull_request:
-    branches: [main]
+    branches: [main, post-release]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
-    timeout-minutes: 15
+    timeout-minutes: 30
 
     steps:
       - name: Harden Runner

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,7 @@ coverage
 *~
 
 *temp
+
+.claude/
+
+.states

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Signer module in multisig directory (#424)
+
 ### Changes
 
 - Add defensive Buffer copy to ZOwnablePKWitnesses (#397)

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -27,6 +27,7 @@
     "compact": "compact-compiler",
     "compact:access": "compact-compiler --dir access",
     "compact:archive": "compact-compiler --dir archive",
+    "compact:multisig": "compact-compiler --dir multisig",
     "compact:security": "compact-compiler --dir security",
     "compact:token": "compact-compiler --dir token",
     "compact:utils": "compact-compiler --dir utils",

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -33,6 +33,7 @@
     "compact:utils": "compact-compiler --dir utils",
     "build": "compact-builder",
     "test": "compact-compiler --skip-zk && vitest run",
+    "test:coverage": "compact-compiler --skip-zk && vitest run --coverage",
     "types": "tsc -p tsconfig.json --noEmit",
     "clean": "git clean -fXd"
   },
@@ -46,6 +47,8 @@
     "@openzeppelin-compact/contracts-simulator": "workspace:^",
     "@tsconfig/node24": "^24.0.4",
     "@types/node": "24.10.0",
+    "@vitest/coverage-v8": "^4.1.6",
+    "fast-check": "^3.23.2",
     "ts-node": "^10.9.2",
     "typescript": "^5.9.3",
     "vitest": "^4.1.2"

--- a/contracts/src/multisig/Forwarder.compact
+++ b/contracts/src/multisig/Forwarder.compact
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Compact Contracts v0.0.1-alpha.1 (multisig/Forwarder.compact)
+
+pragma language_version >= 0.21.0;
+
+/**
+ * @module Forwarder
+ * @description Public-parent forwarder primitives. Provides an atomic
+ * forward pattern: receive a coin (shielded or unshielded) and
+ * immediately send it to a hard-coded parent address.
+ *
+ * The module is generic over the parent's address type `T`. Each preset
+ * specializes it to the address kind it forwards to: `ForwarderShielded`
+ * uses `ZswapCoinPublicKey`, `ForwarderUnshielded` uses `UserAddress`.
+ * Storing the parent as a typed value rather than raw `Bytes<32>` forces
+ * every deployer to supply the correct address kind for the coin type.
+ *
+ * Underscore-prefixed circuits have no access control. The forwarder is
+ * intentionally permissionless — the recipient is hard-coded at deploy,
+ * so any caller may deposit without compromising the parent. State
+ * access is gated by the `Initializable` module: every circuit asserts
+ * the module has been initialized via `initialize`.
+ */
+module Forwarder<T> {
+  import CompactStandardLibrary;
+  import "../security/Initializable" prefix Initializable_;
+
+  // ─── State ──────────────────────────────────────────────────────
+
+  export sealed ledger _parent: T;
+
+  // ─── Init ───────────────────────────────────────────────────────
+
+  /**
+   * @description Initializes the forwarder with a parent address.
+   * Called once from the preset constructor. The parent is the
+   * recipient of every forwarded coin and is immutable after init.
+   *
+   * Requirements:
+   *
+   * - Contract must not be initialized.
+   * - `parent` must not be the zero address. A zero parent would
+   *   forward every deposit to an unspendable address with no recovery
+   *   path.
+   *
+   * @param {T} parent - The parent address. Typed per the specializing
+   * preset: `ZswapCoinPublicKey` for shielded, `UserAddress` for
+   * unshielded.
+   *
+   * @returns {[]} Empty tuple.
+   */
+  export circuit initialize(parent: T): [] {
+    assert(parent != default<T>, "Forwarder: zero parent");
+    Initializable_initialize();
+    _parent = disclose(parent);
+  }
+
+  // ─── Deposit ────────────────────────────────────────────────────
+
+  /**
+   * @description Receives a shielded coin and atomically forwards it
+   * to `_parent`. The coin is claimed at the protocol level via
+   * `receiveShielded`, then immediately re-sent via
+   * `sendImmediateShielded`. The parent's bytes are wrapped as a
+   * `ZswapCoinPublicKey` recipient at the send site.
+   *
+   * @circuitInfo k=15, rows=18573
+   *
+   * Requirements:
+   *
+   * - Contract must be initialized.
+   *
+   * @param {ShieldedCoinInfo} coin - The incoming shielded coin.
+   *
+   * @returns {[]} Empty tuple.
+   */
+  export circuit _depositShielded(coin: ShieldedCoinInfo): [] {
+    Initializable_assertInitialized();
+    receiveShielded(disclose(coin));
+    sendImmediateShielded(
+      disclose(coin),
+      left<ZswapCoinPublicKey, ContractAddress>(ZswapCoinPublicKey { bytes: _parent.bytes }),
+      disclose(coin.value)
+    );
+  }
+
+  /**
+   * @description Receives an unshielded amount of `color` and
+   * atomically forwards it to `_parent`. The parent's bytes are
+   * wrapped as a `UserAddress` recipient at the send site.
+   *
+   * @circuitInfo k=9, rows=436
+   *
+   * Requirements:
+   *
+   * - Contract must be initialized.
+   *
+   * @param {Bytes<32>} color - The token color.
+   * @param {Uint<128>} amount - The amount to deposit.
+   *
+   * @returns {[]} Empty tuple.
+   */
+  export circuit _depositUnshielded(color: Bytes<32>, amount: Uint<128>): [] {
+    Initializable_assertInitialized();
+    receiveUnshielded(disclose(color), disclose(amount));
+    sendUnshielded(
+      disclose(color),
+      disclose(amount),
+      right<ContractAddress, UserAddress>(UserAddress { bytes: _parent.bytes })
+    );
+  }
+}

--- a/contracts/src/multisig/ForwarderPrivate.compact
+++ b/contracts/src/multisig/ForwarderPrivate.compact
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Compact Contracts v0.0.1-alpha.1 (multisig/ForwarderPrivate.compact)
+
+pragma language_version >= 0.21.0;
+
+/**
+ * @module ForwarderPrivate
+ * @description Private-parent forwarder primitives. The parent address
+ * is hidden behind a `persistentHash` commitment on the ledger.
+ * Deposits accumulate at the contract (no atomic forward); the operator
+ * drains coins by presenting the `(parentAddr, opSecret)` preimage at drain
+ * time.
+ *
+ * Knowledge of the preimage is the sole authorization gate — there is
+ * no signer set and no nullifier scheme. The operational secret is
+ * held off-chain; the contract never sees it except during a drain.
+ * Two forwarders bound to the same parent with different operational
+ * secrets produce different commitments and are unlinkable on-chain.
+ *
+ * Underscore-prefixed circuits have no access control beyond the
+ * preimage check inside `_drain`. State access is gated by the
+ * `Initializable` module: every state-touching circuit asserts the
+ * module has been initialized via `initialize`. The pure
+ * `_calculateParentCommitment` helper does not access state and is
+ * intentionally callable without initialization.
+ */
+module ForwarderPrivate {
+  import CompactStandardLibrary;
+  import "../security/Initializable" prefix Initializable_;
+  import "../utils/Utils" prefix Utils_;
+
+  // ─── State ──────────────────────────────────────────────────────
+
+  export sealed ledger _parentCommitment: Bytes<32>;
+
+  // ─── Init ───────────────────────────────────────────────────────
+
+  /**
+   * @description Initializes the forwarder with a parent commitment.
+   * Called once from the preset constructor. The commitment is
+   * immutable after init.
+   *
+   * Requirements:
+   *
+   * - Contract must not be initialized.
+   * - `parentCommitment` must not be the zero bytes. A zero commitment
+   *   is the sole drain gate and would leave every deposited coin
+   *   permanently unrecoverable (no preimage exists for `default<Bytes<32>>`
+   *   under the domain-tagged hash).
+   *
+   * @param {Bytes<32>} parentCommitment - Domain-tagged
+   * `persistentHash([pad(32, "ForwarderPrivate:commitment"), parentAddr, opSecret])`
+   * computed off-chain by the deployer (see `_calculateParentCommitment`).
+   *
+   * @returns {[]} Empty tuple.
+   */
+  export circuit initialize(parentCommitment: Bytes<32>): [] {
+    assert(parentCommitment != default<Bytes<32>>, "ForwarderPrivate: zero commitment");
+    Initializable_initialize();
+    _parentCommitment = disclose(parentCommitment);
+  }
+
+  // ─── Deposit ────────────────────────────────────────────────────
+
+  /**
+   * @description Receives a shielded coin into the forwarder's custody.
+   * No ledger write — coins dwell at the contract address until drained.
+   *
+   * @circuitInfo k=13, rows=6538
+   *
+   * Requirements:
+   *
+   * - Contract must be initialized.
+   *
+   * @param {ShieldedCoinInfo} coin - The incoming shielded coin.
+   *
+   * @returns {[]} Empty tuple.
+   */
+  export circuit _deposit(coin: ShieldedCoinInfo): [] {
+    Initializable_assertInitialized();
+    receiveShielded(disclose(coin));
+  }
+
+  // ─── Drain ──────────────────────────────────────────────────────
+
+  /**
+   * @description Spends a previously-deposited shielded coin to
+   * `parentAddr`. The caller proves knowledge of `(parentAddr, opSecret)`
+   * matching the stored commitment. If `coin.value` exceeds `value`,
+   * the change is re-emitted back to the contract for future drains.
+   *
+   * @circuitInfo k=16, rows=47811
+   *
+   * Requirements:
+   *
+   * - Contract must be initialized.
+   * - `_calculateParentCommitment(parentAddr, opSecret) == _parentCommitment`.
+   * - `coin.value` must be >= `value` (enforced by `sendShielded`).
+   *
+   * @param {QualifiedShieldedCoinInfo} coin - The coin to spend.
+   * @param {Bytes<32>} parentAddr - The parent address. Preimage to the
+   * stored commitment.
+   * @param {Bytes<32>} opSecret - The operational secret. Never appears
+   * on the public transcript.
+   *
+   * @warning **Losing the operational secret is permanent fund loss.** It
+   * is the sole drain authorization, with no rotation, revocation, or
+   * recovery path. If the operator misplaces it, every shielded coin
+   * accumulated at this contract is forever inaccessible, equivalent to
+   * losing a hot-wallet private key. Back it up offline before the first
+   * deposit and treat it with the same hygiene as a signing key.
+   *
+   * @param {Uint<128>} value - The amount to send.
+   *
+   * @returns {ShieldedSendResult} The result containing the sent coin
+   * and any change.
+   */
+  export circuit _drain(
+    coin: QualifiedShieldedCoinInfo,
+    parentAddr: Bytes<32>,
+    opSecret: Bytes<32>,
+    value: Uint<128>
+  ): ShieldedSendResult {
+    Initializable_assertInitialized();
+    assert(
+      _calculateParentCommitment(parentAddr, opSecret) == _parentCommitment,
+      "ForwarderPrivate: invalid parent"
+    );
+
+    const result = sendShielded(
+      disclose(coin),
+      right<ZswapCoinPublicKey, ContractAddress>(ContractAddress { bytes: disclose(parentAddr) }),
+      disclose(value)
+    );
+
+    if (disclose(result.change.is_some)) {
+      sendImmediateShielded(
+        disclose(result.change.value),
+        Utils_selfAsRecipient(),
+        disclose(result.change.value.value)
+      );
+    }
+
+    return result;
+  }
+
+  // ─── Pure helpers ───────────────────────────────────────────────
+
+  /**
+   * @description Computes the parent commitment from `(parentAddr, opSecret)`.
+   * Pure circuit — used off-chain by the deployer to compute the
+   * constructor argument, and inside `_drain` for the preimage check.
+   * Callable without initialization.
+   *
+   * The first hash input is a fixed domain tag
+   * (`pad(32, "ForwarderPrivate:commitment")`). The tag prevents
+   * preimage collisions with other `persistentHash` users in the
+   * system that hash two `Bytes<32>` values — a colliding preimage
+   * crafted under a different domain cannot satisfy this commitment.
+   *
+   * @param {Bytes<32>} parentAddr - The parent address.
+   * @param {Bytes<32>} opSecret - The operational secret.
+   *
+   * @returns {Bytes<32>} `persistentHash([pad(32, "ForwarderPrivate:commitment"), parentAddr, opSecret])`.
+   */
+  export pure circuit _calculateParentCommitment(
+    parentAddr: Bytes<32>,
+    opSecret: Bytes<32>
+  ): Bytes<32> {
+    return persistentHash<Vector<3, Bytes<32>>>(
+      [pad(32, "ForwarderPrivate:commitment"), parentAddr, opSecret]
+    );
+  }
+}

--- a/contracts/src/multisig/ProposalManager.compact
+++ b/contracts/src/multisig/ProposalManager.compact
@@ -1,0 +1,328 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Compact Contracts v0.0.1-alpha.1 (multisig/ProposalManager.compact)
+
+pragma language_version >= 0.21.0;
+
+/**
+ * @module ProposalManager
+ * @description Token-agnostic proposal lifecycle management for multisig
+ * governance contracts.
+ *
+ * Supports shielded and unshielded proposals through a unified
+ * Recipient type with a RecipientKind tag. Typed helper circuits
+ * provide safe construction of recipients without exposing the
+ * internal Bytes<32> representation to consumers.
+ */
+module ProposalManager {
+  import CompactStandardLibrary;
+
+  // ─── Types ──────────────────────────────────────────────────────
+
+  export enum ProposalStatus {
+    Inactive,
+    Active,
+    Executed,
+    Cancelled
+  }
+
+  export enum RecipientKind {
+    ShieldedUser,
+    UnshieldedUser,
+    Contract
+  }
+
+  export struct Recipient {
+    kind: RecipientKind,
+    address: Bytes<32>
+  }
+
+  export struct Proposal {
+    to: Recipient,
+    color: Bytes<32>,
+    amount: Uint<128>,
+    status: ProposalStatus
+  }
+
+  // ─── State ──────────────────────────────────────────────────────
+
+  export ledger _nextProposalId: Counter;
+  export ledger _proposals: Map<Uint<64>, Proposal>;
+
+  // ─── Recipient Helpers ──────────────────────────────────────────
+
+  /**
+   * @description Constructs a shielded user recipient.
+   *
+   * @param {ZswapCoinPublicKey} key - The shielded recipient's public key.
+   *
+   * @returns {Recipient} The typed recipient.
+   */
+  export circuit shieldedUserRecipient(key: ZswapCoinPublicKey): Recipient {
+    return Recipient { kind: RecipientKind.ShieldedUser, address: key.bytes };
+  }
+
+  /**
+   * @description Constructs an unshielded user recipient.
+   *
+   * @param {UserAddress} addr - The unshielded recipient's address.
+   *
+   * @returns {Recipient} The typed recipient.
+   */
+  export circuit unshieldedUserRecipient(addr: UserAddress): Recipient {
+    return Recipient { kind: RecipientKind.UnshieldedUser, address: addr.bytes };
+  }
+
+  /**
+   * @description Constructs a contract recipient.
+   *
+   * @param {ContractAddress} addr - The contract address.
+   *
+   * @returns {Recipient} The typed recipient.
+   */
+  export circuit contractRecipient(addr: ContractAddress): Recipient {
+    return Recipient { kind: RecipientKind.Contract, address: addr.bytes };
+  }
+
+  /**
+   * @description Converts a Recipient to a shielded send recipient.
+   * Handles both ShieldedUser and Contract kinds.
+   *
+   * Requirements:
+   *
+   * - Recipient kind must be ShieldedUser or Contract.
+   *
+   * @param {Recipient} r - The recipient.
+   *
+   * @returns {Either<ZswapCoinPublicKey, ContractAddress>} The shielded recipient.
+   */
+  export circuit toShieldedRecipient(r: Recipient): Either<ZswapCoinPublicKey, ContractAddress> {
+    if (r.kind == RecipientKind.ShieldedUser) {
+      return left<ZswapCoinPublicKey, ContractAddress>(
+        ZswapCoinPublicKey { bytes: r.address }
+      );
+    }
+    assert(r.kind == RecipientKind.Contract, "ProposalManager: invalid shielded recipient");
+    return right<ZswapCoinPublicKey, ContractAddress>(
+      ContractAddress { bytes: r.address }
+    );
+  }
+
+  /**
+   * @description Converts a Recipient to an unshielded send recipient.
+   * Handles both UnshieldedUser and Contract kinds.
+   *
+   * Requirements:
+   *
+   * - Recipient kind must be UnshieldedUser or Contract.
+   *
+   * @param {Recipient} r - The recipient.
+   *
+   * @returns {Either<ContractAddress, UserAddress>} The unshielded recipient.
+   */
+  export circuit toUnshieldedRecipient(r: Recipient): Either<ContractAddress, UserAddress> {
+    if (r.kind == RecipientKind.Contract) {
+      return left<ContractAddress, UserAddress>(
+        ContractAddress { bytes: r.address }
+      );
+    }
+    assert(r.kind == RecipientKind.UnshieldedUser, "ProposalManager: invalid unshielded recipient");
+    return right<ContractAddress, UserAddress>(
+      UserAddress { bytes: r.address }
+    );
+  }
+
+  // ─── Guards ─────────────────────────────────────────────────────
+
+  /**
+   * @description Asserts that a proposal exists.
+   *
+   * Requirements:
+   *
+   * - Proposal with `id` must have been created.
+   *
+   * @param {Uint<64>} id - The proposal ID.
+   *
+   * @returns {[]} Empty tuple.
+   */
+  export circuit assertProposalExists(id: Uint<64>): [] {
+    assert(
+      _proposals.member(disclose(id)),
+      "ProposalManager: proposal not found"
+    );
+  }
+
+  /**
+   * @description Asserts that a proposal exists and is active.
+   *
+   * Requirements:
+   *
+   * - Proposal must exist.
+   * - Proposal status must be Active.
+   *
+   * @param {Uint<64>} id - The proposal ID.
+   *
+   * @returns {[]} Empty tuple.
+   */
+  export circuit assertProposalActive(id: Uint<64>): [] {
+    assertProposalExists(id);
+    assert(
+      _proposals.lookup(disclose(id)).status == ProposalStatus.Active,
+      "ProposalManager: proposal not active"
+    );
+  }
+
+  // ─── Proposal Lifecycle ─────────────────────────────────────────
+
+  /**
+   * @description Creates a new proposal.
+   *
+   * @notice Access control is NOT enforced here.
+   * The consuming contract must gate this behind its own
+   * authorization policy.
+   *
+   * Requirements:
+   *
+   * - `amount` must be greater than 0.
+   *
+   * @param {Recipient} to - The recipient (constructed via helper circuits).
+   * @param {Bytes<32>} color - The token color.
+   * @param {Uint<128>} amount - The amount to transfer.
+   *
+   * @returns {Uint<64>} The new proposal ID.
+   */
+  export circuit _createProposal(
+    to: Recipient,
+    color: Bytes<32>,
+    amount: Uint<128>
+  ): Uint<64> {
+    assert(amount > 0, "ProposalManager: zero amount");
+
+    _nextProposalId.increment(1);
+    const id = _nextProposalId;
+
+    _proposals.insert(id, disclose(Proposal {
+      to: to,
+      color: color,
+      amount: amount,
+      status: ProposalStatus.Active
+    }));
+
+    return id;
+  }
+
+  /**
+   * @description Cancels a proposal.
+   *
+   * @notice Access control is NOT enforced here.
+   * The consuming contract must gate this behind its own
+   * authorization policy.
+   *
+   * Requirements:
+   *
+   * - Proposal must be active.
+   *
+   * @param {Uint<64>} id - The proposal ID.
+   *
+   * @returns {[]} Empty tuple.
+   */
+  export circuit _cancelProposal(id: Uint<64>): [] {
+    assertProposalActive(id);
+
+    const proposal = _proposals.lookup(disclose(id));
+    _proposals.insert(disclose(id), Proposal {
+      to: proposal.to,
+      color: proposal.color,
+      amount: proposal.amount,
+      status: ProposalStatus.Cancelled
+    });
+  }
+
+  /**
+   * @description Marks a proposal as executed.
+   *
+   * @notice Access control is NOT enforced here.
+   * The consuming contract must gate this behind its own
+   * authorization policy.
+   *
+   * Requirements:
+   *
+   * - Proposal must be active.
+   *
+   * @param {Uint<64>} id - The proposal ID.
+   *
+   * @returns {[]} Empty tuple.
+   */
+  export circuit _markExecuted(id: Uint<64>): [] {
+    assertProposalActive(id);
+
+    const proposal = _proposals.lookup(disclose(id));
+    _proposals.insert(disclose(id), Proposal {
+      to: proposal.to,
+      color: proposal.color,
+      amount: proposal.amount,
+      status: ProposalStatus.Executed
+    });
+  }
+
+  // ─── View ───────────────────────────────────────────────────────
+
+  /**
+   * @description Returns the full proposal data.
+   *
+   * @param {Uint<64>} id - The proposal ID.
+   *
+   * @returns {Proposal} The proposal.
+   */
+  export circuit getProposal(id: Uint<64>): Proposal {
+    assertProposalExists(id);
+    return _proposals.lookup(disclose(id));
+  }
+
+  /**
+   * @description Returns the recipient of a proposal.
+   *
+   * @param {Uint<64>} id - The proposal ID.
+   *
+   * @returns {Recipient} The recipient.
+   */
+  export circuit getProposalRecipient(id: Uint<64>): Recipient {
+    assertProposalExists(id);
+    return _proposals.lookup(disclose(id)).to;
+  }
+
+  /**
+   * @description Returns the amount of a proposal.
+   *
+   * @param {Uint<64>} id - The proposal ID.
+   *
+   * @returns {Uint<128>} The amount.
+   */
+  export circuit getProposalAmount(id: Uint<64>): Uint<128> {
+    assertProposalExists(id);
+    return _proposals.lookup(disclose(id)).amount;
+  }
+
+  /**
+   * @description Returns the token color of a proposal.
+   *
+   * @param {Uint<64>} id - The proposal ID.
+   *
+   * @returns {Bytes<32>} The token color.
+   */
+  export circuit getProposalColor(id: Uint<64>): Bytes<32> {
+    assertProposalExists(id);
+    return _proposals.lookup(disclose(id)).color;
+  }
+
+  /**
+   * @description Returns the status of a proposal.
+   *
+   * @param {Uint<64>} id - The proposal ID.
+   *
+   * @returns {ProposalStatus} The proposal status.
+   */
+  export circuit getProposalStatus(id: Uint<64>): ProposalStatus {
+    assertProposalExists(id);
+    return _proposals.lookup(disclose(id)).status;
+  }
+}

--- a/contracts/src/multisig/ShieldedTreasury.compact
+++ b/contracts/src/multisig/ShieldedTreasury.compact
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Compact Contracts v0.0.1-alpha.1 (multisig/ShieldedTreasury.compact)
+
+pragma language_version >= 0.21.0;
+
+/**
+ * @module ShieldedTreasury
+ * @description Manages shielded (private) token deposits, accounting,
+ * and transfers for multisig governance contracts.
+ *
+ * Coins are stored on the contract ledger in a map keyed by token color,
+ * with one UTXO per color. Deposits are merged with existing coins of
+ * the same color via `mergeCoinImmediate`. This simplifies coin selection
+ * at spend time — the executor doesn't need to choose between multiple
+ * UTXOs of the same color.
+ *
+ * Cumulative received and sent totals are tracked per color for audit
+ * purposes. The canonical balance query is `getTokenBalance`, which
+ * reads the actual coin value from the UTXO map.
+ *
+ * Underscore-prefixed circuits (_deposit, _send) have no access control
+ * enforcement. The consuming contract must gate these behind its own
+ * authorization policy.
+ */
+module ShieldedTreasury {
+  import CompactStandardLibrary;
+  import { selfAsRecipient, UINT128_MAX } from "../utils/Utils" prefix Utils_;
+
+  // ─── State ──────────────────────────────────────────────────────
+
+  export ledger _coins: Map<Bytes<32>, QualifiedShieldedCoinInfo>;
+  export ledger _received: Map<Bytes<32>, Uint<128>>;
+  export ledger _sent: Map<Bytes<32>, Uint<128>>;
+
+  // ─── Deposit ────────────────────────────────────────────────────
+
+  /**
+   * @description Receives a shielded coin into the treasury.
+   *
+   * The coin is first claimed at the protocol level via `receiveShielded`,
+   * which allocates the Merkle tree index required by `insertCoin`.
+   * The coin is then merged with any existing coin of the same color,
+   * or inserted as a new entry if no coin of that color exists.
+   *
+   * Zero-value deposits are permitted. While currently a no-op
+   * economically, they may serve as signaling mechanisms when events
+   * are supported, or as decoy transactions for privacy.
+   *
+   * @notice Access control is NOT enforced here.
+   * The consuming contract must gate this behind its own
+   * authorization policy.
+   *
+   * Requirements:
+   *
+   * - Deposit must not cause received total overflow.
+   *
+   * @param {ShieldedCoinInfo} coin - The incoming shielded coin descriptor.
+   *
+   * @returns {[]} Empty tuple.
+   */
+  export circuit _deposit(coin: ShieldedCoinInfo): [] {
+    const currentReceived = getReceivedTotal(coin.color);
+    assert(currentReceived <= Utils_UINT128_MAX() - coin.value, "ShieldedTreasury: overflow");
+
+    receiveShielded(disclose(coin));
+
+    const coinColor = disclose(coin.color);
+
+    if (_coins.member(coinColor)) {
+      const merged = mergeCoinImmediate(_coins.lookup(coinColor), disclose(coin));
+      _coins.insertCoin(coinColor, merged, Utils_selfAsRecipient());
+    } else {
+      _coins.insertCoin(coinColor, disclose(coin), Utils_selfAsRecipient());
+    }
+
+    _received.insert(
+      coinColor,
+      disclose(currentReceived + coin.value as Uint<128>)
+    );
+  }
+
+  // ─── Send ───────────────────────────────────────────────────────
+
+  /**
+   * @description Sends shielded tokens from the treasury.
+   *
+   * Looks up the stored coin by color, verifies sufficient value,
+   * and executes the shielded send. If the send produces change,
+   * it is sent back to the contract via `sendImmediateShielded`.
+   *
+   * @notice Access control is NOT enforced here.
+   * The consuming contract must gate this behind its own
+   * authorization policy.
+   *
+   * Requirements:
+   *
+   * - A coin of the given `color` must exist in the treasury.
+   * - The coin's value must be >= `amount`.
+   * - Send must not cause sent total overflow.
+   *
+   * @param {Either<ZswapCoinPublicKey, ContractAddress>} recipient - The recipient.
+   * @param {Bytes<32>} color - The token color.
+   * @param {Uint<128>} amount - The amount to send.
+   *
+   * @returns {ShieldedSendResult} The result containing sent coin and any change.
+   */
+  export circuit _send(
+    recipient: Either<ZswapCoinPublicKey, ContractAddress>,
+    color: Bytes<32>,
+    amount: Uint<128>
+  ): ShieldedSendResult {
+    assert(_coins.member(disclose(color)), "ShieldedTreasury: no balance");
+
+    const coin = _coins.lookup(disclose(color));
+    assert(coin.value >= amount, "ShieldedTreasury: coin value insufficient");
+
+    const currentSent = getSentTotal(color);
+    assert(currentSent <= Utils_UINT128_MAX() - amount, "ShieldedTreasury: overflow");
+
+    const result = sendShielded(coin, disclose(recipient), disclose(amount));
+
+    if (disclose(result.change.is_some)) {
+      const changeCoin = result.change.value;
+      sendImmediateShielded(
+        changeCoin,
+        Utils_selfAsRecipient(),
+        changeCoin.value
+      );
+      _coins.insertCoin(disclose(color), changeCoin, Utils_selfAsRecipient());
+    } else {
+      _coins.remove(disclose(color));
+    }
+
+    _sent.insert(
+      disclose(color),
+      disclose(currentSent + amount as Uint<128>)
+    );
+
+    return result;
+  }
+
+  // ─── View ───────────────────────────────────────────────────────
+
+  /**
+   * @description Returns the current token balance for a color.
+   * Reads the actual coin value from the UTXO map.
+   *
+   * @param {Bytes<32>} color - The token color.
+   *
+   * @returns {Uint<128>} The current balance.
+   */
+  export circuit getTokenBalance(color: Bytes<32>): Uint<128> {
+    if (!_coins.member(disclose(color))) {
+      return 0;
+    }
+    return _coins.lookup(disclose(color)).value;
+  }
+
+  // ─── Accounting ─────────────────────────────────────────────────
+
+  /**
+   * @description Returns the cumulative received total for a color.
+   *
+   * @param {Bytes<32>} color - The token color.
+   *
+   * @returns {Uint<128>} Total received.
+   */
+  export circuit getReceivedTotal(color: Bytes<32>): Uint<128> {
+    if (!_received.member(disclose(color))) {
+      return 0;
+    }
+    return _received.lookup(disclose(color));
+  }
+
+  /**
+   * @description Returns the cumulative sent total for a color.
+   *
+   * @param {Bytes<32>} color - The token color.
+   *
+   * @returns {Uint<128>} Total sent.
+   */
+  export circuit getSentTotal(color: Bytes<32>): Uint<128> {
+    if (!_sent.member(disclose(color))) {
+      return 0;
+    }
+    return _sent.lookup(disclose(color));
+  }
+
+  /**
+   * @description Returns the difference between cumulative received
+   * and cumulative sent totals for a color. Should equal
+   * `getTokenBalance` if accounting is consistent.
+   *
+   * @param {Bytes<32>} color - The token color.
+   *
+   * @returns {Uint<128>} Received minus sent.
+   */
+  export circuit getReceivedMinusSent(color: Bytes<32>): Uint<128> {
+    return getReceivedTotal(color) - getSentTotal(color) as Uint<128>;
+  }
+}

--- a/contracts/src/multisig/ShieldedTreasuryStateless.compact
+++ b/contracts/src/multisig/ShieldedTreasuryStateless.compact
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Compact Contracts v0.0.1-alpha.1 (multisig/ShieldedTreasuryStateless.compact)
+
+pragma language_version >= 0.21.0;
+
+/**
+ * @module ShieldedTreasury
+ * @description Manages shielded (private) token deposits, accounting,
+ * and transfers for multisig governance contracts.
+ *
+ * Coins are stored on the contract ledger in a map keyed by token color,
+ * with one UTXO per color. Deposits are merged with existing coins of
+ * the same color via `mergeCoinImmediate`. This simplifies coin selection
+ * at spend time — the executor doesn't need to choose between multiple
+ * UTXOs of the same color.
+ *
+ * Cumulative received and sent totals are tracked per color for audit
+ * purposes. The canonical balance query is `getTokenBalance`, which
+ * reads the actual coin value from the UTXO map.
+ */
+module ShieldedTreasuryStateless {
+  import CompactStandardLibrary;
+  import { selfAsRecipient } from "../utils/Utils" prefix Utils_;
+
+  // ─── Deposit ────────────────────────────────────────────────────
+
+  /**
+   * @description Receives a shielded coin into the treasury.
+   */
+  export circuit _deposit(coin: ShieldedCoinInfo): [] {
+    receiveShielded(disclose(coin));
+  }
+
+  // ─── Send ───────────────────────────────────────────────────────
+
+  /**
+   * @description Sends shielded tokens using a caller-provided coin.
+   *
+   * The coin is supplied by the caller rather than looked up from
+   * on-chain state; the token color is derived from `coin.color`.
+   * Executes the shielded send and, if change is produced, returns it
+   * to the contract via `sendImmediateShielded`. No balance or
+   * received/sent accounting is tracked on the ledger.
+   *
+   * @notice Access control is NOT enforced here.
+   * The consuming contract must gate this behind its own
+   * authorization policy.
+   *
+   * Requirements:
+   *
+   * - `coin.value` must be >= `amount`.
+   *
+   * @param {QualifiedShieldedCoinInfo} coin - The coin to spend (provided by the caller).
+   * @param {Either<ZswapCoinPublicKey, ContractAddress>} recipient - The recipient.
+   * @param {Uint<128>} amount - The amount to send.
+   *
+   * @returns {ShieldedSendResult} The result containing sent coin and any change.
+   */
+  export circuit _send(
+    coin: QualifiedShieldedCoinInfo,
+    recipient: Either<ZswapCoinPublicKey, ContractAddress>,
+    amount: Uint<128>
+  ): ShieldedSendResult {
+    const result = sendShielded(disclose(coin), disclose(recipient), disclose(amount));
+
+    if (disclose(result.change.is_some)) {
+      sendImmediateShielded(
+        disclose(result.change.value),
+        Utils_selfAsRecipient(),
+        disclose(result.change.value.value)
+      );
+    }
+
+    return result;
+  }
+}

--- a/contracts/src/multisig/Signer.compact
+++ b/contracts/src/multisig/Signer.compact
@@ -1,0 +1,277 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Compact Contracts v0.0.1-alpha.1 (multisig/Signer.compact)
+
+pragma language_version >= 0.21.0;
+
+/**
+ * @module Signer<T>
+ * @description Manages signer registry, threshold enforcement, and signer
+ * validation for multisig governance contracts.
+ *
+ * Parameterized over the signer identity type `T`, allowing the consuming
+ * contract to choose the identity mechanism at import time. Common
+ * instantiations include:
+ *
+ * - `Bytes<32>` for commitment-based identity (e.g., hash of ECDSA public key)
+ * - `JubjubPoint` for Schnorr/MuSig aggregated key
+ *
+ * The Signer module does not resolve caller identity. It receives a validated
+ * caller from the contract layer and checks it against the registry.
+ * This separation allows the identity mechanism to change without
+ * modifying the module.
+ *
+ * The signer count and threshold are of type `Uint<8>`, limiting the
+ * maximum number of signers and threshold to 255. This is sufficient
+ * for any practical multisig use case. For large-scale governance
+ * requiring more signers, consider a Merkle tree-based variant.
+ *
+ * Multi-step signer reconfigurations (e.g., removing a signer and
+ * lowering the threshold) may produce intermediate states where the
+ * module's invariants temporarily hold but the contract's intended
+ * configuration is incomplete. This is a contract-layer concern.
+ * Contracts should either perform reconfigurations atomically in a
+ * single circuit or use a configuration nonce to invalidate proposals
+ * created under a stale signer set.
+ *
+ * Underscore-prefixed circuits (_addSigner, _removeSigner,
+ * _changeThreshold) have no access control enforcement. The consuming
+ * contract must gate these behind its own authorization policy.
+ *
+ * Contracts may handle their own initialization and this module
+ * supports custom flows. Thus, contracts may choose to not
+ * call `initialize` in the contract's constructor. Contracts MUST NOT
+ * call `initialize` outside of the constructor context because
+ * this could corrupt the signer set and threshold configuration.
+ */
+module Signer<T> {
+  import CompactStandardLibrary;
+  import "../security/Initializable" prefix Initializable_;
+
+  // ─── State ──────────────────────────────────────────────────────────────────
+
+  export ledger _signers: Set<T>;
+  export ledger _signerCount: Uint<8>;
+  export ledger _threshold: Uint<8>;
+
+  // ─── Initialization ─────────────────────────────────────────────────────────
+
+  /**
+   * @description Initializes the signer module with the given threshold
+   * and an initial set of signers.
+   * If used, it should only be called in the contract's constructor.
+   *
+   * @circuitInfo k=11, rows=1815
+   *
+   * Requirements:
+   *
+   * - If used, can only be called once (in the constructor).
+   * - `thresh` must not be zero.
+   * - `thresh` must not exceed the number of `signers`.
+   * - `signers` must not contain duplicates.
+   *
+   * @param {Vector<n, T>} signers - The initial signer set.
+   * @param {Uint<8>} thresh - The minimum number of approvals required.
+   * @returns {[]} Empty tuple.
+   */
+  export circuit initialize<#n>(
+    signers: Vector<n, T>,
+    thresh: Uint<8>
+  ): [] {
+    Initializable_initialize();
+
+    for (const signer of signers) {
+      _addSigner(signer);
+    }
+
+    _changeThreshold(thresh);
+  }
+
+  // ─── Guards ─────────────────────────────────────────────────────────────
+
+  /**
+   * @description Asserts that the given caller is an active signer.
+   *
+   * @circuitInfo k=10, rows=585
+   *
+   * Requirements:
+   *
+   * - Contract must be initialized.
+   * - `caller` must be a member of the signers registry.
+   *
+   * @param {T} caller - The identity to validate.
+   * @returns {[]} Empty tuple.
+   */
+  export circuit assertSigner(caller: T): [] {
+    Initializable_assertInitialized();
+    assert(isSigner(caller), "Signer: not a signer");
+  }
+
+  /**
+   * @description Asserts that the given approval count meets the threshold.
+   *
+   * @circuitInfo k=9, rows=54
+   *
+   * Requirements:
+   *
+   * - Contract must be initialized.
+   * - Ledger threshold must be set (not be zero).
+   * - `approvalCount` must be >= threshold.
+   *
+   * @param {Uint<8>} approvalCount - The current number of approvals.
+   * @returns {[]} Empty tuple.
+   */
+  export circuit assertThresholdMet(approvalCount: Uint<8>): [] {
+    Initializable_assertInitialized();
+    assert(_threshold != 0, "Signer: threshold not set");
+    assert(approvalCount >= _threshold, "Signer: threshold not met");
+  }
+
+  // ─── View ──────────────────────────────────────────────────────────
+
+  /**
+   * @description Returns the current signer count.
+   *
+   * @circuitInfo k=6, rows=26
+   *
+   * Requirements:
+   *
+   * - Contract must be initialized.
+   *
+   * @returns {Uint<8>} The number of active signers.
+   */
+  export circuit getSignerCount(): Uint<8> {
+    Initializable_assertInitialized();
+    return _signerCount;
+  }
+
+  /**
+   * @description Returns the approval threshold.
+   *
+   * @circuitInfo k=6, rows=26
+   *
+   * Requirements:
+   *
+   * - Contract must be initialized.
+   *
+   * @returns {Uint<8>} The threshold.
+   */
+  export circuit getThreshold(): Uint<8> {
+    Initializable_assertInitialized();
+    return _threshold;
+  }
+
+  /**
+   * @description Returns whether the given account is an active signer.
+   *
+   * @circuitInfo k=10, rows=605
+   *
+   * @param {T} account - The account to check.
+   * @returns {Boolean} True if the account is an active signer.
+   */
+  export circuit isSigner(account: T): Boolean {
+    return _signers.member(disclose(account));
+  }
+
+  // ─── Signer Management ─────────────────────────────────────────────────────
+
+  /**
+   * @description Adds a new signer to the registry.
+   *
+   * @notice Access control is NOT enforced here.
+   * The consuming contract must gate this behind its own
+   * authorization policy.
+   *
+   * @circuitInfo k=10, rows=598
+   *
+   * Requirements:
+   *
+   * - `signer` must not already be an active signer.
+   *
+   * @param {T} signer - The signer to add.
+   * @returns {[]} Empty tuple.
+   */
+  export circuit _addSigner(signer: T): [] {
+    assert(
+      !isSigner(signer),
+      "Signer: signer already active"
+    );
+
+    _signers.insert(disclose(signer));
+    _signerCount = _signerCount + 1 as Uint<8>;
+  }
+
+  /**
+   * @description Removes a signer from the registry.
+   *
+   * @notice Access control is NOT enforced here.
+   * The consuming contract must gate this behind its own
+   * authorization policy.
+   *
+   * @circuitInfo k=10, rows=612
+   *
+   * Requirements:
+   *
+   * - `signer` must be an active signer.
+   * - Removal must not drop signer count below threshold.
+   *
+   * @param {T} signer - The signer to remove.
+   * @returns {[]} Empty tuple.
+   */
+  export circuit _removeSigner(signer: T): [] {
+    assert(isSigner(signer), "Signer: not a signer");
+
+    const newCount = _signerCount - 1 as Uint<8>;
+    assert(newCount >= _threshold, "Signer: removal would breach threshold");
+
+    _signers.remove(disclose(signer));
+    _signerCount = newCount;
+  }
+
+  /**
+   * @description Updates the approval threshold.
+   *
+   * @notice Access control is NOT enforced here.
+   * The consuming contract must gate this behind its own
+   * authorization policy.
+   *
+   * @circuitInfo k=9, rows=53
+   *
+   * Requirements:
+   *
+   * - `newThreshold` must not be zero.
+   * - `newThreshold` must not exceed the current signer count.
+   *
+   * @param {Uint<8>} newThreshold - The new minimum number of approvals required.
+   * @returns {[]} Empty tuple.
+   */
+  export circuit _changeThreshold(newThreshold: Uint<8>): [] {
+    assert(newThreshold <= _signerCount, "Signer: threshold exceeds signer count");
+    _setThreshold(newThreshold);
+  }
+
+  /**
+   * @description Sets the approval threshold without checking
+   * against the current signer count.
+   *
+   * @warning This is intended for use during contract construction
+   * or custom setup flows where signers may not yet be registered.
+   *
+   * @notice Access control is NOT enforced here.
+   * The consuming contract must gate this behind its own
+   * authorization policy. Use `_changeThreshold` for
+   * operational threshold changes with signer count validation.
+   *
+   * @circuitInfo k=6, rows=40
+   *
+   * Requirements:
+   *
+   * - `newThreshold` must not be zero.
+   *
+   * @param {Uint<8>} newThreshold - The minimum number of approvals required.
+   * @returns {[]} Empty tuple.
+   */
+  export circuit _setThreshold(newThreshold: Uint<8>): [] {
+    assert(newThreshold != 0, "Signer: threshold must not be zero");
+    _threshold = disclose(newThreshold);
+  }
+}

--- a/contracts/src/multisig/SignerManager.compact
+++ b/contracts/src/multisig/SignerManager.compact
@@ -1,0 +1,205 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Compact Contracts v0.0.1-alpha.1 (multisig/SignerManager.compact)
+
+pragma language_version >= 0.21.0;
+
+/**
+ * @module SignerManager<T>
+ * @description Manages signer registry, threshold enforcement, and signer
+ * validation for multisig governance contracts.
+ *
+ * Parameterized over the signer identity type `T`, allowing the consuming
+ * contract to choose the identity mechanism at import time. Common
+ * instantiations include:
+ *
+ * - `Either<ZswapCoinPublicKey, ContractAddress>` for ownPublicKey()-based identity
+ * - `Bytes<32>` for commitment-based identity (e.g., hash of ECDSA public key)
+ * - `NativePoint` for Schnorr/MuSig aggregated key
+ *
+ * SignerManager does not resolve caller identity. It receives a validated
+ * caller from the contract layer and checks it against the registry.
+ * This separation allows the identity mechanism to change without
+ * modifying the module.
+ *
+ * Underscore-prefixed circuits (_addSigner, _removeSigner,
+ * _changeThreshold) have no access control enforcement. The consuming
+ * contract must gate these behind its own authorization policy.
+ */
+module SignerManager<T> {
+  import CompactStandardLibrary;
+
+  // ─── State ──────────────────────────────────────────────────────────────────
+
+  export ledger _signers: Set<T>;
+  export ledger _signerCount: Uint<8>;
+  export ledger _threshold: Uint<8>;
+
+  // ─── Initialization ─────────────────────────────────────────────────────────
+
+  /**
+   * @description Initializes the signer manager with the given threshold
+   * and an initial set of signers.
+   * Must be called in the contract's constructor.
+   *
+   * Requirements:
+   *
+   * - `thresh` must be greater than 0.
+   * - `signers` must not contain duplicates.
+   *
+   * @param {Vector<n, T>} signers - The initial signer set.
+   * @param {Uint<8>} thresh - The minimum number of approvals required.
+   *
+   * @returns {[]} Empty tuple.
+   */
+  export circuit initialize<#n>(
+    signers: Vector<n, T>,
+    thresh: Uint<8>
+  ): [] {
+    assert(thresh > 0, "SignerManager: threshold must be > 0");
+    _threshold = disclose(thresh);
+
+    for (const signer of signers) {
+      _addSigner(signer);
+    }
+
+    assert(_signerCount >= thresh, "SignerManager: threshold exceeds signer count");
+  }
+
+  // ─── Guards ─────────────────────────────────────────────────────────────
+
+  /**
+   * @description Asserts that the given caller is an active signer.
+   *
+   * Requirements:
+   *
+   * - `caller` must be a member of the signers registry.
+   *
+   * @param {T} caller - The identity to validate.
+   *
+   * @returns {[]} Empty tuple.
+   */
+  export circuit assertSigner(caller: T): [] {
+    assert(isSigner(caller), "SignerManager: not a signer");
+  }
+
+  /**
+   * @description Asserts that the given approval count meets the threshold.
+   *
+   * Requirements:
+   *
+   * - `approvalCount` must be >= threshold.
+   *
+   * @param {Uint<8>} approvalCount - The current number of approvals.
+   *
+   * @returns {[]} Empty tuple.
+   */
+  export circuit assertThresholdMet(approvalCount: Uint<8>): [] {
+    assert(approvalCount >= _threshold, "SignerManager: threshold not met");
+  }
+
+  // ─── View ──────────────────────────────────────────────────────────
+
+  /**
+   * @description Returns the current signer count.
+   *
+   * @returns {Uint<8>} The number of active signers.
+   */
+  export circuit getSignerCount(): Uint<8> {
+    return _signerCount;
+  }
+
+  /**
+   * @description Returns the approval threshold.
+   *
+   * @returns {Uint<8>} The threshold.
+   */
+  export circuit getThreshold(): Uint<8> {
+    return _threshold;
+  }
+
+  /**
+   * @description Returns whether the given account is an active signer.
+   *
+   * @param {T} account - The account to check.
+   *
+   * @returns {Boolean} True if the account is an active signer.
+   */
+  export circuit isSigner(account: T): Boolean {
+    return _signers.member(disclose(account));
+  }
+
+  // ─── Signer Management ─────────────────────────────────────────────────────
+
+  /**
+   * @description Adds a new signer to the registry.
+   *
+   * @notice Access control is NOT enforced here.
+   * The consuming contract must gate this behind its own
+   * authorization policy.
+   *
+   * Requirements:
+   *
+   * - `signer` must not already be an active signer.
+   *
+   * @param {T} signer - The signer to add.
+   *
+   * @returns {[]} Empty tuple.
+   */
+  export circuit _addSigner(signer: T): [] {
+    assert(
+      !isSigner(signer),
+      "SignerManager: signer already active"
+    );
+
+    _signers.insert(disclose(signer));
+    _signerCount = _signerCount + 1 as Uint<8>;
+  }
+
+  /**
+   * @description Removes a signer from the registry.
+   *
+   * @notice Access control is NOT enforced here.
+   * The consuming contract must gate this behind its own
+   * authorization policy.
+   *
+   * Requirements:
+   *
+   * - `signer` must be an active signer.
+   * - Removal must not drop signer count below threshold.
+   *
+   * @param {T} signer - The signer to remove.
+   *
+   * @returns {[]} Empty tuple.
+   */
+  export circuit _removeSigner(signer: T): [] {
+    assert(isSigner(signer), "SignerManager: not a signer");
+
+    const newCount = _signerCount - 1 as Uint<8>;
+    assert(newCount >= _threshold, "SignerManager: removal would breach threshold");
+
+    _signers.remove(disclose(signer));
+    _signerCount = newCount;
+  }
+
+  /**
+   * @description Updates the approval threshold.
+   *
+   * @notice Access control is NOT enforced here.
+   * The consuming contract must gate this behind its own
+   * authorization policy.
+   *
+   * Requirements:
+   *
+   * - `newThreshold` must be greater than 0.
+   * - `newThreshold` must not exceed the current signer count.
+   *
+   * @param {Uint<8>} newThreshold - The new minimum number of approvals required.
+   *
+   * @returns {[]} Empty tuple.
+   */
+  export circuit _changeThreshold(newThreshold: Uint<8>): [] {
+    assert(newThreshold > 0, "SignerManager: threshold must be > 0");
+    assert(newThreshold <= _signerCount, "SignerManager: threshold exceeds signer count");
+    _threshold = disclose(newThreshold);
+  }
+}

--- a/contracts/src/multisig/UnshieldedTreasury.compact
+++ b/contracts/src/multisig/UnshieldedTreasury.compact
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Compact Contracts v0.0.1-alpha.1 (multisig/UnshieldedTreasury.compact)
+
+pragma language_version >= 0.21.0;
+
+/**
+ * @module UnshieldedTreasury
+ * @description Manages unshielded (transparent) token deposits and
+ * transfers for multisig governance contracts.
+ *
+ * Balances are tracked per token color in a single map. Protocol-level
+ * balance comparison circuits (`unshieldedBalanceLte`,
+ * `unshieldedBalanceGte`) are used for overflow and sufficiency checks,
+ * avoiding the exact-match problem of `unshieldedBalance`.
+ *
+ * Underscore-prefixed circuits (_deposit, _send) have no access control
+ * enforcement. The consuming contract must gate these behind its own
+ * authorization policy.
+ */
+module UnshieldedTreasury {
+  import CompactStandardLibrary;
+  import { UINT128_MAX } from "../utils/Utils" prefix Utils_;
+
+  // ─── State ──────────────────────────────────────────────────────
+
+  export ledger _balances: Map<Bytes<32>, Uint<128>>;
+
+  // ─── Deposit ────────────────────────────────────────────────────
+
+  /**
+   * @description Receives unshielded tokens into the treasury.
+   *
+   * The token receive is executed at the protocol level first via
+   * `receiveUnshielded`. The balance map is then updated.
+   *
+   * Zero-value deposits are permitted. While currently a no-op
+   * economically, they may serve as signaling mechanisms when events
+   * are supported.
+   *
+   * @notice Access control is NOT enforced here.
+   * The consuming contract must gate this behind its own
+   * authorization policy.
+   *
+   * Requirements:
+   *
+   * - Deposit must not cause balance overflow.
+   *
+   * @param {Bytes<32>} color - The token type identifier.
+   * @param {Uint<128>} amount - The amount to deposit.
+   *
+   * @returns {[]} Empty tuple.
+   */
+  export circuit _deposit(color: Bytes<32>, amount: Uint<128>): [] {
+    assert(
+      unshieldedBalanceLte(disclose(color), Utils_UINT128_MAX() - disclose(amount)),
+      "UnshieldedTreasury: overflow"
+    );
+
+    receiveUnshielded(disclose(color), disclose(amount));
+
+    const bal = getTokenBalance(color);
+    _balances.insert(disclose(color), disclose(bal + amount as Uint<128>));
+  }
+
+  // ─── Send ───────────────────────────────────────────────────────
+
+  /**
+   * @description Sends unshielded tokens from the treasury.
+   *
+   * @notice Access control is NOT enforced here.
+   * The consuming contract must gate this behind its own
+   * authorization policy.
+   *
+   * Requirements:
+   *
+   * - The treasury must hold sufficient balance for the given token color.
+   *
+   * @param {Either<ContractAddress, UserAddress>} recipient - The recipient address.
+   * @param {Bytes<32>} color - The token type identifier.
+   * @param {Uint<128>} amount - The amount to send.
+   *
+   * @returns {[]} Empty tuple.
+   */
+  export circuit _send(
+    recipient: Either<ContractAddress, UserAddress>,
+    color: Bytes<32>,
+    amount: Uint<128>
+  ): [] {
+    assert(
+      unshieldedBalanceGte(disclose(color), disclose(amount)),
+      "UnshieldedTreasury: insufficient balance"
+    );
+
+    const bal = getTokenBalance(color);
+    _balances.insert(disclose(color), disclose(bal - amount as Uint<128>));
+    sendUnshielded(disclose(color), disclose(amount), disclose(recipient));
+  }
+
+  // ─── View ───────────────────────────────────────────────────────
+
+  /**
+   * @description Returns the balance for a given token color.
+   *
+   * @param {Bytes<32>} color - The token type identifier.
+   *
+   * @returns {Uint<128>} The current balance.
+   */
+  export circuit getTokenBalance(color: Bytes<32>): Uint<128> {
+    if (!_balances.member(disclose(color))) {
+      return 0;
+    }
+    return _balances.lookup(disclose(color));
+  }
+}

--- a/contracts/src/multisig/presets/ShieldedMultiSig.compact
+++ b/contracts/src/multisig/presets/ShieldedMultiSig.compact
@@ -1,0 +1,236 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Compact Contracts v0.0.1-alpha.1 (multisig/presets/ShieldedMultiSig.compact)
+
+pragma language_version >= 0.21.0;
+
+/**
+ * @module ShieldedMultiSig
+ * @description A shielded multisig preset composing `SignerManager`,
+ * `ProposalManager`, and `ShieldedTreasury`. Signers approve proposals that
+ * transfer shielded tokens out of the treasury once the configured threshold
+ * is met.
+ *
+ * @notice Signer identity uses `Either<ZswapCoinPublicKey, ContractAddress>`
+ * in state for forward compatibility. In the current protocol, only
+ * `left(ZswapCoinPublicKey)` callers can authenticate — `getCaller()` resolves
+ * via `ownPublicKey()` and has no way to produce a right-variant today.
+ * Registering contract-address signers is permitted but those signers cannot
+ * exercise governance (create/approve/revoke) until contract-to-contract calls
+ * are supported. Choose your signer set accordingly.
+ *
+ * @notice The state shape is deliberately kept broad so that, once
+ * contract-to-contract calls are supported, `getCaller()` can be swapped via
+ * a CMA (Contract Maintenance Authorities) circuit upgrade without a state
+ * migration. Existing deployments would then gain working contract-signer
+ * authentication.
+ */
+
+import CompactStandardLibrary;
+
+import "../ProposalManager" prefix Proposal_;
+import "../ShieldedTreasury" prefix Treasury_;
+import "../SignerManager"<Either<ZswapCoinPublicKey, ContractAddress>> prefix Signer_;
+
+// ─── State ───────────────────────────────────────────────────────────────
+
+export ledger _proposalApprovals: Map<Uint<64>, Map<Either<ZswapCoinPublicKey, ContractAddress>, Boolean>>;
+export ledger _approvalCount: Map<Uint<64>, Uint<8>>;
+
+// ─── Constructor ─────────────────────────────────────────────────────────
+
+constructor(
+  signers: Vector<3, Either<ZswapCoinPublicKey, ContractAddress>>,
+  thresh: Uint<8>
+) {
+  Signer_initialize<3>(signers, thresh);
+}
+
+// ─── Deposit ─────────────────────────────────────────────────────────────
+
+export circuit deposit(coin: ShieldedCoinInfo): [] {
+  Treasury__deposit(coin);
+}
+
+// ─── Proposals ───────────────────────────────────────────────────────────
+
+export circuit createShieldedProposal(
+  to: Proposal_Recipient,
+  color: Bytes<32>,
+  amount: Uint<128>
+): Uint<64> {
+  const callerPK = getCaller();
+  Signer_assertSigner(callerPK);
+
+  assert(
+    to.kind == Proposal_RecipientKind.ShieldedUser
+      || to.kind == Proposal_RecipientKind.Contract,
+    "ShieldedMultiSig: recipient must be a shielded user or contract"
+  );
+
+  return Proposal__createProposal(to, color, amount);
+}
+
+export circuit approveProposal(id: Uint<64>): [] {
+  // Check if active
+  Proposal_assertProposalActive(id);
+
+  // Check signer
+  const callerPK = getCaller();
+  Signer_assertSigner(callerPK);
+
+  // Check if already approved
+  assert(!isProposalApprovedBySigner(id, callerPK), "Multisig: already approved");
+
+  // Approve
+  _approveProposal(id, callerPK);
+}
+
+export circuit revokeApproval(id: Uint<64>): [] {
+  // Check if active
+  Proposal_assertProposalActive(id);
+
+  // Check signer
+  const callerPK = getCaller();
+  Signer_assertSigner(callerPK);
+
+  // Check has approved
+  assert(isProposalApprovedBySigner(id, callerPK), "Multisig: not approved");
+
+  // Revoke
+  _revokeApproval(id, callerPK);
+}
+
+export circuit executeShieldedProposal(
+  id: Uint<64>,
+): ShieldedSendResult {
+  // Check if active
+  Proposal_assertProposalActive(id);
+
+  // Check threshold
+  const approvalCount = getApprovalCount(id);
+  Signer_assertThresholdMet(approvalCount);
+
+  // Transfer
+  const { to, color, amount } = Proposal_getProposal(id);
+  const result = Treasury__send(
+    Proposal_toShieldedRecipient(to),
+    color,
+    amount,
+  );
+
+  // Finish lifecycle
+  Proposal__markExecuted(id);
+  return result;
+}
+
+// ─── Internal ───────────────────────────────────────────────────────────
+
+circuit _approveProposal(id: Uint<64>, signer: Either<ZswapCoinPublicKey, ContractAddress>): [] {
+  if (!_proposalApprovals.member(disclose(id))) {
+    _proposalApprovals.insert(disclose(id), default<Map<Either<ZswapCoinPublicKey, ContractAddress>, Boolean>>);
+  }
+
+  _proposalApprovals.lookup(disclose(id)).insert(disclose(signer), disclose(true));
+
+  const newCount = getApprovalCount(id) + 1 as Uint<8>;
+  _approvalCount.insert(disclose(id), disclose(newCount));
+}
+
+circuit _revokeApproval(id: Uint<64>, signer: Either<ZswapCoinPublicKey, ContractAddress>): [] {
+  _proposalApprovals.lookup(disclose(id)).remove(disclose(signer));
+
+  const newCount = getApprovalCount(id) - 1 as Uint<8>;
+  _approvalCount.insert(disclose(id), disclose(newCount));
+}
+
+/**
+ * @description Returns the caller identity used for signer authentication.
+ *
+ * @warning Currently resolves callers via `ownPublicKey()` only, so any signer
+ * registered as a `right(ContractAddress)` variant cannot authenticate through
+ * this circuit today. Ledger fields keep the `Either<ZswapCoinPublicKey, ContractAddress>`
+ * shape so that, once contract-to-contract calls are supported, `getCaller()`
+ * can be replaced via a CMA (Contract Maintenance Authorities) circuit upgrade
+ * to detect the contract-call context and return the appropriate variant —
+ * without a state migration.
+ *
+ * @returns {Either<ZswapCoinPublicKey, ContractAddress>} The caller wrapped as a left-variant.
+ */
+circuit getCaller(): Either<ZswapCoinPublicKey, ContractAddress> {
+  return left<ZswapCoinPublicKey, ContractAddress>(ownPublicKey());
+}
+
+// ─── View ───────────────────────────────────────────────────────────────
+
+export circuit isProposalApprovedBySigner(
+  id: Uint<64>,
+  signer: Either<ZswapCoinPublicKey, ContractAddress>
+): Boolean {
+  if (!_proposalApprovals.member(disclose(id)) || !_proposalApprovals.lookup(disclose(id)).member(disclose(signer))) {
+    return false;
+  }
+
+  return _proposalApprovals.lookup(disclose(id)).lookup(disclose(signer));
+}
+
+export circuit getApprovalCount(id: Uint<64>): Uint<8> {
+  if (!_approvalCount.member(disclose(id))) {
+    return 0;
+  }
+
+  return _approvalCount.lookup(disclose(id));
+}
+
+// IProposalManager
+
+export circuit getProposal(id: Uint<64>): Proposal_Proposal {
+  return Proposal_getProposal(id);
+}
+
+export circuit getProposalRecipient(id: Uint<64>): Proposal_Recipient {
+  return Proposal_getProposalRecipient(id);
+}
+
+export circuit getProposalAmount(id: Uint<64>): Uint<128> {
+  return Proposal_getProposalAmount(id);
+}
+
+export circuit getProposalColor(id: Uint<64>): Bytes<32> {
+  return Proposal_getProposalColor(id);
+}
+
+export circuit getProposalStatus(id: Uint<64>): Proposal_ProposalStatus {
+  return Proposal_getProposalStatus(id);
+}
+
+// IShieldedTreasury
+
+export circuit getTokenBalance(color: Bytes<32>): Uint<128> {
+  return Treasury_getTokenBalance(color);
+}
+
+export circuit getReceivedTotal(color: Bytes<32>): Uint<128> {
+  return Treasury_getReceivedTotal(color);
+}
+
+export circuit getSentTotal(color: Bytes<32>): Uint<128> {
+  return Treasury_getSentTotal(color);
+}
+
+export circuit getReceivedMinusSent(color: Bytes<32>): Uint<128> {
+  return Treasury_getReceivedMinusSent(color);
+}
+
+// ISignerManager
+
+export circuit getSignerCount(): Uint<8> {
+  return Signer_getSignerCount();
+}
+
+export circuit getThreshold(): Uint<8> {
+  return Signer_getThreshold();
+}
+
+export circuit isSigner(account: Either<ZswapCoinPublicKey, ContractAddress>): Boolean {
+  return Signer_isSigner(account);
+}

--- a/contracts/src/multisig/presets/ShieldedMultiSigV2.compact
+++ b/contracts/src/multisig/presets/ShieldedMultiSigV2.compact
@@ -1,0 +1,280 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Compact Contracts v0.0.1-alpha.1 (multisig/presets/ShieldedMultiSigV2.compact)
+
+pragma language_version >= 0.21.0;
+
+/**
+ * @title ShieldedMultisigV2
+ * @description Privacy-preserving 2-of-3 multisig contract.
+ *
+ * Signer identities are stored as commitments: hashes of ECDSA public
+ * keys combined with an instance salt and domain separator. Signature
+ * verification happens in a single transaction with no multi-step
+ * proposal lifecycle. The contract enforces threshold authorization
+ * and replay protection. All other coordination (signature collection,
+ * coin selection) happens off-chain.
+ *
+ * Treasury is fully stateless meaning coin data is not stored on the public ledger.
+ * Deposits call receiveShielded only. The operator discovers coin indices
+ * through ZswapOutput events from the indexer, constructs QualifiedShieldedCoinInfo
+ * off-chain, and provides it as a circuit parameter for spending.
+ */
+
+import CompactStandardLibrary;
+
+import "../ProposalManager" prefix Proposal_;
+import "../ShieldedTreasuryStateless" prefix Treasury_;
+import "../SignerManager"<Bytes<32>> prefix Signer_;
+
+// ─── Types ──────────────────────────────────────────────────────
+
+/**
+ * @description Accumulator for fold-based signature verification.
+ * Threads the valid count, previous commitment (for duplicate
+ * detection), and message hash through each iteration.
+ */
+export struct VerificationState {
+  validCount: Uint<8>,
+  prevCommitment: Bytes<32>,
+  msgHash: Bytes<32>
+}
+
+/**
+ * @description Input to persistentHash for computing signer commitments.
+ * Combines the ECDSA public key with an instance-specific salt and
+ * domain separator to produce a unique, unlinkable commitment.
+ */
+export struct SignerCommitmentInput {
+  pk: Bytes<64>,
+  salt: Bytes<32>,
+  domain: Bytes<32>
+}
+
+// ─── State ──────────────────────────────────────────────────────
+
+ledger _nonce: Counter;
+ledger _instanceSalt: Bytes<32>;
+
+// ─── Constructor ────────────────────────────────────────────────
+
+/**
+ * @description Deploys the multisig with 3 signer commitments and
+ * a threshold.
+ *
+ * Each commitment is computed off-chain as:
+ * persistentHash(SignerCommitmentInput { pk, instanceSalt, domain })
+ * where domain is pad(32, "MultiSig:signer:").
+ *
+ * The instanceSalt should be a random value to prevent the same public
+ * key from producing the same commitment across different multisig
+ * deployments, breaking cross-contract signer correlation.
+ *
+ * Requirements:
+ *
+ * - `thresh` must be > 0 and <= 2 (matches the 2-signature `execute` surface).
+ * - `signerCommitments` must not contain duplicates.
+ * - `instanceSalt` should be cryptographically random.
+ *
+ * @param {Bytes<32>} instanceSalt - Random salt for commitment derivation.
+ * @param {Vector<3, Bytes<32>>} signerCommitments - Hashed signer identities.
+ * @param {Uint<8>} thresh - Minimum approvals required.
+ */
+constructor(
+  instanceSalt: Bytes<32>,
+  signerCommitments: Vector<3, Bytes<32>>,
+  thresh: Uint<8>,
+) {
+  assert(
+    thresh <= 2,
+    "ShieldedMultiSigV2: threshold cannot exceed 2 (execute verifies at most 2 signatures)"
+  );
+  _instanceSalt = disclose(instanceSalt);
+  Signer_initialize<3>(signerCommitments, thresh);
+}
+
+// ─── Deposit ────────────────────────────────────────────────────
+
+/**
+ * @description Receives a shielded coin into the multisig treasury.
+ *
+ * No access control which allows anyone to deposit. The coin is claimed at the
+ * protocol level through receiveShielded. No coin data is stored on the
+ * public ledger, preserving full balance privacy.
+ *
+ * The operator discovers the coin's Merkle tree index by subscribing
+ * to ZswapOutput events via the indexer, filtering by contract address,
+ * and extracting mt_index. Combined with the known ShieldedCoinInfo,
+ * this produces the QualifiedShieldedCoinInfo needed for spending.
+ *
+ * @param {ShieldedCoinInfo} coin - The incoming shielded coin.
+ */
+export circuit deposit(coin: ShieldedCoinInfo): [] {
+  receiveShielded(disclose(coin));
+}
+
+// ─── Execute ────────────────────────────────────────────────────
+
+/**
+ * @description Executes a shielded send authorized by threshold signatures.
+ *
+ * The circuit reads the current nonce from the ledger, increments it,
+ * then reconstructs the message hash that signers must have signed
+ * off-chain: `persistentHash(nonce, recipient address, coin color, amount)`.
+ *
+ * Signatures are verified via fold over parallel pubkey and signature
+ * vectors. Each public key is hashed with the instance salt to produce
+ * a commitment, checked against the signer registry, and the signature
+ * is verified against the message hash. Duplicate signers are rejected
+ * via inequality check on adjacent commitments.
+ *
+ * @notice ECDSA verification is stubbed. Replace stubVerifySignature
+ * with ecdsaVerify when Compact ECDSA primitives are available.
+ *
+ * @notice Duplicate detection via != only works for exactly 2 signers.
+ * Production contracts with larger signer sets need a different
+ * uniqueness enforcement mechanism.
+ *
+ * Requirements:
+ *
+ * - Both public keys must hash to registered signer commitments.
+ * - Both signatures must be valid over the message hash.
+ * - Signers must not be duplicates.
+ * - Coin value must be >= amount.
+ *
+ * @param {Proposal_Recipient} to - The recipient.
+ * @param {Uint<128>} amount - The amount to send.
+ * @param {QualifiedShieldedCoinInfo} coin - The coin to spend (from operator's pool).
+ * @param {Vector<2, Bytes<64>>} pubkeys - ECDSA public keys of approving signers.
+ * @param {Vector<2, Bytes<64>>} signatures - ECDSA signatures over the operation.
+ *
+ * @returns {ShieldedSendResult} The send result including any change.
+ */
+export circuit execute(
+  to: Proposal_Recipient,
+  amount: Uint<128>,
+  coin: QualifiedShieldedCoinInfo,
+  pubkeys: Vector<2, Bytes<64>>,
+  signatures: Vector<2, Bytes<64>>
+): ShieldedSendResult {
+  // Increment nonce
+  const currentNonce = _nonce;
+  _nonce.increment(1);
+
+  // Construct message hash
+  const msgHash = persistentHash<Vector<4, Bytes<32>>>([
+    currentNonce as Bytes<32>,
+    to.address,
+    coin.color,
+    amount as Bytes<32>
+  ]);
+
+  // Verify signatures via fold over parallel vectors
+  const initialState = VerificationState {
+    validCount: 0 as Uint<8>,
+    prevCommitment: pad(32, ""),
+    msgHash: msgHash
+  };
+
+  const finalState = fold(verifySignature, initialState, pubkeys, signatures);
+  Signer_assertThresholdMet(finalState.validCount);
+
+  // Execute transfer
+  const normalizedRecipient = Proposal_toShieldedRecipient(to);
+  return Treasury__send(coin, normalizedRecipient, amount);
+}
+
+// ─── Signature Verification ─────────────────────────────────────
+
+/**
+ * @description Fold callback. Verifies one signer's approval.
+ *
+ * Computes the signer's commitment from their public key and the
+ * instance salt, checks for duplicates against the previous commitment,
+ * verifies registry membership, and validates the ECDSA signature.
+ *
+ * @param {VerificationState} state - Accumulator threaded through fold.
+ * @param {Bytes<64>} pubkey - The signer's ECDSA public key.
+ * @param {Bytes<64>} signature - The signer's signature over msgHash.
+ *
+ * @returns {VerificationState} Updated accumulator.
+ */
+circuit verifySignature(
+  state: VerificationState,
+  pubkey: Bytes<64>,
+  signature: Bytes<64>
+): VerificationState {
+  const commitment = _calculateSignerId(pubkey, _instanceSalt);
+
+  // Duplicate detection — sufficient for 2 signers only
+  assert(commitment != state.prevCommitment, "Multisig: duplicate signer");
+
+  // Verify this commitment is a registered signer
+  Signer_assertSigner(commitment);
+
+  // TODO: Replace with actual ECDSA primitive when available
+  // assert(ecdsaVerify(pubkey, state.msgHash, signature), "Multisig: invalid signature");
+  assert(stubVerifySignature(pubkey, state.msgHash, signature), "Multisig: invalid signature");
+
+  return VerificationState {
+    validCount: state.validCount + 1 as Uint<8>,
+    prevCommitment: commitment,
+    msgHash: state.msgHash
+  };
+}
+
+/**
+ * @description Computes a signer commitment from an ECDSA public key.
+ *
+ * The commitment is persistentHash(pk, salt, domain) where:
+ * - pk: the signer's ECDSA public key (64 bytes)
+ * - salt: instance-specific random value (prevents cross-contract correlation)
+ * - domain: "MultiSig:signer:" (domain separation)
+ *
+ * This is a pure circuit. It can be called off-chain by the deployer
+ * to compute commitments for the constructor.
+ *
+ * @param {Bytes<64>} pk - The ECDSA public key.
+ * @param {Bytes<32>} salt - The instance salt.
+ *
+ * @returns {Bytes<32>} The signer commitment.
+ */
+export pure circuit _calculateSignerId(
+  pk: Bytes<64>,
+  salt: Bytes<32>
+): Bytes<32> {
+  return persistentHash<SignerCommitmentInput>(SignerCommitmentInput {
+    pk: pk,
+    salt: salt,
+    domain: pad(32, "MultiSig:signer:")
+  });
+}
+
+/**
+ * @description Stub for ECDSA signature verification.
+ * Always returns true. MUST be replaced before any non-test deployment.
+ */
+circuit stubVerifySignature(
+  pubkey: Bytes<64>,
+  msgHash: Bytes<32>,
+  signature: Bytes<64>
+): Boolean {
+  return true;
+}
+
+// ─── View ───────────────────────────────────────────────────────
+
+export circuit getNonce(): Uint<64> {
+  return _nonce;
+}
+
+export circuit getSignerCount(): Uint<8> {
+  return Signer_getSignerCount();
+}
+
+export circuit getThreshold(): Uint<8> {
+  return Signer_getThreshold();
+}
+
+export circuit isSigner(commitment: Bytes<32>): Boolean {
+  return Signer_isSigner(commitment);
+}

--- a/contracts/src/multisig/presets/forwarder/ForwarderPrivate.compact
+++ b/contracts/src/multisig/presets/forwarder/ForwarderPrivate.compact
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Compact Contracts v0.0.1-alpha.1 (multisig/presets/forwarder/ForwarderPrivate.compact)
+
+pragma language_version >= 0.21.0;
+
+/**
+ * @title ForwarderPrivate
+ * @description Private-parent forwarder. The parent address is hidden
+ * behind a `persistentHash` commitment on the ledger. Coins dwell at
+ * the contract address after deposit; the operator drains them later
+ * by presenting the `(parentAddr, opSecret)` preimage at drain time.
+ *
+ * Knowledge of the preimage is the sole authorization gate. The
+ * operational secret is held off-chain by the deployer; losing it is
+ * equivalent to loss of a hot-wallet key. Two forwarders bound to the
+ * same parent with different operational secrets produce different
+ * commitments and are unlinkable on-chain.
+ *
+ * @notice Each forwarder is bound to a single parent at deploy. To
+ * change the parent, deploy a new forwarder; the old one remains
+ * functional for outstanding coins until drained.
+ */
+
+import CompactStandardLibrary;
+import "../../ForwarderPrivate" prefix ForwarderPrivate_;
+
+export { ShieldedCoinInfo, QualifiedShieldedCoinInfo, ShieldedSendResult };
+
+/**
+ * @description Deploys the forwarder bound to a specific parent
+ * commitment. The deployer computes the commitment off-chain as
+ * `calculateParentCommitment(parentAddr, opSecret)` and passes it here.
+ *
+ * @param {Bytes<32>} parentCommitment - The commitment to the
+ * `(parentAddr, opSecret)` pair that the operator will present at drain.
+ */
+constructor(parentCommitment: Bytes<32>) {
+  ForwarderPrivate_initialize(parentCommitment);
+}
+
+/**
+ * @description Receives a shielded coin into the forwarder's custody.
+ * No ledger write — the coin sits at the contract address until drained.
+ *
+ * @param {ShieldedCoinInfo} coin - The incoming shielded coin.
+ *
+ * @returns {[]} Empty tuple.
+ */
+export circuit deposit(coin: ShieldedCoinInfo): [] {
+  ForwarderPrivate__deposit(coin);
+}
+
+/**
+ * @description Spends a previously-deposited shielded coin to
+ * `parentAddr`. The caller proves knowledge of `(parentAddr, opSecret)`
+ * matching the stored commitment. If the input coin's value exceeds
+ * `value`, change is re-emitted back to the contract for future drains.
+ *
+ * Requirements:
+ *
+ * - `calculateParentCommitment(parentAddr, opSecret)` must equal the stored
+ *   `_parentCommitment`.
+ * - `coin.value` must be >= `value` (enforced by `sendShielded`).
+ *
+ * @param {QualifiedShieldedCoinInfo} coin - The coin to spend.
+ * @param {Bytes<32>} parentAddr - The parent address. Preimage to the
+ * stored commitment.
+ * @param {Bytes<32>} opSecret - The operational secret. Never appears
+ * on the public transcript.
+ *
+ * @warning **Losing the operational secret is permanent fund loss.** It
+ * is the sole drain authorization. No rotation, revocation, or recovery
+ * path exists. If the operator loses it, every shielded coin accumulated
+ * at this contract becomes inaccessible. Back it up offline before the
+ * first deposit.
+ *
+ * @param {Uint<128>} value - The amount to send.
+ *
+ * @returns {ShieldedSendResult} The result containing the sent coin and
+ * any change.
+ */
+export circuit drain(
+  coin: QualifiedShieldedCoinInfo,
+  parentAddr: Bytes<32>,
+  opSecret: Bytes<32>,
+  value: Uint<128>
+): ShieldedSendResult {
+  return ForwarderPrivate__drain(coin, parentAddr, opSecret, value);
+}
+
+/**
+ * @description Returns the stored parent commitment.
+ *
+ * @returns {Bytes<32>} The commitment set at deploy.
+ */
+export circuit getParentCommitment(): Bytes<32> {
+  return ForwarderPrivate__parentCommitment;
+}
+
+/**
+ * @description Computes the parent commitment from a `(parentAddr, opSecret)`
+ * pair. Pure circuit — used off-chain by the deployer to compute the
+ * constructor argument, and inside `drain` for the preimage check.
+ *
+ * The commitment is domain-tagged
+ * (`pad(32, "ForwarderPrivate:commitment")`) to prevent preimage
+ * collisions with other `persistentHash` users in the system.
+ *
+ * @param {Bytes<32>} parentAddr - The parent address.
+ * @param {Bytes<32>} opSecret - The operational secret.
+ *
+ * @returns {Bytes<32>} The commitment `persistentHash([pad(32, "ForwarderPrivate:commitment"), parentAddr, opSecret])`.
+ */
+export pure circuit calculateParentCommitment(
+  parentAddr: Bytes<32>,
+  opSecret: Bytes<32>
+): Bytes<32> {
+  return ForwarderPrivate__calculateParentCommitment(parentAddr, opSecret);
+}

--- a/contracts/src/multisig/presets/forwarder/ForwarderShielded.compact
+++ b/contracts/src/multisig/presets/forwarder/ForwarderShielded.compact
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Compact Contracts v0.0.1-alpha.1 (multisig/presets/forwarder/ForwarderShielded.compact)
+
+pragma language_version >= 0.21.0;
+
+/**
+ * @title ForwarderShielded
+ * @description Public-parent forwarder for shielded coins. Receives a
+ * shielded coin and atomically forwards it to the configured parent
+ * address.
+ *
+ * The parent address is hard-coded at deploy time and immutable. Anyone
+ * may call `deposit`; the recipient is fixed, so there is no need for
+ * access control.
+ */
+
+import CompactStandardLibrary;
+import "../../Forwarder"<ZswapCoinPublicKey> prefix Forwarder_;
+
+export { ZswapCoinPublicKey, ShieldedCoinInfo };
+
+/**
+ * @description Deploys the forwarder bound to a specific parent address.
+ *
+ * @param {ZswapCoinPublicKey} parent - The parent address that receives
+ * every forwarded coin.
+ */
+constructor(parent: ZswapCoinPublicKey) {
+  Forwarder_initialize(parent);
+}
+
+/**
+ * @description Receives a shielded coin and atomically forwards it to
+ * the configured parent. The coin is claimed via `receiveShielded` and
+ * immediately re-sent via `sendImmediateShielded`.
+ *
+ * @param {ShieldedCoinInfo} coin - The incoming shielded coin.
+ *
+ * @returns {[]} Empty tuple.
+ */
+export circuit deposit(coin: ShieldedCoinInfo): [] {
+  Forwarder__depositShielded(coin);
+}
+
+/**
+ * @description Returns the configured parent address.
+ *
+ * @returns {ZswapCoinPublicKey} The parent address set at deploy.
+ */
+export circuit getParent(): ZswapCoinPublicKey {
+  return Forwarder__parent;
+}

--- a/contracts/src/multisig/presets/forwarder/ForwarderUnshielded.compact
+++ b/contracts/src/multisig/presets/forwarder/ForwarderUnshielded.compact
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Compact Contracts v0.0.1-alpha.1 (multisig/presets/forwarder/ForwarderUnshielded.compact)
+
+pragma language_version >= 0.21.0;
+
+/**
+ * @title ForwarderUnshielded
+ * @description Public-parent forwarder for unshielded coins. Receives
+ * an unshielded amount of a given color and atomically forwards it to
+ * the configured parent address.
+ *
+ * Unshielded transfers are publicly visible on the chain: depositor,
+ * recipient, color, and amount all appear on the public transcript.
+ * Use `ForwarderShielded` instead when the deposit kind is shielded.
+ */
+
+import CompactStandardLibrary;
+import "../../Forwarder"<UserAddress> prefix Forwarder_;
+
+export { UserAddress };
+
+/**
+ * @description Deploys the forwarder bound to a specific parent address.
+ *
+ * @param {UserAddress} parent - The parent address that receives every
+ * forwarded amount.
+ */
+constructor(parent: UserAddress) {
+  Forwarder_initialize(parent);
+}
+
+/**
+ * @description Receives an unshielded amount of `color` and atomically
+ * forwards it to the configured parent.
+ *
+ * @param {Bytes<32>} color - The token color.
+ * @param {Uint<128>} amount - The amount to deposit.
+ *
+ * @returns {[]} Empty tuple.
+ */
+export circuit depositUnshielded(color: Bytes<32>, amount: Uint<128>): [] {
+  Forwarder__depositUnshielded(color, amount);
+}
+
+/**
+ * @description Returns the configured parent address.
+ *
+ * @returns {UserAddress} The parent address set at deploy.
+ */
+export circuit getParent(): UserAddress {
+  return Forwarder__parent;
+}

--- a/contracts/src/multisig/test/Forwarder.test.ts
+++ b/contracts/src/multisig/test/Forwarder.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import * as utils from '#test-utils/address.js';
+import { MockForwarderSimulator } from './simulators/MockForwarderSimulator.js';
+
+const PARENT = utils.createEitherTestUser('PARENT').left.bytes;
+const ZERO = new Uint8Array(32);
+const COLOR = new Uint8Array(32).fill(1);
+const AMOUNT = 1000n;
+
+function makeCoin(color: Uint8Array, value: bigint, nonce?: Uint8Array) {
+  return {
+    nonce: nonce ?? new Uint8Array(32).fill(0),
+    color,
+    value,
+  };
+}
+
+describe('Forwarder module', () => {
+  describe('initialization', () => {
+    it('should initialize on construction when isInit is true', () => {
+      expect(() => new MockForwarderSimulator(PARENT, true)).not.toThrow();
+    });
+
+    it('should fail initialization with zero parent', () => {
+      expect(() => new MockForwarderSimulator(ZERO, true)).toThrow(
+        'Forwarder: zero parent',
+      );
+    });
+
+    it('should expose the public ledger state after initialization', () => {
+      const mock = new MockForwarderSimulator(PARENT, true);
+      expect(mock.getPublicState()).toBeDefined();
+    });
+  });
+
+  describe('init guard', () => {
+    let mock: MockForwarderSimulator;
+
+    beforeEach(() => {
+      mock = new MockForwarderSimulator(PARENT, false);
+    });
+
+    it('should fail depositShielded when not initialized', () => {
+      expect(() => mock.depositShielded(makeCoin(COLOR, AMOUNT))).toThrow(
+        'Initializable: contract not initialized',
+      );
+    });
+
+    it('should fail depositUnshielded when not initialized', () => {
+      expect(() => mock.depositUnshielded(COLOR, AMOUNT)).toThrow(
+        'Initializable: contract not initialized',
+      );
+    });
+  });
+
+  describe('deposit', () => {
+    let mock: MockForwarderSimulator;
+
+    beforeEach(() => {
+      mock = new MockForwarderSimulator(PARENT, true);
+    });
+
+    it('should accept a shielded deposit and forward it', () => {
+      expect(() =>
+        mock.depositShielded(makeCoin(COLOR, AMOUNT)),
+      ).not.toThrow();
+    });
+
+    it('should accept an unshielded deposit and forward it', () => {
+      expect(() => mock.depositUnshielded(COLOR, AMOUNT)).not.toThrow();
+    });
+  });
+});

--- a/contracts/src/multisig/test/ForwarderPrivate.test.ts
+++ b/contracts/src/multisig/test/ForwarderPrivate.test.ts
@@ -1,0 +1,235 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import fc from 'fast-check';
+import * as utils from '#test-utils/address.js';
+import { MockForwarderPrivateSimulator } from './simulators/MockForwarderPrivateSimulator.js';
+
+const PARENT = utils.createEitherTestUser('PARENT').left.bytes;
+const WRONG_PARENT = utils.createEitherTestUser('WRONG').left.bytes;
+const OP_SECRET = new Uint8Array(32).fill(0xaa);
+const WRONG_OP_SECRET = new Uint8Array(32).fill(0xbb);
+const ZERO = new Uint8Array(32);
+const COLOR = new Uint8Array(32).fill(1);
+const AMOUNT = 1000n;
+const MAX_U64 = (1n << 64n) - 1n;
+
+function makeCoin(color: Uint8Array, value: bigint, nonce?: Uint8Array) {
+  return {
+    nonce: nonce ?? new Uint8Array(32).fill(0),
+    color,
+    value,
+  };
+}
+
+function makeQualifiedCoin(
+  color: Uint8Array,
+  value: bigint,
+  mtIndex: bigint,
+  nonce?: Uint8Array,
+) {
+  return {
+    nonce: nonce ?? new Uint8Array(32).fill(0),
+    color,
+    value,
+    mt_index: mtIndex,
+  };
+}
+
+function commitment(parent: Uint8Array, opSecret: Uint8Array): Uint8Array {
+  return MockForwarderPrivateSimulator.calculateParentCommitment(parent, opSecret);
+}
+
+describe('ForwarderPrivate module', () => {
+  describe('initialization', () => {
+    it('should initialize on construction when isInit is true', () => {
+      const c = commitment(PARENT, OP_SECRET);
+      const mock = new MockForwarderPrivateSimulator(c, true);
+      expect(() => mock.deposit(makeCoin(COLOR, AMOUNT))).not.toThrow();
+    });
+
+    it('should fail initialization with zero commitment', () => {
+      expect(() => new MockForwarderPrivateSimulator(ZERO, true)).toThrow(
+        'ForwarderPrivate: zero commitment',
+      );
+    });
+
+    it('should expose the public ledger state after initialization', () => {
+      const c = commitment(PARENT, OP_SECRET);
+      const mock = new MockForwarderPrivateSimulator(c, true);
+      expect(mock.getPublicState()).toBeDefined();
+    });
+  });
+
+  describe('init guard', () => {
+    let mock: MockForwarderPrivateSimulator;
+
+    beforeEach(() => {
+      mock = new MockForwarderPrivateSimulator(commitment(PARENT, OP_SECRET), false);
+    });
+
+    it('should fail deposit when not initialized', () => {
+      expect(() => mock.deposit(makeCoin(COLOR, AMOUNT))).toThrow(
+        'Initializable: contract not initialized',
+      );
+    });
+
+    it('should fail drain when not initialized', () => {
+      expect(() =>
+        mock.drain(makeQualifiedCoin(COLOR, AMOUNT, 0n), PARENT, OP_SECRET, AMOUNT),
+      ).toThrow('Initializable: contract not initialized');
+    });
+  });
+
+  describe('calculateParentCommitment', () => {
+    it('should produce the same commitment for the same (parent, opSecret)', () => {
+      const c1 = commitment(PARENT, OP_SECRET);
+      const c2 = commitment(PARENT, OP_SECRET);
+      expect(c1).toEqual(c2);
+    });
+
+    it('should produce different commitments for different opSecrets', () => {
+      fc.assert(
+        fc.property(
+          fc.uint8Array({ minLength: 32, maxLength: 32 }),
+          fc.uint8Array({ minLength: 32, maxLength: 32 }),
+          fc.uint8Array({ minLength: 32, maxLength: 32 }),
+          (parent, s1, s2) => {
+            fc.pre(s1.some((b, i) => b !== s2[i]));
+            const c1 = commitment(
+              Uint8Array.from(parent),
+              Uint8Array.from(s1),
+            );
+            const c2 = commitment(
+              Uint8Array.from(parent),
+              Uint8Array.from(s2),
+            );
+            expect(c1).not.toEqual(c2);
+          },
+        ),
+        { numRuns: 50 },
+      );
+    });
+  });
+
+  describe('drain', () => {
+    let mock: MockForwarderPrivateSimulator;
+
+    beforeEach(() => {
+      mock = new MockForwarderPrivateSimulator(commitment(PARENT, OP_SECRET), true);
+      mock.deposit(makeCoin(COLOR, AMOUNT));
+    });
+
+    it('should succeed drain with correct (parentAddr, opSecret)', () => {
+      const result = mock.drain(
+        makeQualifiedCoin(COLOR, AMOUNT, 0n),
+        PARENT,
+        OP_SECRET,
+        AMOUNT,
+      );
+      expect(result.sent.value).toEqual(AMOUNT);
+    });
+
+    it('should fail drain with wrong parentAddr', () => {
+      expect(() =>
+        mock.drain(
+          makeQualifiedCoin(COLOR, AMOUNT, 0n),
+          WRONG_PARENT,
+          OP_SECRET,
+          AMOUNT,
+        ),
+      ).toThrow('ForwarderPrivate: invalid parent');
+    });
+
+    it('should fail drain with wrong opSecret', () => {
+      expect(() =>
+        mock.drain(
+          makeQualifiedCoin(COLOR, AMOUNT, 0n),
+          PARENT,
+          WRONG_OP_SECRET,
+          AMOUNT,
+        ),
+      ).toThrow('ForwarderPrivate: invalid parent');
+    });
+
+    it('should fail drain with both wrong', () => {
+      expect(() =>
+        mock.drain(
+          makeQualifiedCoin(COLOR, AMOUNT, 0n),
+          WRONG_PARENT,
+          WRONG_OP_SECRET,
+          AMOUNT,
+        ),
+      ).toThrow('ForwarderPrivate: invalid parent');
+    });
+
+    it('should fail drain with value > coin.value', () => {
+      expect(() =>
+        mock.drain(
+          makeQualifiedCoin(COLOR, AMOUNT, 0n),
+          PARENT,
+          OP_SECRET,
+          AMOUNT + 1n,
+        ),
+      ).toThrow();
+    });
+
+    it('should produce no change when drain value equals coin value', () => {
+      const result = mock.drain(
+        makeQualifiedCoin(COLOR, AMOUNT, 0n),
+        PARENT,
+        OP_SECRET,
+        AMOUNT,
+      );
+      expect(result.change.is_some).toBe(false);
+    });
+
+    it('should produce a change coin when drain value is less than coin value', () => {
+      const result = mock.drain(
+        makeQualifiedCoin(COLOR, AMOUNT, 0n),
+        PARENT,
+        OP_SECRET,
+        400n,
+      );
+      expect(result.change.is_some).toBe(true);
+      expect(result.change.value.value).toEqual(AMOUNT - 400n);
+      expect(result.change.value.color).toEqual(COLOR);
+    });
+
+    it('should produce a sent coin of exactly value on partial drain', () => {
+      const result = mock.drain(
+        makeQualifiedCoin(COLOR, AMOUNT, 0n),
+        PARENT,
+        OP_SECRET,
+        400n,
+      );
+      expect(result.sent.value).toEqual(400n);
+      expect(result.sent.color).toEqual(COLOR);
+    });
+  });
+
+  describe('property: change arithmetic', () => {
+    it('should preserve change.value == coin.value - drain.value on partial drain', () => {
+      fc.assert(
+        fc.property(
+          fc.bigInt({ min: 2n, max: MAX_U64 - 1n }),
+          fc.bigInt({ min: 1n, max: MAX_U64 - 1n }),
+          (coinVal, drainVal) => {
+            fc.pre(drainVal < coinVal);
+            const mock = new MockForwarderPrivateSimulator(
+              commitment(PARENT, OP_SECRET),
+              true,
+            );
+            mock.deposit(makeCoin(COLOR, coinVal));
+            const result = mock.drain(
+              makeQualifiedCoin(COLOR, coinVal, 0n),
+              PARENT,
+              OP_SECRET,
+              drainVal,
+            );
+            expect(result.change.value.value).toEqual(coinVal - drainVal);
+          },
+        ),
+        { numRuns: 25 },
+      );
+    });
+  });
+});

--- a/contracts/src/multisig/test/ProposalManager.test.ts
+++ b/contracts/src/multisig/test/ProposalManager.test.ts
@@ -1,0 +1,355 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import * as utils from '#test-utils/address.js';
+import { ProposalManagerSimulator } from './simulators/ProposalManagerSimulator.js';
+
+// Enum values matching ProposalStatus and RecipientKind
+const ProposalStatus = { Inactive: 0, Active: 1, Executed: 2, Cancelled: 3 };
+const RecipientKind = { ShieldedUser: 0, UnshieldedUser: 1, Contract: 2 };
+
+const COLOR = new Uint8Array(32).fill(1);
+const COLOR2 = new Uint8Array(32).fill(2);
+const AMOUNT = 1000n;
+const AMOUNT2 = 2000n;
+
+const [_RECIPIENT, Z_RECIPIENT] = utils.generatePubKeyPair('RECIPIENT');
+const Z_CONTRACT_RECIPIENT = utils.encodeToAddress('CONTRACT_RECIPIENT');
+
+let contract: ProposalManagerSimulator;
+
+describe('ProposalManager', () => {
+  beforeEach(() => {
+    contract = new ProposalManagerSimulator();
+  });
+
+  describe('recipient helpers (pure)', () => {
+    it('should create shielded user recipient', () => {
+      const recipient = contract.shieldedUserRecipient(Z_RECIPIENT);
+      expect(recipient.kind).toEqual(RecipientKind.ShieldedUser);
+      expect(recipient.address).toEqual(Z_RECIPIENT.bytes);
+    });
+
+    it('should create unshielded user recipient', () => {
+      const addr = utils.encodeToPK('UNSHIELDED_USER');
+      const recipient = contract.unshieldedUserRecipient(addr);
+      expect(recipient.kind).toEqual(RecipientKind.UnshieldedUser);
+      expect(recipient.address).toEqual(addr.bytes);
+    });
+
+    it('should create contract recipient', () => {
+      const recipient = contract.contractRecipient(Z_CONTRACT_RECIPIENT);
+      expect(recipient.kind).toEqual(RecipientKind.Contract);
+      expect(recipient.address).toEqual(Z_CONTRACT_RECIPIENT.bytes);
+    });
+
+    it('should convert shielded user recipient to shielded send format', () => {
+      const recipient = contract.shieldedUserRecipient(Z_RECIPIENT);
+      const shielded = contract.toShieldedRecipient(recipient);
+      expect(shielded.is_left).toEqual(true);
+      expect(shielded.left.bytes).toEqual(Z_RECIPIENT.bytes);
+    });
+
+    it('should convert contract recipient to shielded send format', () => {
+      const recipient = contract.contractRecipient(Z_CONTRACT_RECIPIENT);
+      const shielded = contract.toShieldedRecipient(recipient);
+      expect(shielded.is_left).toEqual(false);
+      expect(shielded.right.bytes).toEqual(Z_CONTRACT_RECIPIENT.bytes);
+    });
+
+    it('should reject unshielded user in toShieldedRecipient', () => {
+      const recipient = {
+        kind: RecipientKind.UnshieldedUser,
+        address: new Uint8Array(32),
+      };
+      expect(() => {
+        contract.toShieldedRecipient(recipient);
+      }).toThrow('ProposalManager: invalid shielded recipient');
+    });
+
+    it('should convert contract recipient to unshielded send format', () => {
+      const recipient = contract.contractRecipient(Z_CONTRACT_RECIPIENT);
+      const unshielded = contract.toUnshieldedRecipient(recipient);
+      expect(unshielded.is_left).toEqual(true);
+      expect(unshielded.left.bytes).toEqual(Z_CONTRACT_RECIPIENT.bytes);
+    });
+
+    it('should convert unshielded user recipient to unshielded send format', () => {
+      const addr = utils.encodeToPK('UNSHIELDED_USER');
+      const recipient = contract.unshieldedUserRecipient(addr);
+      const unshielded = contract.toUnshieldedRecipient(recipient);
+      expect(unshielded.is_left).toEqual(false);
+      expect(unshielded.right.bytes).toEqual(addr.bytes);
+    });
+
+    it('should reject shielded user in toUnshieldedRecipient', () => {
+      const recipient = contract.shieldedUserRecipient(Z_RECIPIENT);
+      expect(() => {
+        contract.toUnshieldedRecipient(recipient);
+      }).toThrow('ProposalManager: invalid unshielded recipient');
+    });
+  });
+
+  describe('_createProposal', () => {
+    it('should create a proposal and return id', () => {
+      const recipient = contract.shieldedUserRecipient(Z_RECIPIENT);
+      const id = contract._createProposal(recipient, COLOR, AMOUNT);
+      expect(id).toEqual(1n);
+    });
+
+    it('should create sequential proposal ids', () => {
+      const recipient = contract.shieldedUserRecipient(Z_RECIPIENT);
+      const id1 = contract._createProposal(recipient, COLOR, AMOUNT);
+      const id2 = contract._createProposal(recipient, COLOR2, AMOUNT2);
+      expect(id1).toEqual(1n);
+      expect(id2).toEqual(2n);
+    });
+
+    it('should store proposal data correctly', () => {
+      const recipient = contract.shieldedUserRecipient(Z_RECIPIENT);
+      const id = contract._createProposal(recipient, COLOR, AMOUNT);
+
+      const proposal = contract.getProposal(id);
+      expect(proposal.to.kind).toEqual(RecipientKind.ShieldedUser);
+      expect(proposal.to.address).toEqual(Z_RECIPIENT.bytes);
+      expect(proposal.color).toEqual(COLOR);
+      expect(proposal.amount).toEqual(AMOUNT);
+      expect(proposal.status).toEqual(ProposalStatus.Active);
+    });
+
+    it('should store contract recipient correctly', () => {
+      const recipient = contract.contractRecipient(Z_CONTRACT_RECIPIENT);
+      const id = contract._createProposal(recipient, COLOR2, AMOUNT2);
+
+      const proposal = contract.getProposal(id);
+      expect(proposal.to.kind).toEqual(RecipientKind.Contract);
+      expect(proposal.to.address).toEqual(Z_CONTRACT_RECIPIENT.bytes);
+      expect(proposal.color).toEqual(COLOR2);
+      expect(proposal.amount).toEqual(AMOUNT2);
+    });
+
+    it('should fail with zero amount', () => {
+      const recipient = contract.shieldedUserRecipient(Z_RECIPIENT);
+      expect(() => {
+        contract._createProposal(recipient, COLOR, 0n);
+      }).toThrow('ProposalManager: zero amount');
+    });
+  });
+
+  describe('assertProposalExists', () => {
+    it('should pass for existing proposal', () => {
+      const recipient = contract.shieldedUserRecipient(Z_RECIPIENT);
+      const id = contract._createProposal(recipient, COLOR, AMOUNT);
+      expect(() => contract.assertProposalExists(id)).not.toThrow();
+    });
+
+    it('should fail for non-existing proposal', () => {
+      expect(() => {
+        contract.assertProposalExists(999n);
+      }).toThrow('ProposalManager: proposal not found');
+    });
+  });
+
+  describe('assertProposalActive', () => {
+    it('should pass for active proposal', () => {
+      const recipient = contract.shieldedUserRecipient(Z_RECIPIENT);
+      const id = contract._createProposal(recipient, COLOR, AMOUNT);
+      expect(() => contract.assertProposalActive(id)).not.toThrow();
+    });
+
+    it('should fail for non-existing proposal', () => {
+      expect(() => {
+        contract.assertProposalActive(999n);
+      }).toThrow('ProposalManager: proposal not found');
+    });
+
+    it('should fail for cancelled proposal', () => {
+      const recipient = contract.shieldedUserRecipient(Z_RECIPIENT);
+      const id = contract._createProposal(recipient, COLOR, AMOUNT);
+      contract._cancelProposal(id);
+      expect(() => {
+        contract.assertProposalActive(id);
+      }).toThrow('ProposalManager: proposal not active');
+    });
+
+    it('should fail for executed proposal', () => {
+      const recipient = contract.shieldedUserRecipient(Z_RECIPIENT);
+      const id = contract._createProposal(recipient, COLOR, AMOUNT);
+      contract._markExecuted(id);
+      expect(() => {
+        contract.assertProposalActive(id);
+      }).toThrow('ProposalManager: proposal not active');
+    });
+  });
+
+  describe('_cancelProposal', () => {
+    it('should cancel an active proposal', () => {
+      const recipient = contract.shieldedUserRecipient(Z_RECIPIENT);
+      const id = contract._createProposal(recipient, COLOR, AMOUNT);
+
+      contract._cancelProposal(id);
+      expect(contract.getProposalStatus(id)).toEqual(ProposalStatus.Cancelled);
+    });
+
+    it('should preserve proposal data after cancellation', () => {
+      const recipient = contract.shieldedUserRecipient(Z_RECIPIENT);
+      const id = contract._createProposal(recipient, COLOR, AMOUNT);
+
+      contract._cancelProposal(id);
+      const proposal = contract.getProposal(id);
+      expect(proposal.to.address).toEqual(Z_RECIPIENT.bytes);
+      expect(proposal.color).toEqual(COLOR);
+      expect(proposal.amount).toEqual(AMOUNT);
+    });
+
+    it('should fail for non-existing proposal', () => {
+      expect(() => {
+        contract._cancelProposal(999n);
+      }).toThrow('ProposalManager: proposal not found');
+    });
+
+    it('should fail for already cancelled proposal', () => {
+      const recipient = contract.shieldedUserRecipient(Z_RECIPIENT);
+      const id = contract._createProposal(recipient, COLOR, AMOUNT);
+      contract._cancelProposal(id);
+
+      expect(() => {
+        contract._cancelProposal(id);
+      }).toThrow('ProposalManager: proposal not active');
+    });
+
+    it('should fail for executed proposal', () => {
+      const recipient = contract.shieldedUserRecipient(Z_RECIPIENT);
+      const id = contract._createProposal(recipient, COLOR, AMOUNT);
+      contract._markExecuted(id);
+
+      expect(() => {
+        contract._cancelProposal(id);
+      }).toThrow('ProposalManager: proposal not active');
+    });
+  });
+
+  describe('_markExecuted', () => {
+    it('should mark an active proposal as executed', () => {
+      const recipient = contract.shieldedUserRecipient(Z_RECIPIENT);
+      const id = contract._createProposal(recipient, COLOR, AMOUNT);
+
+      contract._markExecuted(id);
+      expect(contract.getProposalStatus(id)).toEqual(ProposalStatus.Executed);
+    });
+
+    it('should fail for non-existing proposal', () => {
+      expect(() => {
+        contract._markExecuted(999n);
+      }).toThrow('ProposalManager: proposal not found');
+    });
+
+    it('should fail for already executed proposal', () => {
+      const recipient = contract.shieldedUserRecipient(Z_RECIPIENT);
+      const id = contract._createProposal(recipient, COLOR, AMOUNT);
+      contract._markExecuted(id);
+
+      expect(() => {
+        contract._markExecuted(id);
+      }).toThrow('ProposalManager: proposal not active');
+    });
+
+    it('should fail for cancelled proposal', () => {
+      const recipient = contract.shieldedUserRecipient(Z_RECIPIENT);
+      const id = contract._createProposal(recipient, COLOR, AMOUNT);
+      contract._cancelProposal(id);
+
+      expect(() => {
+        contract._markExecuted(id);
+      }).toThrow('ProposalManager: proposal not active');
+    });
+  });
+
+  describe('view circuits', () => {
+    let proposalId: bigint;
+
+    beforeEach(() => {
+      const recipient = contract.shieldedUserRecipient(Z_RECIPIENT);
+      proposalId = contract._createProposal(recipient, COLOR, AMOUNT);
+    });
+
+    it('getProposal should return full proposal', () => {
+      const proposal = contract.getProposal(proposalId);
+      expect(proposal.to.kind).toEqual(RecipientKind.ShieldedUser);
+      expect(proposal.color).toEqual(COLOR);
+      expect(proposal.amount).toEqual(AMOUNT);
+      expect(proposal.status).toEqual(ProposalStatus.Active);
+    });
+
+    it('getProposalRecipient should return recipient', () => {
+      const recipient = contract.getProposalRecipient(proposalId);
+      expect(recipient.kind).toEqual(RecipientKind.ShieldedUser);
+      expect(recipient.address).toEqual(Z_RECIPIENT.bytes);
+    });
+
+    it('getProposalAmount should return amount', () => {
+      expect(contract.getProposalAmount(proposalId)).toEqual(AMOUNT);
+    });
+
+    it('getProposalColor should return color', () => {
+      expect(contract.getProposalColor(proposalId)).toEqual(COLOR);
+    });
+
+    it('getProposalStatus should return status', () => {
+      expect(contract.getProposalStatus(proposalId)).toEqual(
+        ProposalStatus.Active,
+      );
+    });
+
+    it('all view circuits should fail for non-existing proposal', () => {
+      const badId = 999n;
+      expect(() => contract.getProposal(badId)).toThrow(
+        'ProposalManager: proposal not found',
+      );
+      expect(() => contract.getProposalRecipient(badId)).toThrow(
+        'ProposalManager: proposal not found',
+      );
+      expect(() => contract.getProposalAmount(badId)).toThrow(
+        'ProposalManager: proposal not found',
+      );
+      expect(() => contract.getProposalColor(badId)).toThrow(
+        'ProposalManager: proposal not found',
+      );
+      expect(() => contract.getProposalStatus(badId)).toThrow(
+        'ProposalManager: proposal not found',
+      );
+    });
+  });
+
+  describe('lifecycle transitions', () => {
+    it('should handle create -> cancel flow', () => {
+      const recipient = contract.shieldedUserRecipient(Z_RECIPIENT);
+      const id = contract._createProposal(recipient, COLOR, AMOUNT);
+      expect(contract.getProposalStatus(id)).toEqual(ProposalStatus.Active);
+
+      contract._cancelProposal(id);
+      expect(contract.getProposalStatus(id)).toEqual(ProposalStatus.Cancelled);
+    });
+
+    it('should handle create -> execute flow', () => {
+      const recipient = contract.shieldedUserRecipient(Z_RECIPIENT);
+      const id = contract._createProposal(recipient, COLOR, AMOUNT);
+      expect(contract.getProposalStatus(id)).toEqual(ProposalStatus.Active);
+
+      contract._markExecuted(id);
+      expect(contract.getProposalStatus(id)).toEqual(ProposalStatus.Executed);
+    });
+
+    it('should handle multiple proposals independently', () => {
+      const recipient = contract.shieldedUserRecipient(Z_RECIPIENT);
+      const id1 = contract._createProposal(recipient, COLOR, AMOUNT);
+      const id2 = contract._createProposal(recipient, COLOR2, AMOUNT2);
+
+      contract._cancelProposal(id1);
+
+      expect(contract.getProposalStatus(id1)).toEqual(ProposalStatus.Cancelled);
+      expect(contract.getProposalStatus(id2)).toEqual(ProposalStatus.Active);
+
+      contract._markExecuted(id2);
+      expect(contract.getProposalStatus(id2)).toEqual(ProposalStatus.Executed);
+    });
+  });
+});

--- a/contracts/src/multisig/test/ShieldedMultiSig.test.ts
+++ b/contracts/src/multisig/test/ShieldedMultiSig.test.ts
@@ -1,0 +1,528 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import * as utils from '#test-utils/address.js';
+import { ShieldedMultiSigSimulator } from './simulators/ShieldedMultiSigSimulator.js';
+
+const ProposalStatus = { Inactive: 0, Active: 1, Executed: 2, Cancelled: 3 };
+const RecipientKind = { ShieldedUser: 0, UnshieldedUser: 1, Contract: 2 };
+
+const THRESHOLD = 2n;
+const COLOR = new Uint8Array(32).fill(1);
+const AMOUNT = 1000n;
+const PROPOSAL_AMOUNT = 400n;
+
+const [SIGNER1, Z_SIGNER1] = utils.generateEitherPubKeyPair('SIGNER1');
+const [SIGNER2, Z_SIGNER2] = utils.generateEitherPubKeyPair('SIGNER2');
+const [SIGNER3, Z_SIGNER3] = utils.generateEitherPubKeyPair('SIGNER3');
+const SIGNERS = [Z_SIGNER1, Z_SIGNER2, Z_SIGNER3];
+
+const [_NON_SIGNER, Z_NON_SIGNER] = utils.generateEitherPubKeyPair('OTHER');
+const [, Z_RECIPIENT_PK] = utils.generatePubKeyPair('RECIPIENT');
+
+function makeRecipient(pk: { bytes: Uint8Array }): {
+  kind: number;
+  address: Uint8Array;
+} {
+  return { kind: RecipientKind.ShieldedUser, address: pk.bytes };
+}
+
+function makeCoin(
+  color: Uint8Array,
+  value: bigint,
+  nonce?: Uint8Array,
+): { nonce: Uint8Array; color: Uint8Array; value: bigint } {
+  return {
+    nonce: nonce ?? new Uint8Array(32).fill(0),
+    color,
+    value,
+  };
+}
+
+let multisig: ShieldedMultiSigSimulator;
+
+describe('ShieldedMultiSig', () => {
+  describe('constructor', () => {
+    it('should initialize with signers and threshold', () => {
+      multisig = new ShieldedMultiSigSimulator(SIGNERS, THRESHOLD);
+      expect(multisig.getSignerCount()).toEqual(BigInt(SIGNERS.length));
+      expect(multisig.getThreshold()).toEqual(THRESHOLD);
+    });
+
+    it('should register all signers', () => {
+      multisig = new ShieldedMultiSigSimulator(SIGNERS, THRESHOLD);
+      for (const signer of SIGNERS) {
+        expect(multisig.isSigner(signer)).toEqual(true);
+      }
+    });
+
+    it('should reject non-signers', () => {
+      multisig = new ShieldedMultiSigSimulator(SIGNERS, THRESHOLD);
+      expect(multisig.isSigner(Z_NON_SIGNER)).toEqual(false);
+    });
+
+    it('should fail with zero threshold', () => {
+      expect(() => {
+        new ShieldedMultiSigSimulator(SIGNERS, 0n);
+      }).toThrow('SignerManager: threshold must be > 0');
+    });
+
+    it('should fail with threshold exceeding signer count', () => {
+      expect(() => {
+        new ShieldedMultiSigSimulator(SIGNERS, 4n);
+      }).toThrow('SignerManager: threshold exceeds signer count');
+    });
+  });
+
+  describe('when initialized', () => {
+    beforeEach(() => {
+      multisig = new ShieldedMultiSigSimulator(SIGNERS, THRESHOLD);
+    });
+
+    describe('deposit', () => {
+      it('should accept deposits', () => {
+        multisig.deposit(makeCoin(COLOR, AMOUNT));
+        expect(multisig.getTokenBalance(COLOR)).toEqual(AMOUNT);
+      });
+
+      it('should accumulate deposits', () => {
+        multisig.deposit(makeCoin(COLOR, AMOUNT, new Uint8Array(32).fill(1)));
+        multisig.deposit(makeCoin(COLOR, AMOUNT, new Uint8Array(32).fill(2)));
+        expect(multisig.getTokenBalance(COLOR)).toEqual(AMOUNT * 2n);
+      });
+
+      it('should track received total', () => {
+        multisig.deposit(makeCoin(COLOR, AMOUNT));
+        expect(multisig.getReceivedTotal(COLOR)).toEqual(AMOUNT);
+      });
+    });
+
+    describe('createShieldedProposal', () => {
+      it('should allow signer to create proposal', () => {
+        const to = makeRecipient(Z_RECIPIENT_PK);
+        const id = multisig
+          .as(SIGNER1)
+          .createShieldedProposal(to, COLOR, PROPOSAL_AMOUNT);
+        expect(id).toEqual(1n);
+      });
+
+      it('should store proposal data correctly', () => {
+        const to = makeRecipient(Z_RECIPIENT_PK);
+        const id = multisig
+          .as(SIGNER1)
+          .createShieldedProposal(to, COLOR, PROPOSAL_AMOUNT);
+
+        const proposal = multisig.getProposal(id);
+        expect(proposal.status).toEqual(ProposalStatus.Active);
+        expect(proposal.amount).toEqual(PROPOSAL_AMOUNT);
+        expect(proposal.color).toEqual(COLOR);
+      });
+
+      it('should fail for non-signer', () => {
+        const to = makeRecipient(Z_RECIPIENT_PK);
+        expect(() => {
+          multisig
+            .as(_NON_SIGNER)
+            .createShieldedProposal(to, COLOR, PROPOSAL_AMOUNT);
+        }).toThrow('SignerManager: not a signer');
+      });
+
+      it('should fail with zero amount', () => {
+        const to = makeRecipient(Z_RECIPIENT_PK);
+        expect(() => {
+          multisig.as(SIGNER1).createShieldedProposal(to, COLOR, 0n);
+        }).toThrow('ProposalManager: zero amount');
+      });
+
+      it('should reject UnshieldedUser recipient kind', () => {
+        const to = {
+          kind: RecipientKind.UnshieldedUser,
+          address: Z_RECIPIENT_PK.bytes,
+        };
+        expect(() => {
+          multisig
+            .as(SIGNER1)
+            .createShieldedProposal(to, COLOR, PROPOSAL_AMOUNT);
+        }).toThrow(
+          'ShieldedMultiSig: recipient must be a shielded user or contract',
+        );
+      });
+
+      it('should accept Contract recipient kind', () => {
+        const to = {
+          kind: RecipientKind.Contract,
+          address: new Uint8Array(32).fill(7),
+        };
+        const id = multisig
+          .as(SIGNER1)
+          .createShieldedProposal(to, COLOR, PROPOSAL_AMOUNT);
+        expect(id).toEqual(1n);
+        expect(multisig.getProposalRecipient(id).kind).toEqual(
+          RecipientKind.Contract,
+        );
+      });
+    });
+
+    describe('approveProposal', () => {
+      let proposalId: bigint;
+
+      beforeEach(() => {
+        const to = makeRecipient(Z_RECIPIENT_PK);
+        proposalId = multisig
+          .as(SIGNER1)
+          .createShieldedProposal(to, COLOR, PROPOSAL_AMOUNT);
+      });
+
+      it('should allow signer to approve', () => {
+        multisig.as(SIGNER1).approveProposal(proposalId);
+        expect(
+          multisig.isProposalApprovedBySigner(proposalId, Z_SIGNER1),
+        ).toEqual(true);
+        expect(multisig.getApprovalCount(proposalId)).toEqual(1n);
+      });
+
+      it('should allow multiple signers to approve', () => {
+        multisig.as(SIGNER1).approveProposal(proposalId);
+        multisig.as(SIGNER2).approveProposal(proposalId);
+        expect(multisig.getApprovalCount(proposalId)).toEqual(2n);
+      });
+
+      it('should fail for non-signer', () => {
+        expect(() => {
+          multisig.as(_NON_SIGNER).approveProposal(proposalId);
+        }).toThrow('SignerManager: not a signer');
+      });
+
+      it('should fail for double approval', () => {
+        multisig.as(SIGNER1).approveProposal(proposalId);
+        expect(() => {
+          multisig.as(SIGNER1).approveProposal(proposalId);
+        }).toThrow('Multisig: already approved');
+      });
+
+      it('should fail for non-existing proposal', () => {
+        expect(() => {
+          multisig.as(SIGNER1).approveProposal(999n);
+        }).toThrow('ProposalManager: proposal not found');
+      });
+
+      it('should fail for executed proposal', () => {
+        multisig.deposit(makeCoin(COLOR, AMOUNT));
+        multisig.as(SIGNER1).approveProposal(proposalId);
+        multisig.as(SIGNER2).approveProposal(proposalId);
+        multisig.executeShieldedProposal(proposalId);
+
+        expect(() => {
+          multisig.as(SIGNER3).approveProposal(proposalId);
+        }).toThrow('ProposalManager: proposal not active');
+      });
+    });
+
+    describe('revokeApproval', () => {
+      let proposalId: bigint;
+
+      beforeEach(() => {
+        const to = makeRecipient(Z_RECIPIENT_PK);
+        proposalId = multisig
+          .as(SIGNER1)
+          .createShieldedProposal(to, COLOR, PROPOSAL_AMOUNT);
+        multisig.as(SIGNER1).approveProposal(proposalId);
+      });
+
+      it('should allow signer to revoke their approval', () => {
+        multisig.as(SIGNER1).revokeApproval(proposalId);
+        expect(
+          multisig.isProposalApprovedBySigner(proposalId, Z_SIGNER1),
+        ).toEqual(false);
+        expect(multisig.getApprovalCount(proposalId)).toEqual(0n);
+      });
+
+      it('should fail for non-signer', () => {
+        expect(() => {
+          multisig.as(_NON_SIGNER).revokeApproval(proposalId);
+        }).toThrow('SignerManager: not a signer');
+      });
+
+      it('should fail if not yet approved', () => {
+        expect(() => {
+          multisig.as(SIGNER2).revokeApproval(proposalId);
+        }).toThrow('Multisig: not approved');
+      });
+
+      it('should allow re-approval after revoke', () => {
+        multisig.as(SIGNER1).revokeApproval(proposalId);
+        multisig.as(SIGNER1).approveProposal(proposalId);
+        expect(
+          multisig.isProposalApprovedBySigner(proposalId, Z_SIGNER1),
+        ).toEqual(true);
+        expect(multisig.getApprovalCount(proposalId)).toEqual(1n);
+      });
+
+      it('should fail for executed proposal', () => {
+        multisig.deposit(makeCoin(COLOR, AMOUNT));
+        multisig.as(SIGNER2).approveProposal(proposalId);
+        multisig.executeShieldedProposal(proposalId);
+
+        expect(() => {
+          multisig.as(SIGNER1).revokeApproval(proposalId);
+        }).toThrow('ProposalManager: proposal not active');
+      });
+    });
+
+    describe('executeShieldedProposal', () => {
+      let proposalId: bigint;
+
+      beforeEach(() => {
+        // Fund the treasury
+        multisig.deposit(makeCoin(COLOR, AMOUNT));
+
+        // Create and approve proposal to threshold
+        const to = makeRecipient(Z_RECIPIENT_PK);
+        proposalId = multisig
+          .as(SIGNER1)
+          .createShieldedProposal(to, COLOR, PROPOSAL_AMOUNT);
+        multisig.as(SIGNER1).approveProposal(proposalId);
+        multisig.as(SIGNER2).approveProposal(proposalId);
+      });
+
+      it('should execute when threshold is met', () => {
+        multisig.executeShieldedProposal(proposalId);
+        expect(multisig.getProposalStatus(proposalId)).toEqual(
+          ProposalStatus.Executed,
+        );
+      });
+
+      it('should return sent coin and change in result', () => {
+        const result = multisig.executeShieldedProposal(proposalId);
+        expect(result.sent.value).toEqual(PROPOSAL_AMOUNT);
+        expect(result.sent.color).toEqual(COLOR);
+        expect(result.change.is_some).toEqual(true);
+        expect(result.change.value.value).toEqual(AMOUNT - PROPOSAL_AMOUNT);
+        expect(result.change.value.color).toEqual(COLOR);
+      });
+
+      it('should return no change when sending full balance', () => {
+        // Create proposal for the full amount
+        const to = makeRecipient(Z_RECIPIENT_PK);
+        const fullId = multisig
+          .as(SIGNER1)
+          .createShieldedProposal(to, COLOR, AMOUNT);
+        multisig.as(SIGNER1).approveProposal(fullId);
+        multisig.as(SIGNER2).approveProposal(fullId);
+
+        const result = multisig.executeShieldedProposal(fullId);
+        expect(result.sent.value).toEqual(AMOUNT);
+        expect(result.change.is_some).toEqual(false);
+      });
+
+      it('should deduct from treasury balance', () => {
+        multisig.executeShieldedProposal(proposalId);
+        expect(multisig.getTokenBalance(COLOR)).toEqual(
+          AMOUNT - PROPOSAL_AMOUNT,
+        );
+      });
+
+      it('should track sent total', () => {
+        multisig.executeShieldedProposal(proposalId);
+        expect(multisig.getSentTotal(COLOR)).toEqual(PROPOSAL_AMOUNT);
+      });
+
+      it('should fail when threshold is not met', () => {
+        // Create a new proposal with only 1 approval
+        const to = makeRecipient(Z_RECIPIENT_PK);
+        const id2 = multisig
+          .as(SIGNER1)
+          .createShieldedProposal(to, COLOR, 100n);
+        multisig.as(SIGNER1).approveProposal(id2);
+
+        expect(() => {
+          multisig.executeShieldedProposal(id2);
+        }).toThrow('SignerManager: threshold not met');
+      });
+
+      it('should fail for non-existing proposal', () => {
+        expect(() => {
+          multisig.executeShieldedProposal(999n);
+        }).toThrow('ProposalManager: proposal not found');
+      });
+
+      it('should fail when executed twice', () => {
+        multisig.executeShieldedProposal(proposalId);
+        expect(() => {
+          multisig.executeShieldedProposal(proposalId);
+        }).toThrow('ProposalManager: proposal not active');
+      });
+
+      it('should fail with insufficient treasury balance', () => {
+        // Create proposal for more than treasury holds
+        const to = makeRecipient(Z_RECIPIENT_PK);
+        const bigId = multisig
+          .as(SIGNER1)
+          .createShieldedProposal(to, COLOR, AMOUNT + 1n);
+        multisig.as(SIGNER1).approveProposal(bigId);
+        multisig.as(SIGNER2).approveProposal(bigId);
+
+        expect(() => {
+          multisig.executeShieldedProposal(bigId);
+        }).toThrow('ShieldedTreasury: coin value insufficient');
+      });
+    });
+
+    describe('view - approvals', () => {
+      it('should return false for unapproved signer', () => {
+        const to = makeRecipient(Z_RECIPIENT_PK);
+        const id = multisig
+          .as(SIGNER1)
+          .createShieldedProposal(to, COLOR, PROPOSAL_AMOUNT);
+        expect(multisig.isProposalApprovedBySigner(id, Z_SIGNER1)).toEqual(
+          false,
+        );
+      });
+
+      it('should return 0 approval count for new proposal', () => {
+        const to = makeRecipient(Z_RECIPIENT_PK);
+        const id = multisig
+          .as(SIGNER1)
+          .createShieldedProposal(to, COLOR, PROPOSAL_AMOUNT);
+        expect(multisig.getApprovalCount(id)).toEqual(0n);
+      });
+    });
+
+    describe('view - proposal delegation', () => {
+      let proposalId: bigint;
+
+      beforeEach(() => {
+        const to = makeRecipient(Z_RECIPIENT_PK);
+        proposalId = multisig
+          .as(SIGNER1)
+          .createShieldedProposal(to, COLOR, PROPOSAL_AMOUNT);
+      });
+
+      it('getProposalRecipient should return recipient', () => {
+        const recipient = multisig.getProposalRecipient(proposalId);
+        expect(recipient.kind).toEqual(RecipientKind.ShieldedUser);
+        expect(recipient.address).toEqual(Z_RECIPIENT_PK.bytes);
+      });
+
+      it('getProposalAmount should return amount', () => {
+        expect(multisig.getProposalAmount(proposalId)).toEqual(PROPOSAL_AMOUNT);
+      });
+
+      it('getProposalColor should return color', () => {
+        expect(multisig.getProposalColor(proposalId)).toEqual(COLOR);
+      });
+    });
+
+    describe('view - signer manager delegation', () => {
+      it('getSignerCount should match initial count', () => {
+        expect(multisig.getSignerCount()).toEqual(BigInt(SIGNERS.length));
+      });
+
+      it('getThreshold should match initial threshold', () => {
+        expect(multisig.getThreshold()).toEqual(THRESHOLD);
+      });
+
+      it('isSigner should return true for signer', () => {
+        expect(multisig.isSigner(Z_SIGNER1)).toEqual(true);
+      });
+
+      it('isSigner should return false for non-signer', () => {
+        expect(multisig.isSigner(Z_NON_SIGNER)).toEqual(false);
+      });
+    });
+
+    describe('view - treasury delegation', () => {
+      beforeEach(() => {
+        multisig.deposit(makeCoin(COLOR, AMOUNT));
+      });
+
+      it('getTokenBalance should reflect deposits', () => {
+        expect(multisig.getTokenBalance(COLOR)).toEqual(AMOUNT);
+      });
+
+      it('getReceivedTotal should reflect deposits', () => {
+        expect(multisig.getReceivedTotal(COLOR)).toEqual(AMOUNT);
+      });
+
+      it('getSentTotal should be 0 before any sends', () => {
+        expect(multisig.getSentTotal(COLOR)).toEqual(0n);
+      });
+
+      it('getReceivedMinusSent should equal balance', () => {
+        expect(multisig.getReceivedMinusSent(COLOR)).toEqual(AMOUNT);
+      });
+    });
+
+    describe('full lifecycle', () => {
+      it('should handle deposit -> propose -> approve -> execute', () => {
+        // Deposit
+        multisig.deposit(makeCoin(COLOR, AMOUNT));
+        expect(multisig.getTokenBalance(COLOR)).toEqual(AMOUNT);
+
+        // Propose
+        const to = makeRecipient(Z_RECIPIENT_PK);
+        const id = multisig
+          .as(SIGNER1)
+          .createShieldedProposal(to, COLOR, PROPOSAL_AMOUNT);
+
+        // Approve to threshold
+        multisig.as(SIGNER1).approveProposal(id);
+        multisig.as(SIGNER2).approveProposal(id);
+        expect(multisig.getApprovalCount(id)).toEqual(THRESHOLD);
+
+        // Execute
+        multisig.executeShieldedProposal(id);
+        expect(multisig.getProposalStatus(id)).toEqual(ProposalStatus.Executed);
+        expect(multisig.getTokenBalance(COLOR)).toEqual(
+          AMOUNT - PROPOSAL_AMOUNT,
+        );
+        expect(multisig.getReceivedMinusSent(COLOR)).toEqual(
+          AMOUNT - PROPOSAL_AMOUNT,
+        );
+      });
+
+      it('should handle multiple proposals concurrently', () => {
+        multisig.deposit(makeCoin(COLOR, AMOUNT));
+
+        const to = makeRecipient(Z_RECIPIENT_PK);
+        const id1 = multisig
+          .as(SIGNER1)
+          .createShieldedProposal(to, COLOR, 200n);
+        const id2 = multisig
+          .as(SIGNER2)
+          .createShieldedProposal(to, COLOR, 300n);
+
+        // Approve and execute first
+        multisig.as(SIGNER1).approveProposal(id1);
+        multisig.as(SIGNER2).approveProposal(id1);
+        multisig.executeShieldedProposal(id1);
+
+        // Approve and execute second
+        multisig.as(SIGNER1).approveProposal(id2);
+        multisig.as(SIGNER3).approveProposal(id2);
+        multisig.executeShieldedProposal(id2);
+
+        expect(multisig.getTokenBalance(COLOR)).toEqual(AMOUNT - 200n - 300n);
+      });
+
+      it('should handle approve -> revoke -> re-approve -> execute', () => {
+        multisig.deposit(makeCoin(COLOR, AMOUNT));
+        const to = makeRecipient(Z_RECIPIENT_PK);
+        const id = multisig
+          .as(SIGNER1)
+          .createShieldedProposal(to, COLOR, PROPOSAL_AMOUNT);
+
+        // Approve then revoke
+        multisig.as(SIGNER1).approveProposal(id);
+        multisig.as(SIGNER1).revokeApproval(id);
+        expect(multisig.getApprovalCount(id)).toEqual(0n);
+
+        // Re-approve with enough signers
+        multisig.as(SIGNER2).approveProposal(id);
+        multisig.as(SIGNER3).approveProposal(id);
+        expect(multisig.getApprovalCount(id)).toEqual(2n);
+
+        multisig.executeShieldedProposal(id);
+        expect(multisig.getProposalStatus(id)).toEqual(ProposalStatus.Executed);
+      });
+    });
+  });
+});

--- a/contracts/src/multisig/test/ShieldedMultiSigV2.test.ts
+++ b/contracts/src/multisig/test/ShieldedMultiSigV2.test.ts
@@ -1,0 +1,186 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { ShieldedMultiSigV2Simulator } from './simulators/ShieldedMultiSigV2Simulator.js';
+
+const RecipientKind = { ShieldedUser: 0, UnshieldedUser: 1, Contract: 2 };
+
+const INSTANCE_SALT = new Uint8Array(32).fill(0xaa);
+const COLOR = new Uint8Array(32).fill(1);
+const AMOUNT = 1000n;
+
+const PK1 = new Uint8Array(64).fill(0x11);
+const PK2 = new Uint8Array(64).fill(0x22);
+const PK3 = new Uint8Array(64).fill(0x33);
+const NON_SIGNER_PK = new Uint8Array(64).fill(0x99);
+
+const COMMITMENT1 = ShieldedMultiSigV2Simulator.calculateSignerId(
+  PK1,
+  INSTANCE_SALT,
+);
+const COMMITMENT2 = ShieldedMultiSigV2Simulator.calculateSignerId(
+  PK2,
+  INSTANCE_SALT,
+);
+const COMMITMENT3 = ShieldedMultiSigV2Simulator.calculateSignerId(
+  PK3,
+  INSTANCE_SALT,
+);
+const SIGNER_COMMITMENTS = [COMMITMENT1, COMMITMENT2, COMMITMENT3];
+
+const DUMMY_SIG = new Uint8Array(64).fill(0xff);
+
+function makeRecipient(address: Uint8Array): {
+  kind: number;
+  address: Uint8Array;
+} {
+  return { kind: RecipientKind.ShieldedUser, address };
+}
+
+function makeCoin(
+  color: Uint8Array,
+  value: bigint,
+  nonce?: Uint8Array,
+): { nonce: Uint8Array; color: Uint8Array; value: bigint } {
+  return {
+    nonce: nonce ?? new Uint8Array(32).fill(0),
+    color,
+    value,
+  };
+}
+
+function makeQualifiedCoin(
+  color: Uint8Array,
+  value: bigint,
+  mtIndex: bigint,
+  nonce?: Uint8Array,
+): {
+  nonce: Uint8Array;
+  color: Uint8Array;
+  value: bigint;
+  mt_index: bigint;
+} {
+  return {
+    nonce: nonce ?? new Uint8Array(32).fill(0),
+    color,
+    value,
+    mt_index: mtIndex,
+  };
+}
+
+let multisig: ShieldedMultiSigV2Simulator;
+
+describe('ShieldedMultiSigV2', () => {
+  describe('constructor', () => {
+    it('should initialize with 2-of-3 threshold', () => {
+      multisig = new ShieldedMultiSigV2Simulator(
+        INSTANCE_SALT,
+        SIGNER_COMMITMENTS,
+        2n,
+      );
+      expect(multisig.getSignerCount()).toEqual(3n);
+      expect(multisig.getThreshold()).toEqual(2n);
+    });
+
+    it('should initialize with 1-of-3 threshold', () => {
+      multisig = new ShieldedMultiSigV2Simulator(
+        INSTANCE_SALT,
+        SIGNER_COMMITMENTS,
+        1n,
+      );
+      expect(multisig.getThreshold()).toEqual(1n);
+    });
+
+    it('should fail with zero threshold', () => {
+      expect(() => {
+        new ShieldedMultiSigV2Simulator(INSTANCE_SALT, SIGNER_COMMITMENTS, 0n);
+      }).toThrow('SignerManager: threshold must be > 0');
+    });
+
+    it('should fail with threshold greater than 2', () => {
+      expect(() => {
+        new ShieldedMultiSigV2Simulator(INSTANCE_SALT, SIGNER_COMMITMENTS, 3n);
+      }).toThrow(
+        'ShieldedMultiSigV2: threshold cannot exceed 2 (execute verifies at most 2 signatures)',
+      );
+    });
+
+    it('should register all signer commitments', () => {
+      multisig = new ShieldedMultiSigV2Simulator(
+        INSTANCE_SALT,
+        SIGNER_COMMITMENTS,
+        2n,
+      );
+      for (const commitment of SIGNER_COMMITMENTS) {
+        expect(multisig.isSigner(commitment)).toEqual(true);
+      }
+    });
+
+    it('should reject a non-signer commitment', () => {
+      multisig = new ShieldedMultiSigV2Simulator(
+        INSTANCE_SALT,
+        SIGNER_COMMITMENTS,
+        2n,
+      );
+      const unknown = ShieldedMultiSigV2Simulator.calculateSignerId(
+        NON_SIGNER_PK,
+        INSTANCE_SALT,
+      );
+      expect(multisig.isSigner(unknown)).toEqual(false);
+    });
+  });
+
+  describe('when initialized', () => {
+    beforeEach(() => {
+      multisig = new ShieldedMultiSigV2Simulator(
+        INSTANCE_SALT,
+        SIGNER_COMMITMENTS,
+        2n,
+      );
+    });
+
+    describe('view', () => {
+      it('getNonce should start at 0', () => {
+        expect(multisig.getNonce()).toEqual(0n);
+      });
+
+      it('getSignerCount should return 3', () => {
+        expect(multisig.getSignerCount()).toEqual(3n);
+      });
+
+      it('getThreshold should match constructor arg', () => {
+        expect(multisig.getThreshold()).toEqual(2n);
+      });
+    });
+
+    describe('deposit', () => {
+      it('should accept deposits without reverting', () => {
+        expect(() => {
+          multisig.deposit(makeCoin(COLOR, AMOUNT));
+        }).not.toThrow();
+      });
+    });
+
+    describe('execute', () => {
+      it('should reject duplicate signer', () => {
+        const to = makeRecipient(new Uint8Array(32).fill(7));
+        const coin = makeQualifiedCoin(COLOR, AMOUNT, 0n);
+        expect(() => {
+          multisig.execute(to, 100n, coin, [PK1, PK1], [DUMMY_SIG, DUMMY_SIG]);
+        }).toThrow('Multisig: duplicate signer');
+      });
+
+      it('should reject a non-signer pubkey', () => {
+        const to = makeRecipient(new Uint8Array(32).fill(7));
+        const coin = makeQualifiedCoin(COLOR, AMOUNT, 0n);
+        expect(() => {
+          multisig.execute(
+            to,
+            100n,
+            coin,
+            [PK1, NON_SIGNER_PK],
+            [DUMMY_SIG, DUMMY_SIG],
+          );
+        }).toThrow('SignerManager: not a signer');
+      });
+    });
+  });
+});

--- a/contracts/src/multisig/test/ShieldedTreasury.test.ts
+++ b/contracts/src/multisig/test/ShieldedTreasury.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import * as utils from '#test-utils/address.js';
+import { ShieldedTreasurySimulator } from './simulators/ShieldedTreasurySimulator.js';
+
+const COLOR = new Uint8Array(32).fill(1);
+const COLOR2 = new Uint8Array(32).fill(2);
+const AMOUNT = 1000n;
+
+const Z_RECIPIENT = utils.createEitherTestUser('RECIPIENT');
+
+function makeCoin(
+  color: Uint8Array,
+  value: bigint,
+  nonce?: Uint8Array,
+): { nonce: Uint8Array; color: Uint8Array; value: bigint } {
+  return {
+    nonce: nonce ?? new Uint8Array(32).fill(0),
+    color,
+    value,
+  };
+}
+
+let treasury: ShieldedTreasurySimulator;
+
+describe('ShieldedTreasury', () => {
+  beforeEach(() => {
+    treasury = new ShieldedTreasurySimulator();
+  });
+
+  describe('initial state', () => {
+    it('should return 0 balance for unknown color', () => {
+      expect(treasury.getTokenBalance(COLOR)).toEqual(0n);
+    });
+
+    it('should return 0 received total for unknown color', () => {
+      expect(treasury.getReceivedTotal(COLOR)).toEqual(0n);
+    });
+
+    it('should return 0 sent total for unknown color', () => {
+      expect(treasury.getSentTotal(COLOR)).toEqual(0n);
+    });
+
+    it('should return 0 receivedMinusSent for unknown color', () => {
+      expect(treasury.getReceivedMinusSent(COLOR)).toEqual(0n);
+    });
+  });
+
+  describe('_deposit', () => {
+    it('should deposit and update balance', () => {
+      treasury._deposit(makeCoin(COLOR, AMOUNT));
+      expect(treasury.getTokenBalance(COLOR)).toEqual(AMOUNT);
+    });
+
+    it('should track received total', () => {
+      treasury._deposit(makeCoin(COLOR, AMOUNT));
+      expect(treasury.getReceivedTotal(COLOR)).toEqual(AMOUNT);
+    });
+
+    it('should accumulate multiple deposits', () => {
+      treasury._deposit(makeCoin(COLOR, AMOUNT, new Uint8Array(32).fill(1)));
+      treasury._deposit(makeCoin(COLOR, AMOUNT, new Uint8Array(32).fill(2)));
+      expect(treasury.getTokenBalance(COLOR)).toEqual(AMOUNT * 2n);
+      expect(treasury.getReceivedTotal(COLOR)).toEqual(AMOUNT * 2n);
+    });
+
+    it('should track balances per color independently', () => {
+      treasury._deposit(makeCoin(COLOR, AMOUNT));
+      treasury._deposit(makeCoin(COLOR2, AMOUNT * 2n));
+      expect(treasury.getTokenBalance(COLOR)).toEqual(AMOUNT);
+      expect(treasury.getTokenBalance(COLOR2)).toEqual(AMOUNT * 2n);
+    });
+
+    it('should allow zero value deposit', () => {
+      treasury._deposit(makeCoin(COLOR, 0n));
+      expect(treasury.getTokenBalance(COLOR)).toEqual(0n);
+      expect(treasury.getReceivedTotal(COLOR)).toEqual(0n);
+    });
+
+    it('should maintain receivedMinusSent consistency', () => {
+      treasury._deposit(makeCoin(COLOR, AMOUNT));
+      expect(treasury.getReceivedMinusSent(COLOR)).toEqual(AMOUNT);
+    });
+  });
+
+  describe('_send', () => {
+    beforeEach(() => {
+      treasury._deposit(makeCoin(COLOR, AMOUNT));
+    });
+
+    it('should send partial amount', () => {
+      treasury._send(Z_RECIPIENT, COLOR, 400n);
+      expect(treasury.getTokenBalance(COLOR)).toEqual(AMOUNT - 400n);
+    });
+
+    it('should send full balance', () => {
+      treasury._send(Z_RECIPIENT, COLOR, AMOUNT);
+      expect(treasury.getTokenBalance(COLOR)).toEqual(0n);
+    });
+
+    it('should track sent total', () => {
+      treasury._send(Z_RECIPIENT, COLOR, 400n);
+      expect(treasury.getSentTotal(COLOR)).toEqual(400n);
+    });
+
+    it('should maintain receivedMinusSent after send', () => {
+      treasury._send(Z_RECIPIENT, COLOR, 400n);
+      expect(treasury.getReceivedMinusSent(COLOR)).toEqual(AMOUNT - 400n);
+    });
+
+    it('should fail with insufficient balance', () => {
+      expect(() => {
+        treasury._send(Z_RECIPIENT, COLOR, AMOUNT + 1n);
+      }).toThrow('ShieldedTreasury: coin value insufficient');
+    });
+
+    it('should fail for unknown color', () => {
+      expect(() => {
+        treasury._send(Z_RECIPIENT, COLOR2, 1n);
+      }).toThrow('ShieldedTreasury: no balance');
+    });
+  });
+
+  describe('accounting consistency', () => {
+    it('should keep receivedMinusSent equal to balance', () => {
+      treasury._deposit(makeCoin(COLOR, 500n));
+      treasury._send(Z_RECIPIENT, COLOR, 200n);
+      treasury._deposit(makeCoin(COLOR, 300n, new Uint8Array(32).fill(3)));
+
+      const balance = treasury.getTokenBalance(COLOR);
+      const rms = treasury.getReceivedMinusSent(COLOR);
+      expect(balance).toEqual(600n);
+      expect(rms).toEqual(600n);
+    });
+
+    it('should accumulate sent total across sends', () => {
+      treasury._deposit(makeCoin(COLOR, 1000n));
+      treasury._send(Z_RECIPIENT, COLOR, 200n);
+      treasury._send(Z_RECIPIENT, COLOR, 300n);
+      expect(treasury.getSentTotal(COLOR)).toEqual(500n);
+    });
+  });
+});

--- a/contracts/src/multisig/test/Signer.test.ts
+++ b/contracts/src/multisig/test/Signer.test.ts
@@ -1,0 +1,376 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { SignerSimulator } from './simulators/SignerSimulator.js';
+
+const THRESHOLD = 2n;
+const IS_INIT = true;
+
+// Simple `Bytes<32>` ids
+const SIGNER = new Uint8Array(32).fill(1);
+const SIGNER2 = new Uint8Array(32).fill(2);
+const SIGNER3 = new Uint8Array(32).fill(3);
+const SIGNERS = [SIGNER, SIGNER2, SIGNER3];
+const OTHER = new Uint8Array(32).fill(4);
+const OTHER2 = new Uint8Array(32).fill(5);
+
+let contract: SignerSimulator;
+
+describe('Signer', () => {
+  describe('when not initialized', () => {
+    beforeEach(() => {
+      const isNotInit = false;
+      contract = new SignerSimulator(SIGNERS, 0n, isNotInit);
+    });
+
+    const circuitsRequiringInit: [string, unknown[]][] = [
+      ['assertSigner', [SIGNER]],
+      ['assertThresholdMet', [0n]],
+      ['getSignerCount', []],
+      ['getThreshold', []],
+    ];
+
+    it.each(circuitsRequiringInit)('%s should fail', (circuitName, args) => {
+      expect(() => {
+        (
+          contract[circuitName as keyof SignerSimulator] as (
+            ...a: unknown[]
+          ) => unknown
+        )(...args);
+      }).toThrow('Initializable: contract not initialized');
+    });
+
+    it('isSigner should succeed (no init guard)', () => {
+      expect(contract.isSigner(SIGNER)).toEqual(false);
+    });
+  });
+
+  describe('initialization', () => {
+    it('should fail with a threshold of zero', () => {
+      expect(() => {
+        new SignerSimulator(SIGNERS, 0n, IS_INIT);
+      }).toThrow('Signer: threshold must not be zero');
+    });
+
+    it('should fail when threshold exceeds signer count', () => {
+      expect(() => {
+        new SignerSimulator(SIGNERS, BigInt(SIGNERS.length) + 1n, IS_INIT);
+      }).toThrow('Signer: threshold exceeds signer count');
+    });
+
+    it('should fail with duplicate signers', () => {
+      const duplicateSigners = [SIGNER, SIGNER, SIGNER2];
+      expect(() => {
+        new SignerSimulator(duplicateSigners, THRESHOLD, IS_INIT);
+      }).toThrow('Signer: signer already active');
+    });
+
+    it('should initialize with threshold equal to signer count', () => {
+      const contract = new SignerSimulator(
+        SIGNERS,
+        BigInt(SIGNERS.length),
+        IS_INIT,
+      );
+      expect(contract.getThreshold()).toEqual(BigInt(SIGNERS.length));
+    });
+
+    it('should initialize', () => {
+      expect(() => {
+        contract = new SignerSimulator(SIGNERS, THRESHOLD, IS_INIT);
+      }).not.toThrow();
+
+      expect(contract.getThreshold()).toEqual(THRESHOLD);
+      expect(contract.getSignerCount()).toEqual(BigInt(SIGNERS.length));
+      expect(() => {
+        for (let i = 0; i < SIGNERS.length; i++) {
+          contract.assertSigner(SIGNERS[i]);
+        }
+      }).not.toThrow();
+    });
+
+    it('should fail when initialized twice', () => {
+      contract = new SignerSimulator(SIGNERS, THRESHOLD, IS_INIT);
+      expect(() => {
+        contract.initialize(SIGNERS, THRESHOLD);
+      }).toThrow('Initializable: contract already initialized');
+    });
+  });
+
+  beforeEach(() => {
+    contract = new SignerSimulator(SIGNERS, THRESHOLD, IS_INIT);
+  });
+
+  describe('assertSigner', () => {
+    it('should pass with good signer', () => {
+      expect(() => contract.assertSigner(SIGNER)).not.toThrow();
+    });
+
+    it('should fail with bad signer', () => {
+      expect(() => {
+        contract.assertSigner(OTHER);
+      }).toThrow('Signer: not a signer');
+    });
+  });
+
+  describe('assertThresholdMet', () => {
+    it('should pass when approvals equal threshold', () => {
+      expect(() => contract.assertThresholdMet(THRESHOLD)).not.toThrow();
+    });
+
+    it('should pass when approvals exceed threshold', () => {
+      expect(() => contract.assertThresholdMet(THRESHOLD + 1n)).not.toThrow();
+    });
+
+    it('should fail when approvals are below threshold', () => {
+      expect(() => {
+        contract.assertThresholdMet(THRESHOLD - 1n);
+      }).toThrow('Signer: threshold not met');
+    });
+
+    it('should fail with zero approvals', () => {
+      expect(() => {
+        contract.assertThresholdMet(0n);
+      }).toThrow('Signer: threshold not met');
+    });
+  });
+
+  describe('getSignerCount', () => {
+    it('should return the initial signer count', () => {
+      expect(contract.getSignerCount()).toEqual(BigInt(SIGNERS.length));
+    });
+
+    it('should reflect additions', () => {
+      contract._addSigner(OTHER);
+      expect(contract.getSignerCount()).toEqual(BigInt(SIGNERS.length) + 1n);
+    });
+
+    it('should reflect removals', () => {
+      contract._removeSigner(SIGNER3);
+      expect(contract.getSignerCount()).toEqual(BigInt(SIGNERS.length) - 1n);
+    });
+  });
+
+  describe('getThreshold', () => {
+    it('should return the initial threshold', () => {
+      expect(contract.getThreshold()).toEqual(THRESHOLD);
+    });
+
+    it('should reflect _changeThreshold', () => {
+      contract._changeThreshold(3n);
+      expect(contract.getThreshold()).toEqual(3n);
+    });
+
+    it('should reflect _setThreshold', () => {
+      contract._setThreshold(1n);
+      expect(contract.getThreshold()).toEqual(1n);
+    });
+  });
+
+  describe('isSigner', () => {
+    it('should return true for an active signer', () => {
+      expect(contract.isSigner(SIGNER)).toEqual(true);
+    });
+
+    it('should return false for a non-signer', () => {
+      expect(contract.isSigner(OTHER)).toEqual(false);
+    });
+  });
+
+  describe('_addSigner', () => {
+    it('should add a new signer', () => {
+      contract._addSigner(OTHER);
+
+      expect(contract.isSigner(OTHER)).toEqual(true);
+      expect(contract.getSignerCount()).toEqual(BigInt(SIGNERS.length) + 1n);
+    });
+
+    it('should fail when adding an existing signer', () => {
+      contract._addSigner(OTHER);
+
+      expect(() => {
+        contract._addSigner(OTHER);
+      }).toThrow('Signer: signer already active');
+    });
+
+    it('should add multiple new signers', () => {
+      contract._addSigner(OTHER);
+      contract._addSigner(OTHER2);
+
+      expect(contract.isSigner(OTHER)).toEqual(true);
+      expect(contract.isSigner(OTHER2)).toEqual(true);
+      expect(contract.getSignerCount()).toEqual(BigInt(SIGNERS.length) + 2n);
+    });
+
+    it('should allow re-adding a previously removed signer', () => {
+      expect(contract.isSigner(SIGNER)).toEqual(true);
+
+      contract._removeSigner(SIGNER);
+      expect(contract.isSigner(SIGNER)).toEqual(false);
+
+      contract._addSigner(SIGNER);
+      expect(contract.isSigner(SIGNER)).toEqual(true);
+    });
+  });
+
+  describe('_removeSigner', () => {
+    it('should remove an existing signer', () => {
+      contract._removeSigner(SIGNER3);
+
+      expect(contract.isSigner(SIGNER3)).toEqual(false);
+      expect(contract.getSignerCount()).toEqual(BigInt(SIGNERS.length) - 1n);
+    });
+
+    it('should fail when removing a non-signer', () => {
+      expect(() => {
+        contract._removeSigner(OTHER);
+      }).toThrow('Signer: not a signer');
+    });
+
+    it('should fail when removal would breach threshold', () => {
+      contract._removeSigner(SIGNER3);
+
+      expect(() => {
+        contract._removeSigner(SIGNER2);
+      }).toThrow('Signer: removal would breach threshold');
+    });
+
+    it('should allow removal after threshold is lowered', () => {
+      contract._changeThreshold(1n);
+      contract._removeSigner(SIGNER3);
+      contract._removeSigner(SIGNER2);
+
+      expect(contract.getSignerCount()).toEqual(1n);
+      expect(contract.isSigner(SIGNER)).toEqual(true);
+      expect(contract.isSigner(SIGNER2)).toEqual(false);
+      expect(contract.isSigner(SIGNER3)).toEqual(false);
+    });
+
+    it('should keep signer count in sync after multiple add/remove operations', () => {
+      contract._addSigner(OTHER);
+      contract._addSigner(OTHER2);
+      contract._removeSigner(SIGNER3);
+      contract._removeSigner(OTHER);
+
+      expect(contract.getSignerCount()).toEqual(3n);
+      expect(contract.isSigner(SIGNER)).toEqual(true);
+      expect(contract.isSigner(SIGNER2)).toEqual(true);
+      expect(contract.isSigner(SIGNER3)).toEqual(false);
+      expect(contract.isSigner(OTHER)).toEqual(false);
+      expect(contract.isSigner(OTHER2)).toEqual(true);
+    });
+  });
+
+  describe('_changeThreshold', () => {
+    it('should update the threshold', () => {
+      contract._changeThreshold(3n);
+
+      expect(contract.getThreshold()).toEqual(3n);
+    });
+
+    it('should allow lowering the threshold', () => {
+      contract._changeThreshold(1n);
+
+      expect(contract.getThreshold()).toEqual(1n);
+    });
+
+    it('should fail with a threshold of zero', () => {
+      expect(() => {
+        contract._changeThreshold(0n);
+      }).toThrow('Signer: threshold must not be zero');
+    });
+
+    it('should fail when threshold exceeds signer count', () => {
+      expect(() => {
+        contract._changeThreshold(BigInt(SIGNERS.length) + 1n);
+      }).toThrow('Signer: threshold exceeds signer count');
+    });
+
+    it('should allow threshold equal to signer count', () => {
+      contract._changeThreshold(BigInt(SIGNERS.length));
+
+      expect(contract.getThreshold()).toEqual(BigInt(SIGNERS.length));
+    });
+
+    it('should reflect new threshold in assertThresholdMet', () => {
+      contract._changeThreshold(3n);
+
+      expect(() => {
+        contract.assertThresholdMet(2n);
+      }).toThrow('Signer: threshold not met');
+
+      expect(() => contract.assertThresholdMet(3n)).not.toThrow();
+    });
+  });
+
+  describe('_setThreshold', () => {
+    beforeEach(() => {
+      const isNotInit = false;
+      contract = new SignerSimulator(SIGNERS, 0n, isNotInit);
+    });
+
+    it('should have an empty state', () => {
+      expect(contract.getPublicState()._threshold).toEqual(0n);
+      expect(contract.getPublicState()._signerCount).toEqual(0n);
+      expect(contract.getPublicState()._signers.isEmpty()).toEqual(true);
+    });
+
+    it('should set threshold without signers', () => {
+      expect(contract.getPublicState()._threshold).toEqual(0n);
+
+      contract._setThreshold(2n);
+      expect(contract.getPublicState()._threshold).toEqual(2n);
+    });
+
+    it('should set threshold multiple times', () => {
+      contract._setThreshold(2n);
+      contract._setThreshold(3n);
+      expect(contract.getPublicState()._threshold).toEqual(3n);
+    });
+
+    it('should fail with zero threshold', () => {
+      expect(() => {
+        contract._setThreshold(0n);
+      }).toThrow('Signer: threshold must not be zero');
+    });
+  });
+
+  describe('custom setup flow when not initialized', () => {
+    beforeEach(() => {
+      const isNotInit = false;
+      contract = new SignerSimulator(SIGNERS, 0n, isNotInit);
+    });
+
+    it('should have no signers by default', () => {
+      expect(contract.getPublicState()._signerCount).toEqual(0n);
+      expect(contract.isSigner(SIGNER)).toEqual(false);
+    });
+
+    it('should have zero threshold by default', () => {
+      expect(contract.getPublicState()._threshold).toEqual(0n);
+    });
+
+    it('should allow adding signers then setting threshold', () => {
+      contract._addSigner(SIGNER);
+      contract._addSigner(SIGNER2);
+      contract._addSigner(SIGNER3);
+      contract._changeThreshold(2n);
+
+      expect(contract.getPublicState()._signerCount).toEqual(3n);
+      expect(contract.getPublicState()._threshold).toEqual(2n);
+      expect(contract.isSigner(SIGNER)).toEqual(true);
+    });
+
+    it('should allow setting threshold then adding signers to meet it', () => {
+      contract._setThreshold(2n);
+      contract._addSigner(SIGNER);
+      contract._addSigner(SIGNER2);
+
+      expect(contract.getPublicState()._signerCount).toEqual(2n);
+      expect(contract.getPublicState()._threshold).toEqual(2n);
+    });
+
+    it('should fail _changeThreshold before signers are added', () => {
+      expect(() => {
+        contract._changeThreshold(2n);
+      }).toThrow('Signer: threshold exceeds signer count');
+    });
+  });
+});

--- a/contracts/src/multisig/test/SignerManager.test.ts
+++ b/contracts/src/multisig/test/SignerManager.test.ts
@@ -1,0 +1,201 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import * as utils from '#test-utils/address.js';
+import {
+  SignerManagerSimulator,
+  type SignerSet,
+} from './simulators/SignerManagerSimulator.js';
+
+const THRESHOLD = 2n;
+
+const [_SIGNER, Z_SIGNER] = utils.generateEitherPubKeyPair('SIGNER');
+const [_SIGNER2, Z_SIGNER2] = utils.generateEitherPubKeyPair('SIGNER2');
+const [_SIGNER3, Z_SIGNER3] = utils.generateEitherPubKeyPair('SIGNER3');
+const SIGNERS: SignerSet = [Z_SIGNER, Z_SIGNER2, Z_SIGNER3];
+const [_OTHER, Z_OTHER] = utils.generateEitherPubKeyPair('OTHER');
+const [_OTHER2, Z_OTHER2] = utils.generateEitherPubKeyPair('OTHER2');
+
+let contract: SignerManagerSimulator;
+
+describe('SigningManager', () => {
+  describe('initialization', () => {
+    it('should fail with a threshold of zero', () => {
+      expect(() => {
+        new SignerManagerSimulator(SIGNERS, 0n);
+      }).toThrow('SignerManager: threshold must be > 0');
+    });
+
+    it('should fail with duplicate signers', () => {
+      const duplicateSigners: SignerSet = [Z_SIGNER, Z_SIGNER, Z_SIGNER2];
+      expect(() => {
+        new SignerManagerSimulator(duplicateSigners, THRESHOLD);
+      }).toThrow('SignerManager: signer already active');
+    });
+
+    it('should initialize', () => {
+      expect(() => {
+        contract = new SignerManagerSimulator(SIGNERS, THRESHOLD);
+      }).to.be.ok;
+
+      // Check thresh
+      expect(contract.getThreshold()).toEqual(THRESHOLD);
+
+      // Check signers
+      expect(contract.getSignerCount()).toEqual(BigInt(SIGNERS.length));
+      expect(() => {
+        for (let i = 0; i < SIGNERS.length; i++) {
+          contract.assertSigner(SIGNERS[i]);
+        }
+      }).to.be.ok;
+    });
+  });
+
+  beforeEach(() => {
+    contract = new SignerManagerSimulator(SIGNERS, THRESHOLD);
+  });
+
+  describe('assertSigner', () => {
+    it('should pass with good signer', () => {
+      expect(() => contract.assertSigner(Z_SIGNER)).not.toThrow();
+    });
+
+    it('should fail with bad signer', () => {
+      expect(() => {
+        contract.assertSigner(Z_OTHER);
+      }).toThrow('SignerManager: not a signer');
+    });
+  });
+
+  describe('assertThresholdMet', () => {
+    it('should pass when approvals equal threshold', () => {
+      expect(() => contract.assertThresholdMet(THRESHOLD)).not.toThrow();
+    });
+
+    it('should pass when approvals exceed threshold', () => {
+      expect(() => contract.assertThresholdMet(THRESHOLD + 1n)).not.toThrow();
+    });
+
+    it('should fail when approvals are below threshold', () => {
+      expect(() => {
+        contract.assertThresholdMet(THRESHOLD - 1n);
+      }).toThrow('SignerManager: threshold not met');
+    });
+
+    it('should fail with zero approvals', () => {
+      expect(() => {
+        contract.assertThresholdMet(0n);
+      }).toThrow('SignerManager: threshold not met');
+    });
+  });
+
+  describe('isSigner', () => {
+    it('should return true for an active signer', () => {
+      expect(contract.isSigner(Z_SIGNER)).toEqual(true);
+    });
+
+    it('should return false for a non-signer', () => {
+      expect(contract.isSigner(Z_OTHER)).toEqual(false);
+    });
+  });
+
+  describe('_addSigner', () => {
+    it('should add a new signer', () => {
+      contract._addSigner(Z_OTHER);
+
+      expect(contract.isSigner(Z_OTHER)).toEqual(true);
+      expect(contract.getSignerCount()).toEqual(BigInt(SIGNERS.length) + 1n);
+    });
+
+    it('should fail when adding an existing signer', () => {
+      expect(() => {
+        contract._addSigner(Z_SIGNER);
+      }).toThrow('SignerManager: signer already active');
+    });
+
+    it('should add multiple new signers', () => {
+      contract._addSigner(Z_OTHER);
+      contract._addSigner(Z_OTHER2);
+
+      expect(contract.isSigner(Z_OTHER)).toEqual(true);
+      expect(contract.isSigner(Z_OTHER2)).toEqual(true);
+      expect(contract.getSignerCount()).toEqual(BigInt(SIGNERS.length) + 2n);
+    });
+  });
+
+  describe('_removeSigner', () => {
+    it('should remove an existing signer', () => {
+      contract._removeSigner(Z_SIGNER3);
+
+      expect(contract.isSigner(Z_SIGNER3)).toEqual(false);
+      expect(contract.getSignerCount()).toEqual(BigInt(SIGNERS.length) - 1n);
+    });
+
+    it('should fail when removing a non-signer', () => {
+      expect(() => {
+        contract._removeSigner(Z_OTHER);
+      }).toThrow('SignerManager: not a signer');
+    });
+
+    it('should fail when removal would breach threshold', () => {
+      // Remove one signer: count goes from 3 to 2, threshold is 2 — ok
+      contract._removeSigner(Z_SIGNER3);
+
+      // Remove another: count would go from 2 to 1, threshold is 2 — breach
+      expect(() => {
+        contract._removeSigner(Z_SIGNER2);
+      }).toThrow('SignerManager: removal would breach threshold');
+    });
+
+    it('should allow removal after threshold is lowered', () => {
+      contract._changeThreshold(1n);
+      contract._removeSigner(Z_SIGNER3);
+      contract._removeSigner(Z_SIGNER2);
+
+      expect(contract.getSignerCount()).toEqual(1n);
+      expect(contract.isSigner(Z_SIGNER)).toEqual(true);
+      expect(contract.isSigner(Z_SIGNER2)).toEqual(false);
+      expect(contract.isSigner(Z_SIGNER3)).toEqual(false);
+    });
+  });
+
+  describe('_changeThreshold', () => {
+    it('should update the threshold', () => {
+      contract._changeThreshold(3n);
+
+      expect(contract.getThreshold()).toEqual(3n);
+    });
+
+    it('should allow lowering the threshold', () => {
+      contract._changeThreshold(1n);
+
+      expect(contract.getThreshold()).toEqual(1n);
+    });
+
+    it('should fail with a threshold of zero', () => {
+      expect(() => {
+        contract._changeThreshold(0n);
+      }).toThrow('SignerManager: threshold must be > 0');
+    });
+
+    it('should fail when threshold exceeds signer count', () => {
+      expect(() => {
+        contract._changeThreshold(BigInt(SIGNERS.length) + 1n);
+      }).toThrow('SignerManager: threshold exceeds signer count');
+    });
+
+    it('should allow threshold equal to signer count', () => {
+      contract._changeThreshold(BigInt(SIGNERS.length));
+
+      expect(contract.getThreshold()).toEqual(BigInt(SIGNERS.length));
+    });
+
+    it('should reflect new threshold in assertThresholdMet', () => {
+      contract._changeThreshold(3n);
+
+      expect(() => {
+        contract.assertThresholdMet(2n);
+      }).toThrow('SignerManager: threshold not met');
+
+      expect(() => contract.assertThresholdMet(3n)).not.toThrow();
+    });
+  });
+});

--- a/contracts/src/multisig/test/mocks/MockForwarder.compact
+++ b/contracts/src/multisig/test/mocks/MockForwarder.compact
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Compact Contracts v0.0.1-alpha.1 (multisig/test/mocks/MockForwarder.compact)
+
+pragma language_version >= 0.21.0;
+
+import CompactStandardLibrary;
+import "../../Forwarder"<ZswapCoinPublicKey> prefix Forwarder_;
+
+export { ZswapCoinPublicKey, ShieldedCoinInfo };
+
+/**
+ * @description Test fixture exposing the public Forwarder module's
+ * underscore-prefixed circuits directly. `isInit` controls whether the
+ * constructor initializes. Set it to `false` to leave the contract
+ * uninitialized and exercise the not-initialized guard. The parent is a
+ * sealed ledger field, so it can only be set in the constructor.
+ *
+ * DO NOT USE IN PRODUCTION.
+ */
+constructor(parent: ZswapCoinPublicKey, isInit: Boolean) {
+  if (disclose(isInit)) {
+    Forwarder_initialize(parent);
+  }
+}
+
+export circuit depositShielded(coin: ShieldedCoinInfo): [] {
+  return Forwarder__depositShielded(coin);
+}
+
+export circuit depositUnshielded(color: Bytes<32>, amount: Uint<128>): [] {
+  return Forwarder__depositUnshielded(color, amount);
+}

--- a/contracts/src/multisig/test/mocks/MockForwarderPrivate.compact
+++ b/contracts/src/multisig/test/mocks/MockForwarderPrivate.compact
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Compact Contracts v0.0.1-alpha.1 (multisig/test/mocks/MockForwarderPrivate.compact)
+
+pragma language_version >= 0.21.0;
+
+import CompactStandardLibrary;
+import "../../ForwarderPrivate" prefix ForwarderPrivate_;
+
+export { ShieldedCoinInfo, QualifiedShieldedCoinInfo, ShieldedSendResult };
+
+/**
+ * @description Test fixture exposing the private ForwarderPrivate
+ * module's underscore-prefixed circuits directly. `isInit` controls
+ * whether the constructor initializes. Set it to `false` to leave the
+ * contract uninitialized and exercise the not-initialized guard. The
+ * parent commitment is a sealed ledger field, so it can only be set in
+ * the constructor.
+ *
+ * DO NOT USE IN PRODUCTION.
+ */
+constructor(parentCommitment: Bytes<32>, isInit: Boolean) {
+  if (disclose(isInit)) {
+    ForwarderPrivate_initialize(parentCommitment);
+  }
+}
+
+export circuit deposit(coin: ShieldedCoinInfo): [] {
+  return ForwarderPrivate__deposit(coin);
+}
+
+export circuit drain(
+  coin: QualifiedShieldedCoinInfo,
+  parentAddr: Bytes<32>,
+  opSecret: Bytes<32>,
+  value: Uint<128>
+): ShieldedSendResult {
+  return ForwarderPrivate__drain(coin, parentAddr, opSecret, value);
+}
+
+export pure circuit calculateParentCommitment(
+  parentAddr: Bytes<32>,
+  opSecret: Bytes<32>
+): Bytes<32> {
+  return ForwarderPrivate__calculateParentCommitment(parentAddr, opSecret);
+}

--- a/contracts/src/multisig/test/mocks/MockProposalManager.compact
+++ b/contracts/src/multisig/test/mocks/MockProposalManager.compact
@@ -1,0 +1,70 @@
+pragma language_version >= 0.21.0;
+
+import CompactStandardLibrary;
+
+import "../../ProposalManager" prefix Proposal_;
+
+export circuit shieldedUserRecipient(key: ZswapCoinPublicKey): Proposal_Recipient {
+  return Proposal_shieldedUserRecipient(key);
+}
+
+export circuit unshieldedUserRecipient(addr: UserAddress): Proposal_Recipient {
+  return Proposal_unshieldedUserRecipient(addr);
+}
+
+export circuit contractRecipient(addr: ContractAddress): Proposal_Recipient {
+  return Proposal_contractRecipient(addr);
+}
+
+export circuit assertProposalExists(id: Uint<64>): [] {
+  return Proposal_assertProposalExists(id);
+}
+
+export circuit assertProposalActive(id: Uint<64>): [] {
+  return Proposal_assertProposalActive(id);
+}
+
+export circuit _createProposal(
+  to: Proposal_Recipient,
+  color: Bytes<32>,
+  amount: Uint<128>
+): Uint<64> {
+  return Proposal__createProposal(to, color, amount);
+}
+
+export circuit _cancelProposal(id: Uint<64>): [] {
+  return Proposal__cancelProposal(id);
+}
+
+export circuit _markExecuted(id: Uint<64>): [] {
+  return Proposal__markExecuted(id);
+}
+
+export circuit getProposal(id: Uint<64>): Proposal_Proposal {
+  return Proposal_getProposal(id);
+}
+
+export circuit getProposalRecipient(id: Uint<64>): Proposal_Recipient {
+  return Proposal_getProposalRecipient(id);
+}
+
+export circuit getProposalAmount(id: Uint<64>): Uint<128> {
+  return Proposal_getProposalAmount(id);
+}
+
+export circuit getProposalColor(id: Uint<64>): Bytes<32> {
+  return Proposal_getProposalColor(id);
+}
+
+export circuit getProposalStatus(id: Uint<64>): Proposal_ProposalStatus {
+  return Proposal_getProposalStatus(id);
+}
+
+export circuit toShieldedRecipient(r: Proposal_Recipient): Either<ZswapCoinPublicKey, ContractAddress> {
+  return Proposal_toShieldedRecipient(r);
+}
+
+export circuit toUnshieldedRecipient(r: Proposal_Recipient): Either<ContractAddress, UserAddress> {
+  return Proposal_toUnshieldedRecipient(r);
+}
+

--- a/contracts/src/multisig/test/mocks/MockShieldedTreasury.compact
+++ b/contracts/src/multisig/test/mocks/MockShieldedTreasury.compact
@@ -1,0 +1,33 @@
+pragma language_version >= 0.21.0;
+
+import CompactStandardLibrary;
+
+import "../../ShieldedTreasury" prefix Treasury_;
+
+export circuit _deposit(coin: ShieldedCoinInfo): [] {
+  return Treasury__deposit(coin);
+}
+
+export circuit _send(
+    recipient: Either<ZswapCoinPublicKey, ContractAddress>,
+    color: Bytes<32>,
+    amount: Uint<128>,
+  ): ShieldedSendResult {
+  return Treasury__send(recipient, color, amount);
+}
+
+export circuit getTokenBalance(color: Bytes<32>): Uint<128> {
+  return Treasury_getTokenBalance(color);
+}
+
+export circuit getReceivedTotal(color: Bytes<32>): Uint<128> {
+  return Treasury_getReceivedTotal(color);
+}
+
+export circuit getSentTotal(color: Bytes<32>): Uint<128> {
+  return Treasury_getSentTotal(color);
+}
+
+export circuit getReceivedMinusSent(color: Bytes<32>): Uint<128> {
+  return Treasury_getReceivedMinusSent(color);
+}

--- a/contracts/src/multisig/test/mocks/MockShieldedTreasuryStateless.compact
+++ b/contracts/src/multisig/test/mocks/MockShieldedTreasuryStateless.compact
@@ -1,0 +1,17 @@
+pragma language_version >= 0.21.0;
+
+import CompactStandardLibrary;
+import "../../ShieldedTreasuryStateless" prefix Treasury_;
+
+export circuit _deposit(coin: ShieldedCoinInfo): [] {
+  Treasury__deposit(coin);
+}
+
+export circuit _send(
+  coin: QualifiedShieldedCoinInfo,
+  recipient: Either<ZswapCoinPublicKey, ContractAddress>,
+  amount: Uint<128>
+): ShieldedSendResult {
+  return Treasury__send(coin, recipient, amount);
+}
+

--- a/contracts/src/multisig/test/mocks/MockSigner.compact
+++ b/contracts/src/multisig/test/mocks/MockSigner.compact
@@ -1,0 +1,66 @@
+pragma language_version >= 0.21.0;
+
+import CompactStandardLibrary;
+
+import "../../Signer"<Bytes<32>> prefix Signer_;
+import "../../Signer"<Bytes<32>>;
+
+export { ZswapCoinPublicKey, ContractAddress, Either, Maybe };
+export { _signers, _signerCount, _threshold };
+
+/**
+ * @description `isInit` is a param for testing.
+ *
+ * If `isInit` is false, the constructor will not initialize the contract.
+ * This behavior is to test that _setThreshold will work for custom deployments
+ * where contracts don't `initialize` the signer module and instead have some sort
+ * of gated access control prior to setting up the signers
+*/
+constructor(signers: Vector<3, Bytes<32>>, thresh: Uint<8>, isInit: Boolean) {
+  if (disclose(isInit)) {
+    Signer_initialize<3>(signers, thresh);
+  }
+}
+
+// Exposed in order to test that contracts cannot be reinitialized.
+// DO NOT EXPOSE in production
+export circuit initialize(signers: Vector<3, Bytes<32>>, thresh: Uint<8>): [] {
+  return Signer_initialize<3>(signers, thresh);
+}
+
+export circuit assertSigner(caller: Bytes<32>): [] {
+  return Signer_assertSigner(caller);
+}
+
+export circuit assertThresholdMet(approvalCount: Uint<8>): [] {
+  return Signer_assertThresholdMet(approvalCount);
+}
+
+export circuit getSignerCount(): Uint<8> {
+  return Signer_getSignerCount();
+}
+
+export circuit getThreshold(): Uint<8> {
+  return Signer_getThreshold();
+}
+
+export circuit isSigner(account: Bytes<32>): Boolean {
+  return Signer_isSigner(account);
+}
+
+export circuit _addSigner(signer: Bytes<32>): [] {
+  return Signer__addSigner(signer);
+}
+
+export circuit _removeSigner(signer: Bytes<32>): [] {
+  return Signer__removeSigner(signer);
+}
+
+export circuit _changeThreshold(newThreshold: Uint<8>): [] {
+  return Signer__changeThreshold(newThreshold);
+}
+
+export circuit _setThreshold(newThreshold: Uint<8>): [] {
+  return Signer__setThreshold(newThreshold);
+}
+

--- a/contracts/src/multisig/test/mocks/MockSignerManager.compact
+++ b/contracts/src/multisig/test/mocks/MockSignerManager.compact
@@ -1,0 +1,43 @@
+pragma language_version >= 0.21.0;
+
+import CompactStandardLibrary;
+
+import "../../SignerManager"<Either<ZswapCoinPublicKey, ContractAddress>> prefix Signer_;
+
+export { ZswapCoinPublicKey, ContractAddress, Either, Maybe };
+
+constructor(signers: Vector<3, Either<ZswapCoinPublicKey, ContractAddress>>, thresh: Uint<8>) {
+  Signer_initialize<3>(signers, thresh);
+}
+
+export circuit assertSigner(caller: Either<ZswapCoinPublicKey, ContractAddress>): [] {
+  return Signer_assertSigner(caller);
+}
+
+export circuit assertThresholdMet(approvalCount: Uint<8>): [] {
+  return Signer_assertThresholdMet(approvalCount);
+}
+
+export circuit getSignerCount(): Uint<8> {
+  return Signer_getSignerCount();
+}
+
+export circuit getThreshold(): Uint<8> {
+  return Signer_getThreshold();
+}
+
+export circuit isSigner(account: Either<ZswapCoinPublicKey, ContractAddress>): Boolean {
+  return Signer_isSigner(account);
+}
+
+export circuit _addSigner(signer: Either<ZswapCoinPublicKey, ContractAddress>): [] {
+  return Signer__addSigner(signer);
+}
+
+export circuit _removeSigner(signer: Either<ZswapCoinPublicKey, ContractAddress>): [] {
+  return Signer__removeSigner(signer);
+}
+
+export circuit _changeThreshold(newThreshold: Uint<8>): [] {
+  return Signer__changeThreshold(newThreshold);
+}

--- a/contracts/src/multisig/test/mocks/MockUnshieldedTreasury.compact
+++ b/contracts/src/multisig/test/mocks/MockUnshieldedTreasury.compact
@@ -1,0 +1,21 @@
+pragma language_version >= 0.21.0;
+
+import CompactStandardLibrary;
+
+import "../../UnshieldedTreasury" prefix Treasury_;
+
+export circuit _deposit(color: Bytes<32>, amount: Uint<128>): [] {
+  return Treasury__deposit(color, amount);
+}
+
+export circuit _send(
+    recipient: Either<ContractAddress, UserAddress>,
+    color: Bytes<32>,
+    amount: Uint<128>
+  ): [] {
+  return Treasury__send(recipient, color, amount);
+}
+
+export circuit getTokenBalance(color: Bytes<32>): Uint<128> {
+  return Treasury_getTokenBalance(color);
+}

--- a/contracts/src/multisig/test/presets/ForwarderPrivate.test.ts
+++ b/contracts/src/multisig/test/presets/ForwarderPrivate.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import * as utils from '#test-utils/address.js';
+import { ForwarderPrivateSimulator } from '../simulators/presets/ForwarderPrivateSimulator.js';
+
+const PARENT = utils.createEitherTestUser('PARENT').left.bytes;
+const OP_SECRET = new Uint8Array(32).fill(0xaa);
+const COLOR = new Uint8Array(32).fill(1);
+const AMOUNT = 1000n;
+
+function makeCoin(color: Uint8Array, value: bigint) {
+  return { nonce: new Uint8Array(32), color, value };
+}
+
+function makeQualifiedCoin(color: Uint8Array, value: bigint, mtIndex: bigint) {
+  return { nonce: new Uint8Array(32), color, value, mt_index: mtIndex };
+}
+
+function commitment(parent: Uint8Array, opSecret: Uint8Array): Uint8Array {
+  return ForwarderPrivateSimulator.calculateParentCommitment(parent, opSecret);
+}
+
+describe('ForwarderPrivate preset', () => {
+  it('should store the parentCommitment passed to the constructor', () => {
+    const c = commitment(PARENT, OP_SECRET);
+    const fwd = new ForwarderPrivateSimulator(c);
+    expect(fwd.getParentCommitment()).toEqual(c);
+  });
+
+  it('should expose deposit and forward to _deposit', () => {
+    const fwd = new ForwarderPrivateSimulator(commitment(PARENT, OP_SECRET));
+    expect(() => fwd.deposit(makeCoin(COLOR, AMOUNT))).not.toThrow();
+  });
+
+  it('should expose drain and forward to _drain', () => {
+    const fwd = new ForwarderPrivateSimulator(commitment(PARENT, OP_SECRET));
+    fwd.deposit(makeCoin(COLOR, AMOUNT));
+    const result = fwd.drain(
+      makeQualifiedCoin(COLOR, AMOUNT, 0n),
+      PARENT,
+      OP_SECRET,
+      AMOUNT,
+    );
+    expect(result.sent.value).toEqual(AMOUNT);
+  });
+
+  it('should expose calculateParentCommitment as a static pure helper', () => {
+    const c1 = commitment(PARENT, OP_SECRET);
+    const c2 = commitment(PARENT, OP_SECRET);
+    expect(c1).toEqual(c2);
+  });
+
+  it('should propagate the zero-commitment guard from the module', () => {
+    expect(() => new ForwarderPrivateSimulator(new Uint8Array(32))).toThrow(
+      'ForwarderPrivate: zero commitment',
+    );
+  });
+
+  it('should expose the public ledger state', () => {
+    const fwd = new ForwarderPrivateSimulator(commitment(PARENT, OP_SECRET));
+    expect(fwd.getPublicState()).toBeDefined();
+  });
+});

--- a/contracts/src/multisig/test/presets/ForwarderShielded.test.ts
+++ b/contracts/src/multisig/test/presets/ForwarderShielded.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import * as utils from '#test-utils/address.js';
+import { ForwarderShieldedSimulator } from '../simulators/presets/ForwarderShieldedSimulator.js';
+
+const PARENT = utils.createEitherTestUser('PARENT').left.bytes;
+const COLOR = new Uint8Array(32).fill(1);
+const AMOUNT = 1000n;
+
+function makeCoin(color: Uint8Array, value: bigint) {
+  return { nonce: new Uint8Array(32), color, value };
+}
+
+describe('ForwarderShielded preset', () => {
+  it('should store the parent passed to the constructor', () => {
+    const fwd = new ForwarderShieldedSimulator(PARENT);
+    expect(fwd.getParent()).toEqual(PARENT);
+  });
+
+  it('should expose deposit and forward to _depositShielded', () => {
+    const fwd = new ForwarderShieldedSimulator(PARENT);
+    expect(() => fwd.deposit(makeCoin(COLOR, AMOUNT))).not.toThrow();
+  });
+
+  it('should propagate the zero-parent guard from the module', () => {
+    expect(() => new ForwarderShieldedSimulator(new Uint8Array(32))).toThrow(
+      'Forwarder: zero parent',
+    );
+  });
+
+  it('should expose the public ledger state', () => {
+    const fwd = new ForwarderShieldedSimulator(PARENT);
+    expect(fwd.getPublicState()).toBeDefined();
+  });
+});

--- a/contracts/src/multisig/test/presets/ForwarderUnshielded.test.ts
+++ b/contracts/src/multisig/test/presets/ForwarderUnshielded.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import * as utils from '#test-utils/address.js';
+import { ForwarderUnshieldedSimulator } from '../simulators/presets/ForwarderUnshieldedSimulator.js';
+
+const PARENT = utils.createEitherTestUser('PARENT').left.bytes;
+const COLOR = new Uint8Array(32).fill(1);
+const AMOUNT = 1000n;
+
+describe('ForwarderUnshielded preset', () => {
+  it('should store the parent passed to the constructor', () => {
+    const fwd = new ForwarderUnshieldedSimulator(PARENT);
+    expect(fwd.getParent()).toEqual(PARENT);
+  });
+
+  it('should expose depositUnshielded and forward to _depositUnshielded', () => {
+    const fwd = new ForwarderUnshieldedSimulator(PARENT);
+    expect(() => fwd.depositUnshielded(COLOR, AMOUNT)).not.toThrow();
+  });
+
+  it('should propagate the zero-parent guard from the module', () => {
+    expect(() => new ForwarderUnshieldedSimulator(new Uint8Array(32))).toThrow(
+      'Forwarder: zero parent',
+    );
+  });
+
+  it('should expose the public ledger state', () => {
+    const fwd = new ForwarderUnshieldedSimulator(PARENT);
+    expect(fwd.getPublicState()).toBeDefined();
+  });
+});

--- a/contracts/src/multisig/test/simulators/MockForwarderPrivateSimulator.ts
+++ b/contracts/src/multisig/test/simulators/MockForwarderPrivateSimulator.ts
@@ -1,0 +1,69 @@
+import {
+  type BaseSimulatorOptions,
+  createSimulator,
+} from '@openzeppelin-compact/contracts-simulator';
+import {
+  ledger,
+  pureCircuits,
+  type QualifiedShieldedCoinInfo,
+  type ShieldedCoinInfo,
+  type ShieldedSendResult,
+  Contract as MockForwarderPrivate,
+} from '../../../../artifacts/MockForwarderPrivate/contract/index.js';
+import {
+  MockForwarderPrivatePrivateState,
+  MockForwarderPrivateWitnesses,
+} from '../../witnesses/MockForwarderPrivateWitnesses.js';
+
+type MockForwarderPrivateArgs = readonly [
+  parentCommitment: Uint8Array,
+  isInit: boolean,
+];
+
+const MockForwarderPrivateSimulatorBase = createSimulator<
+  MockForwarderPrivatePrivateState,
+  ReturnType<typeof ledger>,
+  ReturnType<typeof MockForwarderPrivateWitnesses>,
+  MockForwarderPrivate<MockForwarderPrivatePrivateState>,
+  MockForwarderPrivateArgs
+>({
+  contractFactory: (witnesses) =>
+    new MockForwarderPrivate<MockForwarderPrivatePrivateState>(witnesses),
+  defaultPrivateState: () => MockForwarderPrivatePrivateState,
+  contractArgs: (parentCommitment, isInit) => [parentCommitment, isInit],
+  ledgerExtractor: (state) => ledger(state),
+  witnessesFactory: () => MockForwarderPrivateWitnesses(),
+});
+
+export class MockForwarderPrivateSimulator extends MockForwarderPrivateSimulatorBase {
+  constructor(
+    parentCommitment: Uint8Array,
+    isInit: boolean,
+    options: BaseSimulatorOptions<
+      MockForwarderPrivatePrivateState,
+      ReturnType<typeof MockForwarderPrivateWitnesses>
+    > = {},
+  ) {
+    super([parentCommitment, isInit], options);
+  }
+
+  public static calculateParentCommitment(
+    parentAddr: Uint8Array,
+    opSecret: Uint8Array,
+  ): Uint8Array {
+    return pureCircuits.calculateParentCommitment(parentAddr, opSecret);
+  }
+
+  public deposit(coin: ShieldedCoinInfo) {
+    return this.circuits.impure.deposit(coin);
+  }
+
+  public drain(
+    coin: QualifiedShieldedCoinInfo,
+    parentAddr: Uint8Array,
+    opSecret: Uint8Array,
+    value: bigint,
+  ): ShieldedSendResult {
+    return this.circuits.impure.drain(coin, parentAddr, opSecret, value);
+  }
+}

--- a/contracts/src/multisig/test/simulators/MockForwarderSimulator.ts
+++ b/contracts/src/multisig/test/simulators/MockForwarderSimulator.ts
@@ -1,0 +1,52 @@
+import {
+  type BaseSimulatorOptions,
+  createSimulator,
+} from '@openzeppelin-compact/contracts-simulator';
+import {
+  ledger,
+  Contract as MockForwarder,
+  type ShieldedCoinInfo,
+  type ZswapCoinPublicKey,
+} from '../../../../artifacts/MockForwarder/contract/index.js';
+import {
+  MockForwarderPrivateState,
+  MockForwarderWitnesses,
+} from '../../witnesses/MockForwarderWitnesses.js';
+
+type MockForwarderArgs = readonly [parent: ZswapCoinPublicKey, isInit: boolean];
+
+const MockForwarderSimulatorBase = createSimulator<
+  MockForwarderPrivateState,
+  ReturnType<typeof ledger>,
+  ReturnType<typeof MockForwarderWitnesses>,
+  MockForwarder<MockForwarderPrivateState>,
+  MockForwarderArgs
+>({
+  contractFactory: (witnesses) =>
+    new MockForwarder<MockForwarderPrivateState>(witnesses),
+  defaultPrivateState: () => MockForwarderPrivateState,
+  contractArgs: (parent, isInit) => [parent, isInit],
+  ledgerExtractor: (state) => ledger(state),
+  witnessesFactory: () => MockForwarderWitnesses(),
+});
+
+export class MockForwarderSimulator extends MockForwarderSimulatorBase {
+  constructor(
+    parent: Uint8Array,
+    isInit: boolean,
+    options: BaseSimulatorOptions<
+      MockForwarderPrivateState,
+      ReturnType<typeof MockForwarderWitnesses>
+    > = {},
+  ) {
+    super([{ bytes: parent }, isInit], options);
+  }
+
+  public depositShielded(coin: ShieldedCoinInfo) {
+    return this.circuits.impure.depositShielded(coin);
+  }
+
+  public depositUnshielded(color: Uint8Array, amount: bigint) {
+    return this.circuits.impure.depositUnshielded(color, amount);
+  }
+}

--- a/contracts/src/multisig/test/simulators/ProposalManagerSimulator.ts
+++ b/contracts/src/multisig/test/simulators/ProposalManagerSimulator.ts
@@ -1,0 +1,125 @@
+import {
+  type BaseSimulatorOptions,
+  createSimulator,
+} from '@openzeppelin-compact/contracts-simulator';
+import {
+  ledger,
+  Contract as MockProposalManager,
+  pureCircuits,
+} from '../../../../artifacts/MockProposalManager/contract/index.js';
+import {
+  ProposalManagerPrivateState,
+  ProposalManagerWitnesses,
+} from '../../witnesses/ProposalManagerWitnesses.js';
+
+type Recipient = { kind: number; address: Uint8Array };
+type Proposal = {
+  to: Recipient;
+  color: Uint8Array;
+  amount: bigint;
+  status: number;
+};
+
+type ProposalManagerArgs = readonly [];
+
+const ProposalManagerSimulatorBase = createSimulator<
+  ProposalManagerPrivateState,
+  ReturnType<typeof ledger>,
+  ReturnType<typeof ProposalManagerWitnesses>,
+  MockProposalManager<ProposalManagerPrivateState>,
+  ProposalManagerArgs
+>({
+  contractFactory: (witnesses) =>
+    new MockProposalManager<ProposalManagerPrivateState>(witnesses),
+  defaultPrivateState: () => ProposalManagerPrivateState,
+  contractArgs: () => [],
+  ledgerExtractor: (state) => ledger(state),
+  witnessesFactory: () => ProposalManagerWitnesses(),
+});
+
+export class ProposalManagerSimulator extends ProposalManagerSimulatorBase {
+  constructor(
+    options: BaseSimulatorOptions<
+      ProposalManagerPrivateState,
+      ReturnType<typeof ProposalManagerWitnesses>
+    > = {},
+  ) {
+    super([], options);
+  }
+
+  // Pure circuits (recipient helpers)
+  public shieldedUserRecipient(key: { bytes: Uint8Array }): Recipient {
+    return pureCircuits.shieldedUserRecipient(key);
+  }
+
+  public unshieldedUserRecipient(addr: { bytes: Uint8Array }): Recipient {
+    return pureCircuits.unshieldedUserRecipient(addr);
+  }
+
+  public contractRecipient(addr: { bytes: Uint8Array }): Recipient {
+    return pureCircuits.contractRecipient(addr);
+  }
+
+  public toShieldedRecipient(r: Recipient): {
+    is_left: boolean;
+    left: { bytes: Uint8Array };
+    right: { bytes: Uint8Array };
+  } {
+    return pureCircuits.toShieldedRecipient(r);
+  }
+
+  public toUnshieldedRecipient(r: Recipient): {
+    is_left: boolean;
+    left: { bytes: Uint8Array };
+    right: { bytes: Uint8Array };
+  } {
+    return pureCircuits.toUnshieldedRecipient(r);
+  }
+
+  // Guards
+  public assertProposalExists(id: bigint) {
+    return this.circuits.impure.assertProposalExists(id);
+  }
+
+  public assertProposalActive(id: bigint) {
+    return this.circuits.impure.assertProposalActive(id);
+  }
+
+  // Lifecycle
+  public _createProposal(
+    to: Recipient,
+    color: Uint8Array,
+    amount: bigint,
+  ): bigint {
+    return this.circuits.impure._createProposal(to, color, amount);
+  }
+
+  public _cancelProposal(id: bigint) {
+    return this.circuits.impure._cancelProposal(id);
+  }
+
+  public _markExecuted(id: bigint) {
+    return this.circuits.impure._markExecuted(id);
+  }
+
+  // View
+  public getProposal(id: bigint): Proposal {
+    return this.circuits.impure.getProposal(id);
+  }
+
+  public getProposalRecipient(id: bigint): Recipient {
+    return this.circuits.impure.getProposalRecipient(id);
+  }
+
+  public getProposalAmount(id: bigint): bigint {
+    return this.circuits.impure.getProposalAmount(id);
+  }
+
+  public getProposalColor(id: bigint): Uint8Array {
+    return this.circuits.impure.getProposalColor(id);
+  }
+
+  public getProposalStatus(id: bigint): number {
+    return this.circuits.impure.getProposalStatus(id);
+  }
+}

--- a/contracts/src/multisig/test/simulators/ShieldedMultiSigSimulator.ts
+++ b/contracts/src/multisig/test/simulators/ShieldedMultiSigSimulator.ts
@@ -1,0 +1,158 @@
+import {
+  type BaseSimulatorOptions,
+  createSimulator,
+} from '@openzeppelin-compact/contracts-simulator';
+import {
+  type Ledger,
+  ledger,
+  Contract as ShieldedMultiSig,
+} from '../../../../artifacts/ShieldedMultiSig/contract/index.js';
+import {
+  ShieldedMultiSigPrivateState,
+  ShieldedMultiSigWitnesses,
+} from '../../witnesses/ShieldedMultiSigWitnesses.js';
+
+type EitherPKAddress = {
+  is_left: boolean;
+  left: { bytes: Uint8Array };
+  right: { bytes: Uint8Array };
+};
+type Recipient = { kind: number; address: Uint8Array };
+type ShieldedCoinInfo = { nonce: Uint8Array; color: Uint8Array; value: bigint };
+type ShieldedSendResult = {
+  change: { is_some: boolean; value: ShieldedCoinInfo };
+  sent: ShieldedCoinInfo;
+};
+type Proposal = {
+  to: Recipient;
+  color: Uint8Array;
+  amount: bigint;
+  status: number;
+};
+
+type ShieldedMultiSigArgs = readonly [
+  signers: EitherPKAddress[],
+  thresh: bigint,
+];
+
+const ShieldedMultiSigSimulatorBase = createSimulator<
+  ShieldedMultiSigPrivateState,
+  ReturnType<typeof ledger>,
+  ReturnType<typeof ShieldedMultiSigWitnesses>,
+  ShieldedMultiSig<ShieldedMultiSigPrivateState>,
+  ShieldedMultiSigArgs
+>({
+  contractFactory: (witnesses) =>
+    new ShieldedMultiSig<ShieldedMultiSigPrivateState>(witnesses),
+  defaultPrivateState: () => ShieldedMultiSigPrivateState,
+  contractArgs: (signers, thresh) => [signers, thresh],
+  ledgerExtractor: (state) => ledger(state),
+  witnessesFactory: () => ShieldedMultiSigWitnesses(),
+});
+
+export class ShieldedMultiSigSimulator extends ShieldedMultiSigSimulatorBase {
+  constructor(
+    signers: EitherPKAddress[],
+    thresh: bigint,
+    options: BaseSimulatorOptions<
+      ShieldedMultiSigPrivateState,
+      ReturnType<typeof ShieldedMultiSigWitnesses>
+    > = {},
+  ) {
+    super([signers, thresh], options);
+  }
+
+  // Deposit
+  public deposit(coin: ShieldedCoinInfo) {
+    return this.circuits.impure.deposit(coin);
+  }
+
+  // Proposals
+  public createShieldedProposal(
+    to: Recipient,
+    color: Uint8Array,
+    amount: bigint,
+  ): bigint {
+    return this.circuits.impure.createShieldedProposal(to, color, amount);
+  }
+
+  public approveProposal(id: bigint) {
+    return this.circuits.impure.approveProposal(id);
+  }
+
+  public revokeApproval(id: bigint) {
+    return this.circuits.impure.revokeApproval(id);
+  }
+
+  public executeShieldedProposal(id: bigint): ShieldedSendResult {
+    return this.circuits.impure.executeShieldedProposal(id);
+  }
+
+  // View - Approvals
+  public isProposalApprovedBySigner(
+    id: bigint,
+    signer: EitherPKAddress,
+  ): boolean {
+    return this.circuits.impure.isProposalApprovedBySigner(id, signer);
+  }
+
+  public getApprovalCount(id: bigint): bigint {
+    return this.circuits.impure.getApprovalCount(id);
+  }
+
+  // View - Proposals
+  public getProposal(id: bigint): Proposal {
+    return this.circuits.impure.getProposal(id);
+  }
+
+  public getProposalRecipient(id: bigint): Recipient {
+    return this.circuits.impure.getProposalRecipient(id);
+  }
+
+  public getProposalAmount(id: bigint): bigint {
+    return this.circuits.impure.getProposalAmount(id);
+  }
+
+  public getProposalColor(id: bigint): Uint8Array {
+    return this.circuits.impure.getProposalColor(id);
+  }
+
+  public getProposalStatus(id: bigint): number {
+    return this.circuits.impure.getProposalStatus(id);
+  }
+
+  // View - Treasury
+  public getTokenBalance(color: Uint8Array): bigint {
+    return this.circuits.impure.getTokenBalance(color);
+  }
+
+  public getReceivedTotal(color: Uint8Array): bigint {
+    return this.circuits.impure.getReceivedTotal(color);
+  }
+
+  public getSentTotal(color: Uint8Array): bigint {
+    return this.circuits.impure.getSentTotal(color);
+  }
+
+  public getReceivedMinusSent(color: Uint8Array): bigint {
+    return this.circuits.impure.getReceivedMinusSent(color);
+  }
+
+  // View - Signers
+  public getSignerCount(): bigint {
+    return this.circuits.impure.getSignerCount();
+  }
+
+  public getThreshold(): bigint {
+    return this.circuits.impure.getThreshold();
+  }
+
+  public isSigner(account: EitherPKAddress): boolean {
+    return this.circuits.impure.isSigner(account);
+  }
+
+  // Ledger access
+  public getLedger(): Ledger {
+    return this.getPublicState();
+  }
+}

--- a/contracts/src/multisig/test/simulators/ShieldedMultiSigV2Simulator.ts
+++ b/contracts/src/multisig/test/simulators/ShieldedMultiSigV2Simulator.ts
@@ -1,0 +1,107 @@
+import {
+  type BaseSimulatorOptions,
+  createSimulator,
+} from '@openzeppelin-compact/contracts-simulator';
+import {
+  type Ledger,
+  ledger,
+  pureCircuits,
+  Contract as ShieldedMultiSigV2,
+} from '../../../../artifacts/ShieldedMultiSigV2/contract/index.js';
+import {
+  ShieldedMultiSigV2PrivateState,
+  ShieldedMultiSigV2Witnesses,
+} from '../../witnesses/ShieldedMultiSigV2Witnesses.js';
+
+type Recipient = { kind: number; address: Uint8Array };
+type ShieldedCoinInfo = { nonce: Uint8Array; color: Uint8Array; value: bigint };
+type QualifiedShieldedCoinInfo = {
+  nonce: Uint8Array;
+  color: Uint8Array;
+  value: bigint;
+  mt_index: bigint;
+};
+type ShieldedSendResult = {
+  change: { is_some: boolean; value: ShieldedCoinInfo };
+  sent: ShieldedCoinInfo;
+};
+
+type ShieldedMultiSigV2Args = readonly [
+  instanceSalt: Uint8Array,
+  signerCommitments: Uint8Array[],
+  thresh: bigint,
+];
+
+const ShieldedMultiSigV2SimulatorBase = createSimulator<
+  ShieldedMultiSigV2PrivateState,
+  ReturnType<typeof ledger>,
+  ReturnType<typeof ShieldedMultiSigV2Witnesses>,
+  ShieldedMultiSigV2<ShieldedMultiSigV2PrivateState>,
+  ShieldedMultiSigV2Args
+>({
+  contractFactory: (witnesses) =>
+    new ShieldedMultiSigV2<ShieldedMultiSigV2PrivateState>(witnesses),
+  defaultPrivateState: () => ShieldedMultiSigV2PrivateState,
+  contractArgs: (instanceSalt, signerCommitments, thresh) => [
+    instanceSalt,
+    signerCommitments,
+    thresh,
+  ],
+  ledgerExtractor: (state) => ledger(state),
+  witnessesFactory: () => ShieldedMultiSigV2Witnesses(),
+});
+
+export class ShieldedMultiSigV2Simulator extends ShieldedMultiSigV2SimulatorBase {
+  constructor(
+    instanceSalt: Uint8Array,
+    signerCommitments: Uint8Array[],
+    thresh: bigint,
+    options: BaseSimulatorOptions<
+      ShieldedMultiSigV2PrivateState,
+      ReturnType<typeof ShieldedMultiSigV2Witnesses>
+    > = {},
+  ) {
+    super([instanceSalt, signerCommitments, thresh], options);
+  }
+
+  public static calculateSignerId(
+    pk: Uint8Array,
+    salt: Uint8Array,
+  ): Uint8Array {
+    return pureCircuits._calculateSignerId(pk, salt);
+  }
+
+  public deposit(coin: ShieldedCoinInfo) {
+    return this.circuits.impure.deposit(coin);
+  }
+
+  public execute(
+    to: Recipient,
+    amount: bigint,
+    coin: QualifiedShieldedCoinInfo,
+    pubkeys: Uint8Array[],
+    signatures: Uint8Array[],
+  ): ShieldedSendResult {
+    return this.circuits.impure.execute(to, amount, coin, pubkeys, signatures);
+  }
+
+  public getNonce(): bigint {
+    return this.circuits.impure.getNonce();
+  }
+
+  public getSignerCount(): bigint {
+    return this.circuits.impure.getSignerCount();
+  }
+
+  public getThreshold(): bigint {
+    return this.circuits.impure.getThreshold();
+  }
+
+  public isSigner(commitment: Uint8Array): boolean {
+    return this.circuits.impure.isSigner(commitment);
+  }
+
+  public getLedger(): Ledger {
+    return this.getPublicState();
+  }
+}

--- a/contracts/src/multisig/test/simulators/ShieldedTreasurySimulator.ts
+++ b/contracts/src/multisig/test/simulators/ShieldedTreasurySimulator.ts
@@ -1,0 +1,78 @@
+import {
+  type BaseSimulatorOptions,
+  createSimulator,
+} from '@openzeppelin-compact/contracts-simulator';
+import {
+  ledger,
+  Contract as MockShieldedTreasury,
+} from '../../../../artifacts/MockShieldedTreasury/contract/index.js';
+import {
+  ShieldedTreasuryPrivateState,
+  ShieldedTreasuryWitnesses,
+} from '../../witnesses/ShieldedTreasuryWitnesses.js';
+
+type ShieldedCoinInfo = { nonce: Uint8Array; color: Uint8Array; value: bigint };
+type ShieldedSendResult = {
+  change: { is_some: boolean; value: ShieldedCoinInfo };
+  sent: ShieldedCoinInfo;
+};
+
+type ShieldedTreasuryArgs = readonly [];
+
+const ShieldedTreasurySimulatorBase = createSimulator<
+  ShieldedTreasuryPrivateState,
+  ReturnType<typeof ledger>,
+  ReturnType<typeof ShieldedTreasuryWitnesses>,
+  MockShieldedTreasury<ShieldedTreasuryPrivateState>,
+  ShieldedTreasuryArgs
+>({
+  contractFactory: (witnesses) =>
+    new MockShieldedTreasury<ShieldedTreasuryPrivateState>(witnesses),
+  defaultPrivateState: () => ShieldedTreasuryPrivateState,
+  contractArgs: () => [],
+  ledgerExtractor: (state) => ledger(state),
+  witnessesFactory: () => ShieldedTreasuryWitnesses(),
+});
+
+export class ShieldedTreasurySimulator extends ShieldedTreasurySimulatorBase {
+  constructor(
+    options: BaseSimulatorOptions<
+      ShieldedTreasuryPrivateState,
+      ReturnType<typeof ShieldedTreasuryWitnesses>
+    > = {},
+  ) {
+    super([], options);
+  }
+
+  public _deposit(coin: ShieldedCoinInfo) {
+    return this.circuits.impure._deposit(coin);
+  }
+
+  public _send(
+    recipient: {
+      is_left: boolean;
+      left: { bytes: Uint8Array };
+      right: { bytes: Uint8Array };
+    },
+    color: Uint8Array,
+    amount: bigint,
+  ): ShieldedSendResult {
+    return this.circuits.impure._send(recipient, color, amount);
+  }
+
+  public getTokenBalance(color: Uint8Array): bigint {
+    return this.circuits.impure.getTokenBalance(color);
+  }
+
+  public getReceivedTotal(color: Uint8Array): bigint {
+    return this.circuits.impure.getReceivedTotal(color);
+  }
+
+  public getSentTotal(color: Uint8Array): bigint {
+    return this.circuits.impure.getSentTotal(color);
+  }
+
+  public getReceivedMinusSent(color: Uint8Array): bigint {
+    return this.circuits.impure.getReceivedMinusSent(color);
+  }
+}

--- a/contracts/src/multisig/test/simulators/SignerManagerSimulator.ts
+++ b/contracts/src/multisig/test/simulators/SignerManagerSimulator.ts
@@ -1,0 +1,96 @@
+import {
+  type BaseSimulatorOptions,
+  createSimulator,
+} from '@openzeppelin-compact/contracts-simulator';
+import {
+  type ContractAddress,
+  type Either,
+  ledger,
+  Contract as MockSignerManager,
+  type ZswapCoinPublicKey,
+} from '../../../../artifacts/MockSignerManager/contract/index.js';
+import {
+  SignerManagerPrivateState,
+  SignerManagerWitnesses,
+} from '../../witnesses/SignerManagerWitnesses.js';
+
+/**
+ * A fixed set of exactly three signers, matching the
+ * `Vector<3, Either<ZswapCoinPublicKey, ContractAddress>>` the underlying
+ * `MockSignerManager` constructor expects.
+ */
+export type SignerSet = readonly [
+  Either<ZswapCoinPublicKey, ContractAddress>,
+  Either<ZswapCoinPublicKey, ContractAddress>,
+  Either<ZswapCoinPublicKey, ContractAddress>,
+];
+
+/**
+ * Type constructor args
+ */
+type SignerManagerArgs = readonly [signers: SignerSet, thresh: bigint];
+
+const SignerManagerSimulatorBase = createSimulator<
+  SignerManagerPrivateState,
+  ReturnType<typeof ledger>,
+  ReturnType<typeof SignerManagerWitnesses>,
+  MockSignerManager<SignerManagerPrivateState>,
+  SignerManagerArgs
+>({
+  contractFactory: (witnesses) =>
+    new MockSignerManager<SignerManagerPrivateState>(witnesses),
+  defaultPrivateState: () => SignerManagerPrivateState,
+  contractArgs: (signers, thresh) => [signers, thresh],
+  ledgerExtractor: (state) => ledger(state),
+  witnessesFactory: () => SignerManagerWitnesses(),
+});
+
+/**
+ * SignerManager Simulator
+ */
+export class SignerManagerSimulator extends SignerManagerSimulatorBase {
+  constructor(
+    signers: SignerSet,
+    thresh: bigint,
+    options: BaseSimulatorOptions<
+      SignerManagerPrivateState,
+      ReturnType<typeof SignerManagerWitnesses>
+    > = {},
+  ) {
+    super([signers, thresh], options);
+  }
+
+  public assertSigner(caller: Either<ZswapCoinPublicKey, ContractAddress>) {
+    return this.circuits.impure.assertSigner(caller);
+  }
+
+  public assertThresholdMet(approvalCount: bigint) {
+    return this.circuits.impure.assertThresholdMet(approvalCount);
+  }
+
+  public getSignerCount(): bigint {
+    return this.circuits.impure.getSignerCount();
+  }
+
+  public getThreshold(): bigint {
+    return this.circuits.impure.getThreshold();
+  }
+
+  public isSigner(
+    account: Either<ZswapCoinPublicKey, ContractAddress>,
+  ): boolean {
+    return this.circuits.impure.isSigner(account);
+  }
+
+  public _addSigner(signer: Either<ZswapCoinPublicKey, ContractAddress>) {
+    return this.circuits.impure._addSigner(signer);
+  }
+
+  public _removeSigner(signer: Either<ZswapCoinPublicKey, ContractAddress>) {
+    return this.circuits.impure._removeSigner(signer);
+  }
+
+  public _changeThreshold(newThreshold: bigint) {
+    return this.circuits.impure._changeThreshold(newThreshold);
+  }
+}

--- a/contracts/src/multisig/test/simulators/SignerSimulator.ts
+++ b/contracts/src/multisig/test/simulators/SignerSimulator.ts
@@ -1,0 +1,92 @@
+import {
+  type BaseSimulatorOptions,
+  createSimulator,
+} from '@openzeppelin-compact/contracts-simulator';
+import {
+  ledger,
+  Contract as MockSigner,
+} from '../../../../artifacts/MockSigner/contract/index.js';
+import {
+  SignerPrivateState,
+  SignerWitnesses,
+} from '../../witnesses/SignerWitnesses.js';
+
+/**
+ * Type constructor args
+ */
+type SignerArgs = readonly [
+  signers: Uint8Array[],
+  thresh: bigint,
+  isInit: boolean,
+];
+
+const SignerSimulatorBase = createSimulator<
+  SignerPrivateState,
+  ReturnType<typeof ledger>,
+  ReturnType<typeof SignerWitnesses>,
+  MockSigner<SignerPrivateState>,
+  SignerArgs
+>({
+  contractFactory: (witnesses) => new MockSigner<SignerPrivateState>(witnesses),
+  defaultPrivateState: () => SignerPrivateState,
+  contractArgs: (signers, thresh, isInit) => [signers, thresh, isInit],
+  ledgerExtractor: (state) => ledger(state),
+  witnessesFactory: () => SignerWitnesses(),
+});
+
+/**
+ * Signer Simulator
+ */
+export class SignerSimulator extends SignerSimulatorBase {
+  constructor(
+    signers: Uint8Array[],
+    thresh: bigint,
+    isInit: boolean,
+    options: BaseSimulatorOptions<
+      SignerPrivateState,
+      ReturnType<typeof SignerWitnesses>
+    > = {},
+  ) {
+    super([signers, thresh, isInit], options);
+  }
+
+  public initialize(signers: Uint8Array[], thresh: bigint) {
+    return this.circuits.impure.initialize(signers, thresh);
+  }
+
+  public assertSigner(caller: Uint8Array) {
+    return this.circuits.impure.assertSigner(caller);
+  }
+
+  public assertThresholdMet(approvalCount: bigint) {
+    return this.circuits.impure.assertThresholdMet(approvalCount);
+  }
+
+  public getSignerCount(): bigint {
+    return this.circuits.impure.getSignerCount();
+  }
+
+  public getThreshold(): bigint {
+    return this.circuits.impure.getThreshold();
+  }
+
+  public isSigner(account: Uint8Array): boolean {
+    return this.circuits.impure.isSigner(account);
+  }
+
+  public _addSigner(signer: Uint8Array) {
+    return this.circuits.impure._addSigner(signer);
+  }
+
+  public _removeSigner(signer: Uint8Array) {
+    return this.circuits.impure._removeSigner(signer);
+  }
+
+  public _changeThreshold(newThreshold: bigint) {
+    return this.circuits.impure._changeThreshold(newThreshold);
+  }
+
+  public _setThreshold(newThreshold: bigint) {
+    return this.circuits.impure._setThreshold(newThreshold);
+  }
+}

--- a/contracts/src/multisig/test/simulators/presets/ForwarderPrivateSimulator.ts
+++ b/contracts/src/multisig/test/simulators/presets/ForwarderPrivateSimulator.ts
@@ -1,0 +1,69 @@
+import {
+  type BaseSimulatorOptions,
+  createSimulator,
+} from '@openzeppelin-compact/contracts-simulator';
+import {
+  ledger,
+  pureCircuits,
+  type QualifiedShieldedCoinInfo,
+  type ShieldedCoinInfo,
+  type ShieldedSendResult,
+  Contract as ForwarderPrivate,
+} from '../../../../../artifacts/ForwarderPrivate/contract/index.js';
+import {
+  ForwarderPrivatePrivateState,
+  ForwarderPrivateWitnesses,
+} from '../../../witnesses/presets/ForwarderPrivateWitnesses.js';
+
+type ForwarderPrivateArgs = readonly [parentCommitment: Uint8Array];
+
+const ForwarderPrivateSimulatorBase = createSimulator<
+  ForwarderPrivatePrivateState,
+  ReturnType<typeof ledger>,
+  ReturnType<typeof ForwarderPrivateWitnesses>,
+  ForwarderPrivate<ForwarderPrivatePrivateState>,
+  ForwarderPrivateArgs
+>({
+  contractFactory: (witnesses) =>
+    new ForwarderPrivate<ForwarderPrivatePrivateState>(witnesses),
+  defaultPrivateState: () => ForwarderPrivatePrivateState,
+  contractArgs: (parentCommitment) => [parentCommitment],
+  ledgerExtractor: (state) => ledger(state),
+  witnessesFactory: () => ForwarderPrivateWitnesses(),
+});
+
+export class ForwarderPrivateSimulator extends ForwarderPrivateSimulatorBase {
+  constructor(
+    parentCommitment: Uint8Array,
+    options: BaseSimulatorOptions<
+      ForwarderPrivatePrivateState,
+      ReturnType<typeof ForwarderPrivateWitnesses>
+    > = {},
+  ) {
+    super([parentCommitment], options);
+  }
+
+  public static calculateParentCommitment(
+    parentAddr: Uint8Array,
+    opSecret: Uint8Array,
+  ): Uint8Array {
+    return pureCircuits.calculateParentCommitment(parentAddr, opSecret);
+  }
+
+  public deposit(coin: ShieldedCoinInfo) {
+    return this.circuits.impure.deposit(coin);
+  }
+
+  public drain(
+    coin: QualifiedShieldedCoinInfo,
+    parentAddr: Uint8Array,
+    opSecret: Uint8Array,
+    value: bigint,
+  ): ShieldedSendResult {
+    return this.circuits.impure.drain(coin, parentAddr, opSecret, value);
+  }
+
+  public getParentCommitment(): Uint8Array {
+    return this.circuits.impure.getParentCommitment();
+  }
+}

--- a/contracts/src/multisig/test/simulators/presets/ForwarderShieldedSimulator.ts
+++ b/contracts/src/multisig/test/simulators/presets/ForwarderShieldedSimulator.ts
@@ -1,0 +1,51 @@
+import {
+  type BaseSimulatorOptions,
+  createSimulator,
+} from '@openzeppelin-compact/contracts-simulator';
+import {
+  ledger,
+  Contract as ForwarderShielded,
+  type ShieldedCoinInfo,
+  type ZswapCoinPublicKey,
+} from '../../../../../artifacts/ForwarderShielded/contract/index.js';
+import {
+  ForwarderShieldedPrivateState,
+  ForwarderShieldedWitnesses,
+} from '../../../witnesses/presets/ForwarderShieldedWitnesses.js';
+
+type ForwarderShieldedArgs = readonly [parent: ZswapCoinPublicKey];
+
+const ForwarderShieldedSimulatorBase = createSimulator<
+  ForwarderShieldedPrivateState,
+  ReturnType<typeof ledger>,
+  ReturnType<typeof ForwarderShieldedWitnesses>,
+  ForwarderShielded<ForwarderShieldedPrivateState>,
+  ForwarderShieldedArgs
+>({
+  contractFactory: (witnesses) =>
+    new ForwarderShielded<ForwarderShieldedPrivateState>(witnesses),
+  defaultPrivateState: () => ForwarderShieldedPrivateState,
+  contractArgs: (parent) => [parent],
+  ledgerExtractor: (state) => ledger(state),
+  witnessesFactory: () => ForwarderShieldedWitnesses(),
+});
+
+export class ForwarderShieldedSimulator extends ForwarderShieldedSimulatorBase {
+  constructor(
+    parent: Uint8Array,
+    options: BaseSimulatorOptions<
+      ForwarderShieldedPrivateState,
+      ReturnType<typeof ForwarderShieldedWitnesses>
+    > = {},
+  ) {
+    super([{ bytes: parent }], options);
+  }
+
+  public deposit(coin: ShieldedCoinInfo) {
+    return this.circuits.impure.deposit(coin);
+  }
+
+  public getParent(): Uint8Array {
+    return this.circuits.impure.getParent().bytes;
+  }
+}

--- a/contracts/src/multisig/test/simulators/presets/ForwarderUnshieldedSimulator.ts
+++ b/contracts/src/multisig/test/simulators/presets/ForwarderUnshieldedSimulator.ts
@@ -1,0 +1,50 @@
+import {
+  type BaseSimulatorOptions,
+  createSimulator,
+} from '@openzeppelin-compact/contracts-simulator';
+import {
+  ledger,
+  Contract as ForwarderUnshielded,
+  type UserAddress,
+} from '../../../../../artifacts/ForwarderUnshielded/contract/index.js';
+import {
+  ForwarderUnshieldedPrivateState,
+  ForwarderUnshieldedWitnesses,
+} from '../../../witnesses/presets/ForwarderUnshieldedWitnesses.js';
+
+type ForwarderUnshieldedArgs = readonly [parent: UserAddress];
+
+const ForwarderUnshieldedSimulatorBase = createSimulator<
+  ForwarderUnshieldedPrivateState,
+  ReturnType<typeof ledger>,
+  ReturnType<typeof ForwarderUnshieldedWitnesses>,
+  ForwarderUnshielded<ForwarderUnshieldedPrivateState>,
+  ForwarderUnshieldedArgs
+>({
+  contractFactory: (witnesses) =>
+    new ForwarderUnshielded<ForwarderUnshieldedPrivateState>(witnesses),
+  defaultPrivateState: () => ForwarderUnshieldedPrivateState,
+  contractArgs: (parent) => [parent],
+  ledgerExtractor: (state) => ledger(state),
+  witnessesFactory: () => ForwarderUnshieldedWitnesses(),
+});
+
+export class ForwarderUnshieldedSimulator extends ForwarderUnshieldedSimulatorBase {
+  constructor(
+    parent: Uint8Array,
+    options: BaseSimulatorOptions<
+      ForwarderUnshieldedPrivateState,
+      ReturnType<typeof ForwarderUnshieldedWitnesses>
+    > = {},
+  ) {
+    super([{ bytes: parent }], options);
+  }
+
+  public depositUnshielded(color: Uint8Array, amount: bigint) {
+    return this.circuits.impure.depositUnshielded(color, amount);
+  }
+
+  public getParent(): Uint8Array {
+    return this.circuits.impure.getParent().bytes;
+  }
+}

--- a/contracts/src/multisig/witnesses/MockForwarderPrivateWitnesses.ts
+++ b/contracts/src/multisig/witnesses/MockForwarderPrivateWitnesses.ts
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Compact Contracts v0.0.1-alpha.1 (multisig/witnesses/MockForwarderPrivateWitnesses.ts)
+
+export type MockForwarderPrivatePrivateState = Record<string, never>;
+export const MockForwarderPrivatePrivateState: MockForwarderPrivatePrivateState = {};
+export const MockForwarderPrivateWitnesses = () => ({});

--- a/contracts/src/multisig/witnesses/MockForwarderWitnesses.ts
+++ b/contracts/src/multisig/witnesses/MockForwarderWitnesses.ts
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Compact Contracts v0.0.1-alpha.1 (multisig/witnesses/MockForwarderWitnesses.ts)
+
+export type MockForwarderPrivateState = Record<string, never>;
+export const MockForwarderPrivateState: MockForwarderPrivateState = {};
+export const MockForwarderWitnesses = () => ({});

--- a/contracts/src/multisig/witnesses/ProposalManagerWitnesses.ts
+++ b/contracts/src/multisig/witnesses/ProposalManagerWitnesses.ts
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Compact Contracts v0.0.1-alpha.1 (multisig/witnesses/ProposalManagerWitnesses.ts)
+
+export type ProposalManagerPrivateState = Record<string, never>;
+export const ProposalManagerPrivateState: ProposalManagerPrivateState = {};
+export const ProposalManagerWitnesses = () => ({});

--- a/contracts/src/multisig/witnesses/ShieldedMultiSigV2Witnesses.ts
+++ b/contracts/src/multisig/witnesses/ShieldedMultiSigV2Witnesses.ts
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Compact Contracts v0.0.1-alpha.1 (multisig/witnesses/ShieldedMultiSigV2Witnesses.ts)
+
+export type ShieldedMultiSigV2PrivateState = Record<string, never>;
+export const ShieldedMultiSigV2PrivateState: ShieldedMultiSigV2PrivateState =
+  {};
+export const ShieldedMultiSigV2Witnesses = () => ({});

--- a/contracts/src/multisig/witnesses/ShieldedMultiSigWitnesses.ts
+++ b/contracts/src/multisig/witnesses/ShieldedMultiSigWitnesses.ts
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Compact Contracts v0.0.1-alpha.1 (multisig/witnesses/ShieldedMultiSigWitnesses.ts)
+
+export type ShieldedMultiSigPrivateState = Record<string, never>;
+export const ShieldedMultiSigPrivateState: ShieldedMultiSigPrivateState = {};
+export const ShieldedMultiSigWitnesses = () => ({});

--- a/contracts/src/multisig/witnesses/ShieldedTreasuryWitnesses.ts
+++ b/contracts/src/multisig/witnesses/ShieldedTreasuryWitnesses.ts
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Compact Contracts v0.0.1-alpha.1 (multisig/witnesses/ShieldedTreasuryWitnesses.ts)
+
+export type ShieldedTreasuryPrivateState = Record<string, never>;
+export const ShieldedTreasuryPrivateState: ShieldedTreasuryPrivateState = {};
+export const ShieldedTreasuryWitnesses = () => ({});

--- a/contracts/src/multisig/witnesses/SignerManagerWitnesses.ts
+++ b/contracts/src/multisig/witnesses/SignerManagerWitnesses.ts
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Compact Contracts v0.0.1-alpha.1 (multisig/witnesses/SignerManagerWitnesses.ts)
+
+export type SignerManagerPrivateState = Record<string, never>;
+export const SignerManagerPrivateState: SignerManagerPrivateState = {};
+export const SignerManagerWitnesses = () => ({});

--- a/contracts/src/multisig/witnesses/SignerWitnesses.ts
+++ b/contracts/src/multisig/witnesses/SignerWitnesses.ts
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Compact Contracts v0.0.1-alpha.1 (multisig/witnesses/SignerWitnesses.ts)
+
+export type SignerPrivateState = Record<string, never>;
+export const SignerPrivateState: SignerPrivateState = {};
+export const SignerWitnesses = () => ({});

--- a/contracts/src/multisig/witnesses/UnshieldedTreasuryWitnesses.ts
+++ b/contracts/src/multisig/witnesses/UnshieldedTreasuryWitnesses.ts
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Compact Contracts v0.0.1-alpha.1 (multisig/witnesses/UnshieldedTreasuryWitnesses.ts)
+
+export type UnshieldedTreasuryPrivateState = Record<string, never>;
+export const UnshieldedTreasuryPrivateState: UnshieldedTreasuryPrivateState =
+  {};
+export const UnshieldedTreasuryWitnesses = () => ({});

--- a/contracts/src/multisig/witnesses/presets/ForwarderPrivateWitnesses.ts
+++ b/contracts/src/multisig/witnesses/presets/ForwarderPrivateWitnesses.ts
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Compact Contracts v0.0.1-alpha.1 (multisig/witnesses/presets/ForwarderPrivateWitnesses.ts)
+
+export type ForwarderPrivatePrivateState = Record<string, never>;
+export const ForwarderPrivatePrivateState: ForwarderPrivatePrivateState = {};
+export const ForwarderPrivateWitnesses = () => ({});

--- a/contracts/src/multisig/witnesses/presets/ForwarderShieldedWitnesses.ts
+++ b/contracts/src/multisig/witnesses/presets/ForwarderShieldedWitnesses.ts
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Compact Contracts v0.0.1-alpha.1 (multisig/witnesses/presets/ForwarderShieldedWitnesses.ts)
+
+export type ForwarderShieldedPrivateState = Record<string, never>;
+export const ForwarderShieldedPrivateState: ForwarderShieldedPrivateState = {};
+export const ForwarderShieldedWitnesses = () => ({});

--- a/contracts/src/multisig/witnesses/presets/ForwarderUnshieldedWitnesses.ts
+++ b/contracts/src/multisig/witnesses/presets/ForwarderUnshieldedWitnesses.ts
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Compact Contracts v0.0.1-alpha.1 (multisig/witnesses/presets/ForwarderUnshieldedWitnesses.ts)
+
+export type ForwarderUnshieldedPrivateState = Record<string, never>;
+export const ForwarderUnshieldedPrivateState: ForwarderUnshieldedPrivateState = {};
+export const ForwarderUnshieldedWitnesses = () => ({});

--- a/contracts/src/utils/Utils.compact
+++ b/contracts/src/utils/Utils.compact
@@ -95,4 +95,26 @@ module Utils {
       ? Either<T1, T2>{ is_left: true, left: value.left, right: default<T2> }
       : Either<T1, T2>{ is_left: false, left: default<T1>, right: value.right };
   }
+
+  /**
+   * @description Returns the current contract's address as an
+   * `Either<ZswapCoinPublicKey, ContractAddress>` for use as a
+   * recipient in shielded send operations (deposits and receiving change).
+   *
+   * @returns {Either<ZswapCoinPublicKey, ContractAddress>} The contract's address as a recipient.
+   */
+  export circuit selfAsRecipient(): Either<ZswapCoinPublicKey, ContractAddress> {
+    return right<ZswapCoinPublicKey, ContractAddress>(kernel.self());
+  }
+
+  /**
+   * @description The maximum value representable by a `Uint<128>`.
+   *
+   * @notice TODO: Remove once a math module providing this constant is available.
+   *
+   * @returns {Uint<128>} `2^128 - 1`.
+   */
+  export pure circuit UINT128_MAX(): Uint<128> {
+    return 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF;
+  }
 }

--- a/contracts/src/utils/test/mocks/MockUtils.compact
+++ b/contracts/src/utils/test/mocks/MockUtils.compact
@@ -41,3 +41,11 @@ export pure circuit canonicalizeKeyOrAddress(
 ): Either<ZswapCoinPublicKey, ContractAddress> {
   return Utils_canonicalize<ZswapCoinPublicKey, ContractAddress>(keyOrAddress);
 }
+
+export circuit selfAsRecipient(): Either<ZswapCoinPublicKey, ContractAddress> {
+  return Utils_selfAsRecipient();
+}
+
+export pure circuit UINT128_MAX(): Uint<128> {
+  return Utils_UINT128_MAX();
+}

--- a/contracts/src/utils/test/simulators/UtilsSimulator.ts
+++ b/contracts/src/utils/test/simulators/UtilsSimulator.ts
@@ -111,4 +111,21 @@ export class UtilsSimulator extends UtilsSimulatorBase {
   ): Either<ZswapCoinPublicKey, ContractAddress> {
     return this.circuits.pure.canonicalizeKeyOrAddress(keyOrAddress);
   }
+
+  /**
+   * @description Returns the current contract's address wrapped as a
+   * right-variant `Either<ZswapCoinPublicKey, ContractAddress>`.
+   * @returns The contract's own address as a recipient.
+   */
+  public selfAsRecipient(): Either<ZswapCoinPublicKey, ContractAddress> {
+    return this.circuits.impure.selfAsRecipient();
+  }
+
+  /**
+   * @description The maximum value representable by a `Uint<128>`.
+   * @returns `2^128 - 1`.
+   */
+  public UINT128_MAX(): bigint {
+    return this.circuits.pure.UINT128_MAX();
+  }
 }

--- a/contracts/src/utils/test/utils.test.ts
+++ b/contracts/src/utils/test/utils.test.ts
@@ -145,4 +145,30 @@ describe('Utils', () => {
       expect(canonical).toEqual(contractUtils.ZERO_ADDRESS);
     });
   });
+
+  describe('selfAsRecipient', () => {
+    it('should return the contract address as a right-variant recipient', () => {
+      const result = contract.selfAsRecipient();
+      expect(result.is_left).toBe(false);
+      expect(contract.isContractAddress(result)).toBe(true);
+    });
+
+    it('should return a 32-byte contract address', () => {
+      const result = contract.selfAsRecipient();
+      expect(result.right.bytes).toBeInstanceOf(Uint8Array);
+      expect(result.right.bytes.length).toBe(32);
+    });
+
+    it('should return the same address on repeated calls', () => {
+      const first = contract.selfAsRecipient();
+      const second = contract.selfAsRecipient();
+      expect(first.right.bytes).toEqual(second.right.bytes);
+    });
+  });
+
+  describe('UINT128_MAX', () => {
+    it('should return 2^128 - 1', () => {
+      expect(contract.UINT128_MAX()).toBe((1n << 128n) - 1n);
+    });
+  });
 });

--- a/contracts/vitest.config.ts
+++ b/contracts/vitest.config.ts
@@ -7,5 +7,40 @@ export default defineConfig({
     include: ['src/**/*.test.ts'],
     exclude: [...configDefaults.exclude, 'src/archive/**'],
     reporters: 'verbose',
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'html'],
+      include: [
+        'src/**/witnesses/**/*.ts',
+        'src/**/test/simulators/**/*.ts',
+        // compactc-generated JS for every compiled contract.
+        'artifacts/*/contract/index.js',
+      ],
+      exclude: [
+        ...(configDefaults.coverage?.exclude ?? []),
+        'src/archive/**',
+        'src/**/test/**/*.test.ts',
+        // Drop `.compact` after source-map remap: compactc emits
+        // function-entry-granularity maps, so branch / line attribution
+        // on `.compact` lines is unreliable even when both legs of an
+        // `if` are exercised. Tracking upstream:
+        // https://github.com/LFDT-Minokawa/compact/issues/465
+        'src/**/*.compact',
+      ],
+      excludeAfterRemap: true,
+      // 95 % per-file is the closing gate of the test stage. Leaves
+      // room for unavoidable TS-plumbing gaps (simulator factory
+      // callbacks, witness stub bodies) without contorting tests
+      // around test infrastructure. Subset runs (e.g.
+      // `vitest run <one.test.ts>`) fail this gate — pass
+      // `--coverage.thresholds.lines=0` etc. when iterating on one file.
+      thresholds: {
+        perFile: true,
+        lines: 95,
+        branches: 95,
+        functions: 95,
+        statements: 95,
+      },
+    },
   },
 });

--- a/turbo.json
+++ b/turbo.json
@@ -29,6 +29,13 @@
       "outputLogs": "new-only",
       "outputs": ["artifacts/**/"]
     },
+    "compact:multisig": {
+      "dependsOn": ["^build", "compact:security", "compact:utils"],
+      "env": ["COMPACT_HOME", "SKIP_ZK"],
+      "inputs": ["src/multisig/**/*.compact"],
+      "outputLogs": "new-only",
+      "outputs": ["artifacts/**/"]
+    },
     "compact:token": {
       "dependsOn": ["^build", "compact:security", "compact:utils"],
       "env": ["COMPACT_HOME", "SKIP_ZK"],
@@ -41,6 +48,7 @@
         "compact:security",
         "compact:utils",
         "compact:access",
+        "compact:multisig",
         "compact:token"
       ],
       "env": ["COMPACT_HOME", "SKIP_ZK"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,6 +5,48 @@ __metadata:
   version: 8
   cacheKey: 10
 
+"@babel/helper-string-parser@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-string-parser@npm:7.29.7"
+  checksum: 10/4d8ef0ef7105f3d9fe4361137c8f42e5b4c7a52b5380b962762f2a528a1ba89064e2c6236090716ce34b63707b886ae0ebf36b2c2fcc2851f27e652febfc3648
+  languageName: node
+  linkType: hard
+
+"@babel/helper-validator-identifier@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-validator-identifier@npm:7.29.7"
+  checksum: 10/2efa42701eb05babf26dff3332109c9e5e1a3400a71fb9e68ee27af28235036a2a72c2494c04bdab3f909075f42a58b2e8271074372bc7f8e79ec02bd364d7a7
+  languageName: node
+  linkType: hard
+
+"@babel/parser@npm:^7.29.3":
+  version: 7.29.7
+  resolution: "@babel/parser@npm:7.29.7"
+  dependencies:
+    "@babel/types": "npm:^7.29.7"
+  bin:
+    parser: ./bin/babel-parser.js
+  checksum: 10/da40c5928c95997b01aabe84fc3440881b8f20b866714fefa142961d37e82ffc03fbb9afed706f15f8a688278f95286ca0cea0d87ad6c77600f8c6c45d9824ee
+  languageName: node
+  linkType: hard
+
+"@babel/types@npm:^7.29.0, @babel/types@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/types@npm:7.29.7"
+  dependencies:
+    "@babel/helper-string-parser": "npm:^7.29.7"
+    "@babel/helper-validator-identifier": "npm:^7.29.7"
+  checksum: 10/bd4f5635db1057bd0abeebf93eb3ae38399e152271cea8dce8288350f0afa13ed3e2db2e16e22bd3303068890eec18965a83420539afbe0dde31432b4cf9636d
+  languageName: node
+  linkType: hard
+
+"@bcoe/v8-coverage@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "@bcoe/v8-coverage@npm:1.0.2"
+  checksum: 10/46600b2dde460269b07a8e4f12b72e418eae1337b85c979f43af3336c9a1c65b04e42508ab6b245f1e0e3c64328e1c38d8cd733e4a7cebc4fbf9cf65c6e59937
+  languageName: node
+  linkType: hard
+
 "@biomejs/biome@npm:^2.4.7":
   version: 2.4.7
   resolution: "@biomejs/biome@npm:2.4.7"
@@ -156,14 +198,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/resolve-uri@npm:^3.0.3":
+"@jridgewell/resolve-uri@npm:^3.0.3, @jridgewell/resolve-uri@npm:^3.1.0":
   version: 3.1.2
   resolution: "@jridgewell/resolve-uri@npm:3.1.2"
   checksum: 10/97106439d750a409c22c8bff822d648f6a71f3aa9bc8e5129efdc36343cd3096ddc4eeb1c62d2fe48e9bdd4db37b05d4646a17114ecebd3bbcacfa2de51c3c1d
   languageName: node
   linkType: hard
 
-"@jridgewell/sourcemap-codec@npm:^1.4.10, @jridgewell/sourcemap-codec@npm:^1.5.5":
+"@jridgewell/sourcemap-codec@npm:^1.4.10, @jridgewell/sourcemap-codec@npm:^1.4.14, @jridgewell/sourcemap-codec@npm:^1.5.5":
   version: 1.5.5
   resolution: "@jridgewell/sourcemap-codec@npm:1.5.5"
   checksum: 10/5d9d207b462c11e322d71911e55e21a4e2772f71ffe8d6f1221b8eb5ae6774458c1d242f897fb0814e8714ca9a6b498abfa74dfe4f434493342902b1a48b33a5
@@ -177,6 +219,16 @@ __metadata:
     "@jridgewell/resolve-uri": "npm:^3.0.3"
     "@jridgewell/sourcemap-codec": "npm:^1.4.10"
   checksum: 10/83deafb8e7a5ca98993c2c6eeaa93c270f6f647a4c0dc00deb38c9cf9b2d3b7bf15e8839540155247ef034a052c0ec4466f980bf0c9e2ab63b97d16c0cedd3ff
+  languageName: node
+  linkType: hard
+
+"@jridgewell/trace-mapping@npm:^0.3.31":
+  version: 0.3.31
+  resolution: "@jridgewell/trace-mapping@npm:0.3.31"
+  dependencies:
+    "@jridgewell/resolve-uri": "npm:^3.1.0"
+    "@jridgewell/sourcemap-codec": "npm:^1.4.14"
+  checksum: 10/da0283270e691bdb5543806077548532791608e52386cfbbf3b9e8fb00457859d1bd01d512851161c886eb3a2f3ce6fd9bcf25db8edf3bddedd275bd4a88d606
   languageName: node
   linkType: hard
 
@@ -285,6 +337,8 @@ __metadata:
     "@openzeppelin-compact/contracts-simulator": "workspace:^"
     "@tsconfig/node24": "npm:^24.0.4"
     "@types/node": "npm:24.10.0"
+    "@vitest/coverage-v8": "npm:^4.1.6"
+    fast-check: "npm:^3.23.2"
     ts-node: "npm:^10.9.2"
     typescript: "npm:^5.9.3"
     vitest: "npm:^4.1.2"
@@ -560,6 +614,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@vitest/coverage-v8@npm:^4.1.6":
+  version: 4.1.7
+  resolution: "@vitest/coverage-v8@npm:4.1.7"
+  dependencies:
+    "@bcoe/v8-coverage": "npm:^1.0.2"
+    "@vitest/utils": "npm:4.1.7"
+    ast-v8-to-istanbul: "npm:^1.0.0"
+    istanbul-lib-coverage: "npm:^3.2.2"
+    istanbul-lib-report: "npm:^3.0.1"
+    istanbul-reports: "npm:^3.2.0"
+    magicast: "npm:^0.5.2"
+    obug: "npm:^2.1.1"
+    std-env: "npm:^4.0.0-rc.1"
+    tinyrainbow: "npm:^3.1.0"
+  peerDependencies:
+    "@vitest/browser": 4.1.7
+    vitest: 4.1.7
+  peerDependenciesMeta:
+    "@vitest/browser":
+      optional: true
+  checksum: 10/ebfe69453f635946449303356fd7b41d6db5ef2449c7e50fe4789930d4b386685c5d8e3587c0fb8ce4010463371dad195471dda2efad673ee26b58d6ff5b7fbe
+  languageName: node
+  linkType: hard
+
 "@vitest/expect@npm:4.1.2":
   version: 4.1.2
   resolution: "@vitest/expect@npm:4.1.2"
@@ -602,6 +680,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@vitest/pretty-format@npm:4.1.7":
+  version: 4.1.7
+  resolution: "@vitest/pretty-format@npm:4.1.7"
+  dependencies:
+    tinyrainbow: "npm:^3.1.0"
+  checksum: 10/79c86c39173577250955744c3444d8c0c9304c95c7d351b91a916229252c3733a0e969741a8f3441a5c4777b5a4371707ecb747ea4bfd2c07e72ddf1ef621293
+  languageName: node
+  linkType: hard
+
 "@vitest/runner@npm:4.1.2":
   version: 4.1.2
   resolution: "@vitest/runner@npm:4.1.2"
@@ -639,6 +726,17 @@ __metadata:
     convert-source-map: "npm:^2.0.0"
     tinyrainbow: "npm:^3.1.0"
   checksum: 10/854decf0eb639758d012c9aa53c3d7aed547e37c05ece6704d5f53035be77f704a24973ed95089926e1768c0b55902d42c4438660788e7a0f0e80d0fda1c713b
+  languageName: node
+  linkType: hard
+
+"@vitest/utils@npm:4.1.7":
+  version: 4.1.7
+  resolution: "@vitest/utils@npm:4.1.7"
+  dependencies:
+    "@vitest/pretty-format": "npm:4.1.7"
+    convert-source-map: "npm:^2.0.0"
+    tinyrainbow: "npm:^3.1.0"
+  checksum: 10/9cc729618dade24de3ad6862c288c22e9daac3fda5cae0abc9b6ce87035cc8e7efa2b66c3c124ae08beef462b36761b062e792bbc619798b832a7ea9382ed12a
   languageName: node
   linkType: hard
 
@@ -708,6 +806,17 @@ __metadata:
   version: 4.1.3
   resolution: "arg@npm:4.1.3"
   checksum: 10/969b491082f20cad166649fa4d2073ea9e974a4e5ac36247ca23d2e5a8b3cb12d60e9ff70a8acfe26d76566c71fd351ee5e6a9a6595157eb36f92b1fd64e1599
+  languageName: node
+  linkType: hard
+
+"ast-v8-to-istanbul@npm:^1.0.0":
+  version: 1.0.2
+  resolution: "ast-v8-to-istanbul@npm:1.0.2"
+  dependencies:
+    "@jridgewell/trace-mapping": "npm:^0.3.31"
+    estree-walker: "npm:^3.0.3"
+    js-tokens: "npm:^10.0.0"
+  checksum: 10/640494e7170d3b36079da24c35f132bbac51c7e63289d418d3054a085dc84e3e5f7c3e56136647f302a3d48c64acf8f4230d7d13acb45ff9ac5f50d398512f8c
   languageName: node
   linkType: hard
 
@@ -925,6 +1034,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fast-check@npm:^3.23.2":
+  version: 3.23.2
+  resolution: "fast-check@npm:3.23.2"
+  dependencies:
+    pure-rand: "npm:^6.1.0"
+  checksum: 10/dab344146b778e8bc2973366ea55528d1b58d3e3037270262b877c54241e800c4d744957722c24705c787020d702aece11e57c9e3dbd5ea19c3e10926bf1f3fe
+  languageName: node
+  linkType: hard
+
 "fast-check@npm:^4.6.0":
   version: 4.6.0
   resolution: "fast-check@npm:4.6.0"
@@ -1014,6 +1132,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"has-flag@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "has-flag@npm:4.0.0"
+  checksum: 10/261a1357037ead75e338156b1f9452c016a37dcd3283a972a30d9e4a87441ba372c8b81f818cd0fbcd9c0354b4ae7e18b9e1afa1971164aef6d18c2b6095a8ad
+  languageName: node
+  linkType: hard
+
+"html-escaper@npm:^2.0.0":
+  version: 2.0.2
+  resolution: "html-escaper@npm:2.0.2"
+  checksum: 10/034d74029dcca544a34fb6135e98d427acd73019796ffc17383eaa3ec2fe1c0471dcbbc8f8ed39e46e86d43ccd753a160631615e4048285e313569609b66d5b7
+  languageName: node
+  linkType: hard
+
 "http-cache-semantics@npm:^4.1.1":
   version: 4.2.0
   resolution: "http-cache-semantics@npm:4.2.0"
@@ -1099,6 +1231,34 @@ __metadata:
   languageName: node
   linkType: hard
 
+"istanbul-lib-coverage@npm:^3.0.0, istanbul-lib-coverage@npm:^3.2.2":
+  version: 3.2.2
+  resolution: "istanbul-lib-coverage@npm:3.2.2"
+  checksum: 10/40bbdd1e937dfd8c830fa286d0f665e81b7a78bdabcd4565f6d5667c99828bda3db7fb7ac6b96a3e2e8a2461ddbc5452d9f8bc7d00cb00075fa6a3e99f5b6a81
+  languageName: node
+  linkType: hard
+
+"istanbul-lib-report@npm:^3.0.0, istanbul-lib-report@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "istanbul-lib-report@npm:3.0.1"
+  dependencies:
+    istanbul-lib-coverage: "npm:^3.0.0"
+    make-dir: "npm:^4.0.0"
+    supports-color: "npm:^7.1.0"
+  checksum: 10/86a83421ca1cf2109a9f6d193c06c31ef04a45e72a74579b11060b1e7bb9b6337a4e6f04abfb8857e2d569c271273c65e855ee429376a0d7c91ad91db42accd1
+  languageName: node
+  linkType: hard
+
+"istanbul-reports@npm:^3.2.0":
+  version: 3.2.0
+  resolution: "istanbul-reports@npm:3.2.0"
+  dependencies:
+    html-escaper: "npm:^2.0.0"
+    istanbul-lib-report: "npm:^3.0.0"
+  checksum: 10/6773a1d5c7d47eeec75b317144fe2a3b1da84a44b6282bebdc856e09667865e58c9b025b75b3d87f5bc62939126cbba4c871ee84254537d934ba5da5d4c4ec4e
+  languageName: node
+  linkType: hard
+
 "jackspeak@npm:^3.1.2":
   version: 3.4.3
   resolution: "jackspeak@npm:3.4.3"
@@ -1109,6 +1269,13 @@ __metadata:
     "@pkgjs/parseargs":
       optional: true
   checksum: 10/96f8786eaab98e4bf5b2a5d6d9588ea46c4d06bbc4f2eb861fdd7b6b182b16f71d8a70e79820f335d52653b16d4843b29dd9cdcf38ae80406756db9199497cf3
+  languageName: node
+  linkType: hard
+
+"js-tokens@npm:^10.0.0":
+  version: 10.0.0
+  resolution: "js-tokens@npm:10.0.0"
+  checksum: 10/88f536ec89f076fc230d29df255b3c55531237669d746d1868fca716b1e3f5f2e4abf8e5b8701903216e3f00d2dc3918d078b35da87772d433ab6a513c3bf76d
   languageName: node
   linkType: hard
 
@@ -1255,6 +1422,26 @@ __metadata:
   dependencies:
     "@jridgewell/sourcemap-codec": "npm:^1.5.5"
   checksum: 10/57d5691f41ed40d962d8bd300148114f53db67fadbff336207db10a99f2bdf4a1be9cac3a68ee85dba575912ee1d4402e4396408196ec2d3afd043b076156221
+  languageName: node
+  linkType: hard
+
+"magicast@npm:^0.5.2":
+  version: 0.5.3
+  resolution: "magicast@npm:0.5.3"
+  dependencies:
+    "@babel/parser": "npm:^7.29.3"
+    "@babel/types": "npm:^7.29.0"
+    source-map-js: "npm:^1.2.1"
+  checksum: 10/436ad518726b691cf9ac1a14ab14705784f28075892a092b06e8b17ac7303fe57e8a2789989c68b560653a909a8df49d1582bb73f9bdad4bcbab892201251049
+  languageName: node
+  linkType: hard
+
+"make-dir@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "make-dir@npm:4.0.0"
+  dependencies:
+    semver: "npm:^7.5.3"
+  checksum: 10/bf0731a2dd3aab4db6f3de1585cea0b746bb73eb5a02e3d8d72757e376e64e6ada190b1eddcde5b2f24a81b688a9897efd5018737d05e02e2a671dda9cff8a8a
   languageName: node
   linkType: hard
 
@@ -1572,6 +1759,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pure-rand@npm:^6.1.0":
+  version: 6.1.0
+  resolution: "pure-rand@npm:6.1.0"
+  checksum: 10/256aa4bcaf9297256f552914e03cbdb0039c8fe1db11fa1e6d3f80790e16e563eb0a859a1e61082a95e224fc0c608661839439f8ecc6a3db4e48d46d99216ee4
+  languageName: node
+  linkType: hard
+
 "pure-rand@npm:^8.0.0":
   version: 8.1.0
   resolution: "pure-rand@npm:8.1.0"
@@ -1667,6 +1861,15 @@ __metadata:
   bin:
     semver: bin/semver.js
   checksum: 10/7a24cffcaa13f53c09ce55e05efe25cd41328730b2308678624f8b9f5fc3093fc4d189f47950f0b811ff8f3c3039c24a2c36717ba7961615c682045bf03e1dda
+  languageName: node
+  linkType: hard
+
+"semver@npm:^7.5.3":
+  version: 7.8.1
+  resolution: "semver@npm:7.8.1"
+  bin:
+    semver: bin/semver.js
+  checksum: 10/3244f6c4cb3f8126fea0426d353829ed4967e41e1f4696337c6fdcad87426466fe2badaf49d7dc85849acfc496ea0599432a4aecc33802d2d774e723acfa30e6
   languageName: node
   linkType: hard
 
@@ -1812,6 +2015,15 @@ __metadata:
   dependencies:
     ansi-regex: "npm:^6.0.1"
   checksum: 10/db0e3f9654e519c8a33c50fc9304d07df5649388e7da06d3aabf66d29e5ad65d5e6315d8519d409c15b32fa82c1df7e11ed6f8cd50b0e4404463f0c9d77c8d0b
+  languageName: node
+  linkType: hard
+
+"supports-color@npm:^7.1.0":
+  version: 7.2.0
+  resolution: "supports-color@npm:7.2.0"
+  dependencies:
+    has-flag: "npm:^4.0.0"
+  checksum: 10/c8bb7afd564e3b26b50ca6ee47572c217526a1389fe018d00345856d4a9b08ffbd61fadaf283a87368d94c3dcdb8f5ffe2650a5a65863e21ad2730ca0f05210a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Types of changes

What types of changes does your code introduce to OpenZeppelin Midnight Contracts?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

Closes #471
Closes #476
Closes #477
Closes #478
Closes #479
Closes #480
Closes #481
Closes #474

Merges the self-contained multisig contract suite from `post-release` into `main`. The suite was developed and reviewed on `post-release` across #378, #424, and #526; this PR brings it forward onto the current `main`.

### What lands

| Module / preset | Closes |
| --- | --- |
| `Signer` / `SignerManager` — configurable M-of-N signer registry | #471 |
| `ProposalManager` | #476 |
| `ShieldedTreasury` (stateful) | #477 |
| `ShieldedTreasuryStateless` | #478 |
| `UnshieldedTreasury` | #479 |
| `ShieldedMultiSig` preset (ledger-backed) | #480 |
| `ShieldedMultiSigV2` preset (stateless vault) | #481 |
| `Forwarder` / `ForwarderPrivate` + per-recipient presets | #474 |

Plus supporting `Utils` additions (`selfAsRecipient`, `isContractAddress`, `UINT128_MAX`) and their tests.

### Explicitly out of scope (left open)

- #482 — `ShieldedMultiSigToken` preset is not present on `post-release`; not delivered here.
- #475 / #470 — signature verification is still stubbed pending ECDSA + Keccak primitives. The umbrella (#470) stays open until those land.
- #565 — remaining Forwarder review feedback from #526 is tracked separately.

### Merge mechanics

The multisig modules import only other multisig modules plus the Compact standard library, so they are unaffected by `main`'s per-module `Initializable` split (#562), the `pk`→`sk` refactor, and the witness relocation. Conflicts were limited to shared infra files and resolved in favour of `main`'s conventions while preserving the multisig additions:

- `.gitignore`, `CHANGELOG.md`: keep both sides' entries.
- `contracts/package.json`: keep `main`'s hierarchical build + `SKIP_ZK` test scripts and modern dependency versions; re-add `fast-check`.
- `contracts/vitest.config.ts`: keep `main`'s per-`.ts` 95% coverage gate.
- `contracts/src/utils/test/utils.test.ts`: keep both `describe` blocks.
- `yarn.lock`: regenerated via `yarn install`.

All 21 multisig `.compact` modules compile cleanly.

**Supersedes #577**, which is now stale/conflicting against the current `main`.

## PR Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md#your-first-code-contribution)
- [x] I have added tests that prove my fix is effective or that my feature works. See [GUIDELINES.md#testing](../GUIDELINES.md#testing) for more information.
- [x] I have added documentation for new methods or changes to existing method behavior. See [GUIDELINES.md#documentation](../GUIDELINES.md#documentation) for more information.
- [ ] CI Workflows Are Passing

#### Further comments

This is a forward-merge of already-reviewed work, so the diff is dominated by the new `multisig/` tree (new files, no conflicts) and the witnesses currently sit under `src/multisig/witnesses/` rather than `main`'s newer `test/witnesses/` layout (#528). Aligning that layout can be a follow-up alongside #565.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a comprehensive multisig contract suite enabling configurable M-of-N signer governance.
  * Introduced shielded and unshielded treasury modules for managing token deposits and transfers.
  * Added proposal management system with approval tracking and lifecycle controls.
  * Introduced forwarder modules for flexible fund routing with multiple deployment presets.
  * Note: Signature verification is currently stubbed pending underlying cryptographic primitives.

* **Chores**
  * Updated build system and dependencies to support multisig contract compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->