### PR TITLE
build: upgrade Compact toolchain to 0.31.0 and Midnight packages

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,7 +3,7 @@ FROM mcr.microsoft.com/devcontainers/javascript-node
 
 # Midnight binaries and tools download URLs
 # Source: https://docs.midnight.network/relnotes/overview
-ARG COMPACT_TOOLCHAIN_VERSION=0.29.0
+ARG COMPACT_TOOLCHAIN_VERSION=0.31.0
 ARG COMPACT_VSCODE_VERSION=0.2.13
 ARG COMPACT_VSCODE_URL="https://raw.githubusercontent.com/midnight-ntwrk/releases/gh-pages/artifacts/vscode-extension/compact-${COMPACT_VSCODE_VERSION}/compact-${COMPACT_VSCODE_VERSION}.vsix"
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,5 +3,5 @@
   "build": {
     "dockerfile": "Dockerfile"
   },
-  "postCreateCommand": "code --install-extension /tmp/compact.vsix && compact update 0.29.0"
+  "postCreateCommand": "code --install-extension /tmp/compact.vsix && compact update 0.31.0"
 }

--- a/.github/ISSUE_TEMPLATE/01_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/01_bug_report.yml
@@ -93,7 +93,9 @@ body:
       label: Version
       description: What version of Compact are you running?
       options:
-        - 0.29.0 (Default)
+        - 0.31.0 (Default)
+        - 0.30.0
+        - 0.29.0
       default: 0
     validations:
       required: true

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -36,4 +36,4 @@ runs:
       if: ${{ inputs.skip-compact != 'true' }}
       uses: midnightntwrk/setup-compact-action@836895c8fffbbea6bd986af2b17e8941ff29d1f8 # v1
       with:
-        compact-version: "0.29.0"
+        compact-version: "0.31.0"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Compact Compiler
         uses: midnightntwrk/setup-compact-action@836895c8fffbbea6bd986af2b17e8941ff29d1f8 # v1
         with:
