### PR TITLE
build: raise language_version pragma to 0.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Upgrade the Compact toolchain and Midnight dependencies: compiler `0.29.0` → `0.31.0`, `@midnight-ntwrk/compact-runtime` `0.14.0` → `0.16.0`, `@midnight-ntwrk/ledger-v7` `7.0.3` → `@midnight-ntwrk/ledger-v8` `8.1.0`, and `@openzeppelin/compact-simulator` `^0.0.1` → `^0.1.0`.
+- Upgrade the Compact toolchain and Midnight dependencies: compiler `0.29.0` → `0.31.0`, `@midnight-ntwrk/compact-runtime` `0.14.0` → `0.16.0`, `@midnight-ntwrk/ledger-v7` `7.0.3` → `@midnight-ntwrk/ledger-v8` `8.1.0`, and `@openzeppelin/compact-simulator` `^0.0.1` → `^0.1.0`. Contract `pragma language_version` raised `>= 0.21.0` → `>= 0.23.0` (the language version shipped with compiler 0.31.0).
 
 ## 0.2.0 (2026-06-12)
 

--- a/contracts/src/access/AccessControl.compact
+++ b/contracts/src/access/AccessControl.compact
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Compact Contracts v0.2.0 (access/AccessControl.compact)
 
-pragma language_version >= 0.21.0;
+pragma language_version >= 0.23.0;
 
 /**
  * @module AccessControl

--- a/contracts/src/access/Ownable.compact
+++ b/contracts/src/access/Ownable.compact
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Compact Contracts v0.2.0 (access/Ownable.compact)
 
-pragma language_version >= 0.21.0;
+pragma language_version >= 0.23.0;
 
 /**
  * @module Ownable

--- a/contracts/src/access/ShieldedAccessControl.compact
+++ b/contracts/src/access/ShieldedAccessControl.compact
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Compact Contracts v0.2.0 (access/ShieldedAccessControl.compact)
 
-pragma language_version >= 0.21.0;
+pragma language_version >= 0.23.0;
 
 /**
  * @module ShieldedAccessControl

--- a/contracts/src/access/ZOwnablePK.compact
+++ b/contracts/src/access/ZOwnablePK.compact
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Compact Contracts v0.2.0 (access/ZOwnablePK.compact)
 
-pragma language_version >= 0.21.0;
+pragma language_version >= 0.23.0;
 
 /**
  * @module ZOwnablePK

--- a/contracts/src/access/test/mocks/MockAccessControl.compact
+++ b/contracts/src/access/test/mocks/MockAccessControl.compact
@@ -5,7 +5,7 @@
 // corresponding production contract relies on. DO NOT deploy or use this
 // contract in any production application.
 
-pragma language_version >= 0.21.0;
+pragma language_version >= 0.23.0;
 
 import CompactStandardLibrary;
 

--- a/contracts/src/access/test/mocks/MockOwnable.compact
+++ b/contracts/src/access/test/mocks/MockOwnable.compact
@@ -5,7 +5,7 @@
 // corresponding production contract relies on. DO NOT deploy or use this
 // contract in any production application.
 
-pragma language_version >= 0.21.0;
+pragma language_version >= 0.23.0;
 
 import CompactStandardLibrary;
 

--- a/contracts/src/access/test/mocks/MockShieldedAccessControl.compact
+++ b/contracts/src/access/test/mocks/MockShieldedAccessControl.compact
@@ -5,7 +5,7 @@
 // corresponding production contract relies on. DO NOT deploy or use this
 // contract in any production application.
 
-pragma language_version >= 0.21.0;
+pragma language_version >= 0.23.0;
 
 import CompactStandardLibrary;
 

--- a/contracts/src/access/test/mocks/MockZOwnablePK.compact
+++ b/contracts/src/access/test/mocks/MockZOwnablePK.compact
@@ -5,7 +5,7 @@
 // corresponding production contract relies on. DO NOT deploy or use this
 // contract in any production application.
 
-pragma language_version >= 0.21.0;
+pragma language_version >= 0.23.0;
 
 import CompactStandardLibrary;
 import "../../ZOwnablePK" prefix ZOwnablePK_;

--- a/contracts/src/archive/ShieldedToken.compact
+++ b/contracts/src/archive/ShieldedToken.compact
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Compact Contracts v0.2.0 (archive/ShieldedToken.compact)
 
-pragma language_version >= 0.21.0;
+pragma language_version >= 0.23.0;
 
 /**
  * @module ShieldedToken (archived until further notice, DO NOT USE IN PRODUCTION)

--- a/contracts/src/archive/test/mocks/MockShieldedToken.compact
+++ b/contracts/src/archive/test/mocks/MockShieldedToken.compact
@@ -5,7 +5,7 @@
 // corresponding production contract relies on. DO NOT deploy or use this
 // contract in any production application.
 
-pragma language_version >= 0.21.0;
+pragma language_version >= 0.23.0;
 
 import CompactStandardLibrary;
 import "../../ShieldedToken" prefix ShieldedToken_;

--- a/contracts/src/multisig/Forwarder.compact
+++ b/contracts/src/multisig/Forwarder.compact
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Compact Contracts v0.0.1-alpha.1 (multisig/Forwarder.compact)
 
-pragma language_version >= 0.21.0;
+pragma language_version >= 0.23.0;
 
 /**
  * @module Forwarder

--- a/contracts/src/multisig/ForwarderPrivate.compact
+++ b/contracts/src/multisig/ForwarderPrivate.compact
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Compact Contracts v0.0.1-alpha.1 (multisig/ForwarderPrivate.compact)
 
-pragma language_version >= 0.21.0;
+pragma language_version >= 0.23.0;
 
 /**
  * @module ForwarderPrivate

--- a/contracts/src/multisig/ProposalManager.compact
+++ b/contracts/src/multisig/ProposalManager.compact
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Compact Contracts v0.0.1-alpha.1 (multisig/ProposalManager.compact)
 
-pragma language_version >= 0.21.0;
+pragma language_version >= 0.23.0;
 
 /**
  * @module ProposalManager

--- a/contracts/src/multisig/ShieldedTreasury.compact
+++ b/contracts/src/multisig/ShieldedTreasury.compact
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Compact Contracts v0.0.1-alpha.1 (multisig/ShieldedTreasury.compact)
 
-pragma language_version >= 0.21.0;
+pragma language_version >= 0.23.0;
 
 /**
  * @module ShieldedTreasury

--- a/contracts/src/multisig/ShieldedTreasuryStateless.compact
+++ b/contracts/src/multisig/ShieldedTreasuryStateless.compact
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Compact Contracts v0.0.1-alpha.1 (multisig/ShieldedTreasuryStateless.compact)
 
-pragma language_version >= 0.21.0;
+pragma language_version >= 0.23.0;
 
 /**
  * @module ShieldedTreasury

--- a/contracts/src/multisig/Signer.compact
+++ b/contracts/src/multisig/Signer.compact
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Compact Contracts v0.0.1-alpha.1 (multisig/Signer.compact)
 
-pragma language_version >= 0.21.0;
+pragma language_version >= 0.23.0;
 
 /**
  * @module Signer<T>

--- a/contracts/src/multisig/SignerManager.compact
+++ b/contracts/src/multisig/SignerManager.compact
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Compact Contracts v0.0.1-alpha.1 (multisig/SignerManager.compact)
 
-pragma language_version >= 0.21.0;
+pragma language_version >= 0.23.0;
 
 /**
  * @module SignerManager<T>

--- a/contracts/src/multisig/UnshieldedTreasury.compact
+++ b/contracts/src/multisig/UnshieldedTreasury.compact
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Compact Contracts v0.0.1-alpha.1 (multisig/UnshieldedTreasury.compact)
 
-pragma language_version >= 0.21.0;
+pragma language_version >= 0.23.0;
 
 /**
  * @module UnshieldedTreasury

--- a/contracts/src/multisig/presets/ShieldedMultiSig.compact
+++ b/contracts/src/multisig/presets/ShieldedMultiSig.compact
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Compact Contracts v0.0.1-alpha.1 (multisig/presets/ShieldedMultiSig.compact)
 
-pragma language_version >= 0.21.0;
+pragma language_version >= 0.23.0;
 
 /**
  * @module ShieldedMultiSig

--- a/contracts/src/multisig/presets/ShieldedMultiSigV2.compact
+++ b/contracts/src/multisig/presets/ShieldedMultiSigV2.compact
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Compact Contracts v0.0.1-alpha.1 (multisig/presets/ShieldedMultiSigV2.compact)
 
-pragma language_version >= 0.21.0;
+pragma language_version >= 0.23.0;
 
 /**
  * @title ShieldedMultisigV2

--- a/contracts/src/multisig/presets/forwarder/ForwarderPrivate.compact
+++ b/contracts/src/multisig/presets/forwarder/ForwarderPrivate.compact
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Compact Contracts v0.0.1-alpha.1 (multisig/presets/forwarder/ForwarderPrivate.compact)
 
-pragma language_version >= 0.21.0;
+pragma language_version >= 0.23.0;
 
 /**
  * @title ForwarderPrivate

--- a/contracts/src/multisig/presets/forwarder/ForwarderShielded.compact
+++ b/contracts/src/multisig/presets/forwarder/ForwarderShielded.compact
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Compact Contracts v0.0.1-alpha.1 (multisig/presets/forwarder/ForwarderShielded.compact)
 
-pragma language_version >= 0.21.0;
+pragma language_version >= 0.23.0;
 
 /**
  * @title ForwarderShielded

--- a/contracts/src/multisig/presets/forwarder/ForwarderUnshielded.compact
+++ b/contracts/src/multisig/presets/forwarder/ForwarderUnshielded.compact
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Compact Contracts v0.0.1-alpha.1 (multisig/presets/forwarder/ForwarderUnshielded.compact)
 
-pragma language_version >= 0.21.0;
+pragma language_version >= 0.23.0;
 
 /**
  * @title ForwarderUnshielded

--- a/contracts/src/multisig/test/mocks/MockForwarder.compact
+++ b/contracts/src/multisig/test/mocks/MockForwarder.compact
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Compact Contracts v0.0.1-alpha.1 (multisig/test/mocks/MockForwarder.compact)
 
-pragma language_version >= 0.21.0;
+pragma language_version >= 0.23.0;
 
 import CompactStandardLibrary;
 import "../../Forwarder"<ZswapCoinPublicKey> prefix Forwarder_;

--- a/contracts/src/multisig/test/mocks/MockForwarderPrivate.compact
+++ b/contracts/src/multisig/test/mocks/MockForwarderPrivate.compact
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Compact Contracts v0.0.1-alpha.1 (multisig/test/mocks/MockForwarderPrivate.compact)
 
-pragma language_version >= 0.21.0;
+pragma language_version >= 0.23.0;
 
 import CompactStandardLibrary;
 import "../../ForwarderPrivate" prefix ForwarderPrivate_;

--- a/contracts/src/multisig/test/mocks/MockProposalManager.compact
+++ b/contracts/src/multisig/test/mocks/MockProposalManager.compact
@@ -1,4 +1,4 @@
-pragma language_version >= 0.21.0;
+pragma language_version >= 0.23.0;
 
 import CompactStandardLibrary;
 

--- a/contracts/src/multisig/test/mocks/MockShieldedTreasury.compact
+++ b/contracts/src/multisig/test/mocks/MockShieldedTreasury.compact
@@ -1,4 +1,4 @@
-pragma language_version >= 0.21.0;
+pragma language_version >= 0.23.0;
 
 import CompactStandardLibrary;
 

--- a/contracts/src/multisig/test/mocks/MockShieldedTreasuryStateless.compact
+++ b/contracts/src/multisig/test/mocks/MockShieldedTreasuryStateless.compact
@@ -1,4 +1,4 @@
-pragma language_version >= 0.21.0;
+pragma language_version >= 0.23.0;
 
 import CompactStandardLibrary;
 import "../../ShieldedTreasuryStateless" prefix Treasury_;

--- a/contracts/src/multisig/test/mocks/MockSigner.compact
+++ b/contracts/src/multisig/test/mocks/MockSigner.compact
@@ -1,4 +1,4 @@
-pragma language_version >= 0.21.0;
+pragma language_version >= 0.23.0;
 
 import CompactStandardLibrary;
 

--- a/contracts/src/multisig/test/mocks/MockSignerManager.compact
+++ b/contracts/src/multisig/test/mocks/MockSignerManager.compact
@@ -1,4 +1,4 @@
-pragma language_version >= 0.21.0;
+pragma language_version >= 0.23.0;
 
 import CompactStandardLibrary;
 

--- a/contracts/src/multisig/test/mocks/MockUnshieldedTreasury.compact
+++ b/contracts/src/multisig/test/mocks/MockUnshieldedTreasury.compact
@@ -1,4 +1,4 @@
-pragma language_version >= 0.21.0;
+pragma language_version >= 0.23.0;
 
 import CompactStandardLibrary;
 

--- a/contracts/src/security/Initializable.compact
+++ b/contracts/src/security/Initializable.compact
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Compact Contracts v0.2.0 (security/Initializable.compact)
 
-pragma language_version >= 0.21.0;
+pragma language_version >= 0.23.0;
 
 /**
  * @module Initializable

--- a/contracts/src/security/Pausable.compact
+++ b/contracts/src/security/Pausable.compact
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Compact Contracts v0.2.0 (security/Pausable.compact)
 
-pragma language_version >= 0.21.0;
+pragma language_version >= 0.23.0;
 
 /**
  * @module Pausable

--- a/contracts/src/security/test/mocks/MockInitializable.compact
+++ b/contracts/src/security/test/mocks/MockInitializable.compact
@@ -5,7 +5,7 @@
 // corresponding production contract relies on. DO NOT deploy or use this
 // contract in any production application.
 
-pragma language_version >= 0.21.0;
+pragma language_version >= 0.23.0;
 
 import CompactStandardLibrary;
 import "../../Initializable" prefix Initializable_;

--- a/contracts/src/security/test/mocks/MockPausable.compact
+++ b/contracts/src/security/test/mocks/MockPausable.compact
@@ -5,7 +5,7 @@
 // corresponding production contract relies on. DO NOT deploy or use this
 // contract in any production application.
 
-pragma language_version >= 0.21.0;
+pragma language_version >= 0.23.0;
 
 import CompactStandardLibrary;
 import "../../Pausable" prefix Pausable_;

--- a/contracts/src/token/FungibleToken.compact
+++ b/contracts/src/token/FungibleToken.compact
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Compact Contracts v0.2.0 (token/FungibleToken.compact)
 
-pragma language_version >= 0.21.0;
+pragma language_version >= 0.23.0;
 
 /**
  * @module FungibleToken

--- a/contracts/src/token/MultiToken.compact
+++ b/contracts/src/token/MultiToken.compact
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Compact Contracts v0.2.0 (token/MultiToken.compact)
 
-pragma language_version >= 0.21.0;
+pragma language_version >= 0.23.0;
 
 /**
  * @module MultiToken

--- a/contracts/src/token/NonFungibleToken.compact
+++ b/contracts/src/token/NonFungibleToken.compact
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Compact Contracts v0.2.0 (token/NonFungibleToken.compact)
 
-pragma language_version >= 0.21.0;
+pragma language_version >= 0.23.0;
 
 /**
  * @module NonFungibleToken

--- a/contracts/src/token/test/mocks/MockFungibleToken.compact
+++ b/contracts/src/token/test/mocks/MockFungibleToken.compact
@@ -5,7 +5,7 @@
 // corresponding production contract relies on. DO NOT deploy or use this
 // contract in any production application.
 
-pragma language_version >= 0.21.0;
+pragma language_version >= 0.23.0;
 
 import CompactStandardLibrary;
 

--- a/contracts/src/token/test/mocks/MockMultiToken.compact
+++ b/contracts/src/token/test/mocks/MockMultiToken.compact
@@ -5,7 +5,7 @@
 // corresponding production contract relies on. DO NOT deploy or use this
 // contract in any production application.
 
-pragma language_version >= 0.21.0;
+pragma language_version >= 0.23.0;
 
 import CompactStandardLibrary;
 import "../../MultiToken" prefix MultiToken_;

--- a/contracts/src/token/test/mocks/MockNonFungibleToken.compact
+++ b/contracts/src/token/test/mocks/MockNonFungibleToken.compact
@@ -5,7 +5,7 @@
 // corresponding production contract relies on. DO NOT deploy or use this
 // contract in any production application.
 
-pragma language_version >= 0.21.0;
+pragma language_version >= 0.23.0;
 
 import CompactStandardLibrary;
 

--- a/contracts/src/utils/Utils.compact
+++ b/contracts/src/utils/Utils.compact
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Compact Contracts v0.2.0 (utils/Utils.compact)
 
-pragma language_version >= 0.21.0;
+pragma language_version >= 0.23.0;
 
 /**
  * @module Utils.

--- a/contracts/src/utils/test/mocks/MockUtils.compact
+++ b/contracts/src/utils/test/mocks/MockUtils.compact
@@ -5,7 +5,7 @@
 // corresponding production contract relies on. DO NOT deploy or use this
 // contract in any production application.
 
-pragma language_version >= 0.21.0;
+pragma language_version >= 0.23.0;
 
 import CompactStandardLibrary;
 

--- a/contracts/test/integration/_mocks/ComposedTokens.compact
+++ b/contracts/test/integration/_mocks/ComposedTokens.compact
@@ -13,7 +13,7 @@
 // `initFT` / `initNFT` select which module is initialized at construction, so a
 // test can initialize one and assert the other is still uninitialized. (Both
 // initializers write `sealed` ledger fields, so they must run in the constructor.)
-pragma language_version >= 0.21.0;
+pragma language_version >= 0.23.0;
 
 import CompactStandardLibrary;
 import "../../../src/token/FungibleToken" prefix FungibleToken_;

--- a/contracts/test/integration/_mocks/SharedInitCollision.compact
+++ b/contracts/test/integration/_mocks/SharedInitCollision.compact
@@ -9,7 +9,7 @@
 // so initializing one module also marks the other initialized. The
 // `initStateIsolation` spec asserts this collision (the bug), justifying why the
 // production modules now track their init flag per-module instead.
-pragma language_version >= 0.21.0;
+pragma language_version >= 0.23.0;
 
 import CompactStandardLibrary;
 import "./sharedInit/ModuleA" prefix A_;

--- a/contracts/test/integration/_mocks/sharedInit/ModuleA.compact
+++ b/contracts/test/integration/_mocks/sharedInit/ModuleA.compact
@@ -1,7 +1,7 @@
 // TEST-ONLY. Demonstrates the compiler#270 collision: a module that depends on
 // the shared, stateful `Initializable` module. Paired with ModuleB (same
 // directory) so a composing contract triggers the shared-ledger-slot bug.
-pragma language_version >= 0.21.0;
+pragma language_version >= 0.23.0;
 
 module ModuleA {
   import CompactStandardLibrary;

--- a/contracts/test/integration/_mocks/sharedInit/ModuleB.compact
+++ b/contracts/test/integration/_mocks/sharedInit/ModuleB.compact
@@ -1,7 +1,7 @@
 // TEST-ONLY. Demonstrates the compiler#270 collision: a module that depends on
 // the shared, stateful `Initializable` module. Paired with ModuleA (same
 // directory) so a composing contract triggers the shared-ledger-slot bug.
-pragma language_version >= 0.21.0;
+pragma language_version >= 0.23.0;
 
 module ModuleB {
   import CompactStandardLibrary;


### PR DESCRIPTION
## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

No linked issue — follow-up to #597.

Raises the `pragma language_version` floor `>= 0.21.0` → `>= 0.23.0` across all **47** `.compact` files. `0.23.0` is the Compact language version that ships with compiler `0.31.0` ([compactc-v0.31.0 release](https://github.com/LFDT-Minokawa/compact/releases/tag/compactc-v0.31.0)), so the declared minimum now matches the toolchain.

### Depends on #597

Stacked on the toolchain upgrade (#597), which bumps the compiler to `0.31.0`. Until #597 merges, this PR's diff against `main` includes the toolchain upgrade **plus** the pragma bump; once #597 lands, rebasing onto `main` collapses it to the pragma change only. **Merge #597 first.**

### Validation

- All contracts compile on `0.31.0`.
- Full vitest suite passes: **1156 tests across 27 files**.

## PR Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md#your-first-code-contribution)
- [ ] I have added tests that prove my fix is effective or that my feature works. — N/A: no behavior change; the existing suite passes.
- [x] I have added documentation for new methods or changes to existing method behavior. — CHANGELOG updated.
- [ ] CI Workflows Are Passing — pending first run.

#### Further comments

Split out from #597 so the toolchain upgrade and the language-version floor land as separate, reviewable changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded Compact toolchain dependencies including compiler, runtime, ledger implementation, and simulation library to latest versions
  * Updated minimum language version requirement across all smart contracts in the project
<!-- end of auto-generated comment: release notes by coderabbit.ai -->