-          compact-version: "0.29.0"
+          compact-version: "0.31.0"
 
       - name: Build contracts
         run: yarn build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Multisig contract suite under `contracts/src/multisig/`: configurable M-of-N `Signer` / `SignerManager` registry, `ProposalManager`, stateful `ShieldedTreasury` and `ShieldedTreasuryStateless`, `UnshieldedTreasury`, `Forwarder` + `ForwarderPrivate` modules with per-recipient presets, and the `ShieldedMultiSig` / `ShieldedMultiSigV2` presets. Signature verification is stubbed pending ECDSA + Keccak primitives (#475). (#378, #424, #526)
 
+### Changed
+
+- Upgrade the Compact toolchain and Midnight dependencies: compiler `0.29.0` → `0.31.0`, `@midnight-ntwrk/compact-runtime` `0.14.0` → `0.16.0`, `@midnight-ntwrk/ledger-v7` `7.0.3` → `@midnight-ntwrk/ledger-v8` `8.1.0`, and `@openzeppelin/compact-simulator` `^0.0.1` → `^0.1.0`.
+
 ## 0.2.0 (2026-06-12)
 
 ### Changed

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -46,7 +46,7 @@
     "@openzeppelin/compact-cli": "^0.0.2"
   },
   "devDependencies": {
-    "@openzeppelin/compact-simulator": "^0.0.1",
+    "@openzeppelin/compact-simulator": "^0.1.0",
     "@tsconfig/node24": "^24.0.4",
     "@types/node": "25.9.3",
     "@vitest/coverage-v8": "^4.1.8",

--- a/contracts/src/archive/test/utils/address.ts
+++ b/contracts/src/archive/test/utils/address.ts
@@ -2,7 +2,7 @@ import {
   convertFieldToBytes,
   encodeCoinPublicKey,
 } from '@midnight-ntwrk/compact-runtime';
-import { encodeContractAddress } from '@midnight-ntwrk/ledger-v7';
+import { encodeContractAddress } from '@midnight-ntwrk/ledger-v8';
 import type * as Compact from '../../../../artifacts/MockShieldedToken/contract/index.js';
 
 const PREFIX_ADDRESS = '0200';

--- a/contracts/test-utils/address.ts
+++ b/contracts/test-utils/address.ts
@@ -4,7 +4,7 @@ import {
   encodeCoinPublicKey,
   isContractAddress,
 } from '@midnight-ntwrk/compact-runtime';
-import { encodeContractAddress } from '@midnight-ntwrk/ledger-v7';
+import { encodeContractAddress } from '@midnight-ntwrk/ledger-v8';
 
 type ZswapCoinPublicKey = { bytes: Uint8Array };
 

--- a/package.json
+++ b/package.json
@@ -27,11 +27,11 @@
     "glob": "~10.5.0"
   },
   "dependencies": {
-    "@midnight-ntwrk/compact-runtime": "0.14.0"
+    "@midnight-ntwrk/compact-runtime": "0.16.0"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.5.0",
-    "@midnight-ntwrk/ledger-v7": "7.0.3",
+    "@midnight-ntwrk/ledger-v8": "8.1.0",
     "@midnight-ntwrk/zswap": "^4.0.0",
     "@types/node": "25.9.3",
     "ts-node": "^10.9.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -232,28 +232,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@midnight-ntwrk/compact-runtime@npm:0.14.0":
-  version: 0.14.0
-  resolution: "@midnight-ntwrk/compact-runtime@npm:0.14.0"
+"@midnight-ntwrk/compact-runtime@npm:0.16.0":
+  version: 0.16.0
+  resolution: "@midnight-ntwrk/compact-runtime@npm:0.16.0"
   dependencies:
-    "@midnight-ntwrk/onchain-runtime-v2": "npm:^2.0.0"
+    "@midnight-ntwrk/onchain-runtime-v3": "npm:^3.0.0"
     "@types/object-inspect": "npm:^1.8.1"
     object-inspect: "npm:^1.12.3"
-  checksum: 10/bba44d09770b172b7a5ba193f59d2ec57ca0dff2e3fd538326942e102e8cbe0b0cc1cb736e1f469afc74258517e7d25fc4dfa7f89a299aed900efc89f1eed3a7
+  checksum: 10/ef0c68d53bba6a04f336094c82c26b781082d7ce4ee09f0539009fb108776b36ea24b9a774292d9bbf9722b8a78d47254b5f80a613d4010a7f7d108514243023
   languageName: node
   linkType: hard
 
-"@midnight-ntwrk/ledger-v7@npm:7.0.3, @midnight-ntwrk/ledger-v7@npm:^7.0.0":
-  version: 7.0.3
-  resolution: "@midnight-ntwrk/ledger-v7@npm:7.0.3"
-  checksum: 10/49f59fa611996a1514f3143828e240cff7d34db7cdaf76b2131b346687139b81dc9ecd7870b29103962cf3c296cd0d11aebf1cc7b2bf0f6a3bf9263d3af19815
+"@midnight-ntwrk/ledger-v8@npm:8.1.0":
+  version: 8.1.0
+  resolution: "@midnight-ntwrk/ledger-v8@npm:8.1.0"
+  checksum: 10/10d56076b0333a502f157c816f8cfebefc8d50221cb20c6db15abcbf2d0092bdaf7e9bc1bd19a6d9f51455547c713c916cb16d4a7d18e83cba0e172ad6e2a507
   languageName: node
   linkType: hard
 
-"@midnight-ntwrk/onchain-runtime-v2@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "@midnight-ntwrk/onchain-runtime-v2@npm:2.0.0"
-  checksum: 10/71b2b5e2270ce36fbdb63c0bd531f09f2de9151b286b6c7389966279750080b300893aef973621e438a934f9274277181cdf9bdc1350abc0e244fa892a145b19
+"@midnight-ntwrk/onchain-runtime-v3@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@midnight-ntwrk/onchain-runtime-v3@npm:3.0.0"
+  checksum: 10/873aeb9e631c3678373c62b5aef847de454de94427028fb3d3f28bfdc8b2c02a3c770bd79d9bfef183eb9db6fb8c23e6826636f2e512ffd6eacbcf7cc0651c5d
   languageName: node
   linkType: hard
 
@@ -328,7 +328,7 @@ __metadata:
   resolution: "@openzeppelin/compact-contracts@workspace:contracts"
   dependencies:
     "@openzeppelin/compact-cli": "npm:^0.0.2"
-    "@openzeppelin/compact-simulator": "npm:^0.0.1"
+    "@openzeppelin/compact-simulator": "npm:^0.1.0"
     "@tsconfig/node24": "npm:^24.0.4"
     "@types/node": "npm:25.9.3"
     "@vitest/coverage-v8": "npm:^4.1.8"
@@ -339,13 +339,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@openzeppelin/compact-simulator@npm:^0.0.1":
-  version: 0.0.1
-  resolution: "@openzeppelin/compact-simulator@npm:0.0.1"
+"@openzeppelin/compact-simulator@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "@openzeppelin/compact-simulator@npm:0.1.0"
   dependencies:
-    "@midnight-ntwrk/compact-runtime": "npm:0.14.0"
-    "@midnight-ntwrk/ledger-v7": "npm:^7.0.0"
-  checksum: 10/f1f60957aa81389bcea8ab33f6049f716348538be0e601c12085b8314fb204126b88448589d028cb3c46174ea24c32180ccc9fbaaeb089dd85afd794860b74d6
+    "@midnight-ntwrk/compact-runtime": "npm:0.16.0"
+    "@midnight-ntwrk/ledger-v8": "npm:8.1.0"
+  checksum: 10/432bb2b4c8440e30046198471bb34cf08efec697d10a8f3cc0ce4ffe78e339eb7ea2c405e3114dbdae28c63e07936cba039105277f1ac17d521536b55aa0c7d0
   languageName: node
   linkType: hard
 
@@ -1611,8 +1611,8 @@ __metadata:
   resolution: "openzeppelin-compact@workspace:."
   dependencies:
     "@biomejs/biome": "npm:^2.5.0"
-    "@midnight-ntwrk/compact-runtime": "npm:0.14.0"
-    "@midnight-ntwrk/ledger-v7": "npm:7.0.3"
+    "@midnight-ntwrk/compact-runtime": "npm:0.16.0"
+    "@midnight-ntwrk/ledger-v8": "npm:8.1.0"
     "@midnight-ntwrk/zswap": "npm:^4.0.0"
     "@types/node": "npm:25.9.3"
     ts-node: "npm:^10.9.2"


### PR DESCRIPTION
## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

fixes https://github.com/OpenZeppelin/compact-contracts/issues/400 — deliberate toolchain/dependency upgrade for the `0.3.0` cycle.

Upgrades the Compact toolchain and all Midnight packages to their current versions:

| Package                           | From     | To                                  |
| --------------------------------- | -------- | ----------------------------------- |
| Compact compiler                  | `0.29.0` | `0.31.0`                            |
| `@midnight-ntwrk/compact-runtime` | `0.14.0` | `0.16.0`                            |
| `@midnight-ntwrk/ledger-v7`       | `7.0.3`  | `@midnight-ntwrk/ledger-v8` `8.1.0` |
| `@openzeppelin/compact-simulator` | `^0.0.1` | `^0.1.0`                            |

- Compiler pin updated in the devcontainer (`Dockerfile`, `devcontainer.json`), the `setup` composite action, the `release` workflow, and the bug-report template default.
- `ledger-v7` → `ledger-v8` is a package rename; the two `encodeContractAddress` imports (`contracts/test-utils/address.ts`, `contracts/src/archive/test/utils/address.ts`) were updated.
- `@midnight-ntwrk/zswap` (`^4.0.0`) and `@openzeppelin/compact-cli` (`^0.0.2`) are already at their latest.
- `pragma language_version >= 0.21.0` is unchanged — `0.31.0` accepts it, so no per-contract edits were needed.

### Validation

- All 41 contracts compile on `0.31.0`.
- `tsc --noEmit` is clean against `compact-runtime@0.16.0` / `ledger-v8@8.1.0`.
- Full vitest suite passes: **1156 tests across 27 files**.

### Dependency on [#594](https://github.com/OpenZeppelin/compact-contracts/issues/594)

Based on `post-release`. Until [#594](https://github.com/OpenZeppelin/compact-contracts/issues/594) (`post-release → main`) merges, the diff against `main` shows the multisig suite **plus** this upgrade; once [#594](https://github.com/OpenZeppelin/compact-contracts/issues/594) lands it collapses to the toolchain upgrade only (rebase onto `main`). **Merge **[**#594**](https://github.com/OpenZeppelin/compact-contracts/issues/594)** first.**

> Note: v0.1.0 / v0.2.0 pinned the audited toolchain (`0.29.0` / `0.14.0` / `ledger-v7`). This PR intentionally moves the `0.3.0` line to the current toolchain; released contracts will run on the new toolchain pending any re-audit.

## PR Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md#your-first-code-contribution)
- [ ] I have added tests that prove my fix is effective or that my feature works. — N/A: no behavior change; the existing suite (1156 tests) passes on the new toolchain.
- [x] I have added documentation for new methods or changes to existing method behavior. — CHANGELOG updated.
- [ ] CI Workflows Are Passing — pending first run.

#### Further comments

Verified end-to-end locally (compile + typecheck + full suite) before opening. The `ledger-v7 → ledger-v8` and `compact-runtime 0.14 → 0.16` bumps are API-compatible for the surface this repo uses (`encodeContractAddress`, `WitnessContext`, `MerkleTreePath`, `CoinInfo`/`TokenType`, `sampleContractAddress`), so no code changes beyond the two import paths were required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added multisig contract suite with configurable signer management, proposal handling, treasury operations, and customizable forwarder modules with per-recipient presets.
  * Note: signature verification is currently stubbed pending cryptographic enhancements.

* **Chores**
  * Upgraded Compact compiler to version 0.31.0 and supporting toolchain dependencies for improved compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
