### PR TITLE
Remove init dep from multisig mods

### DIFF
--- a/contracts/src/multisig/Forwarder.compact
+++ b/contracts/src/multisig/Forwarder.compact
@@ -18,16 +18,22 @@ pragma language_version >= 0.23.0;
  * Underscore-prefixed circuits have no access control. The forwarder is
  * intentionally permissionless — the recipient is hard-coded at deploy,
  * so any caller may deposit without compromising the parent. State
- * access is gated by the `Initializable` module: every circuit asserts
- * the module has been initialized via `initialize`.
+ * access is gated by the initialization pattern: every circuit asserts
+ * the module has been initialized.
  */
 module Forwarder<T> {
   import CompactStandardLibrary;
-  import "../security/Initializable" prefix Initializable_;
 
   // ─── State ──────────────────────────────────────────────────────
 
   export sealed ledger _parent: T;
+
+  /**
+   * @description Initialization flag, tracked per-module to avoid the compiler's
+   * shared transitive-dependency state bug (LFDT-Minokawa/compact#270). See the
+   * Initializable module for rationale.
+   */
+  export ledger _isInitialized: Boolean;
 
   // ─── Init ───────────────────────────────────────────────────────
 
@@ -51,7 +57,8 @@ module Forwarder<T> {
    */
   export circuit initialize(parent: T): [] {
     assert(parent != default<T>, "Forwarder: zero parent");
-    Initializable_initialize();
+    assertNotInitialized();
+    _isInitialized = true;
     _parent = disclose(parent);
   }
 
@@ -75,7 +82,7 @@ module Forwarder<T> {
    * @returns {[]} Empty tuple.
    */
   export circuit _depositShielded(coin: ShieldedCoinInfo): [] {
-    Initializable_assertInitialized();
+    assertInitialized();
     receiveShielded(disclose(coin));
     sendImmediateShielded(
       disclose(coin),
@@ -101,12 +108,38 @@ module Forwarder<T> {
    * @returns {[]} Empty tuple.
    */
   export circuit _depositUnshielded(color: Bytes<32>, amount: Uint<128>): [] {
-    Initializable_assertInitialized();
+    assertInitialized();
     receiveUnshielded(disclose(color), disclose(amount));
     sendUnshielded(
       disclose(color),
       disclose(amount),
       right<ContractAddress, UserAddress>(UserAddress { bytes: _parent.bytes })
     );
+  }
+
+  /**
+   * @description Asserts that the contract has been initialized, throwing an error if not.
+   *
+   * Requirements:
+   *
+   * - Contract must be initialized.
+   *
+   * @return {[]} - Empty tuple.
+   */
+  circuit assertInitialized(): [] {
+    assert(_isInitialized, "Forwarder: contract not initialized");
+  }
+
+  /**
+   * @description Asserts that the contract has not been initialized, throwing an error if it has.
+   *
+   * Requirements:
+   *
+   * - Contract must not be initialized.
+   *
+   * @return {[]} - Empty tuple.
+   */
+  circuit assertNotInitialized(): [] {
+    assert(!_isInitialized, "Forwarder: contract already initialized");
   }
 }

--- a/contracts/src/multisig/ForwarderPrivate.compact
+++ b/contracts/src/multisig/ForwarderPrivate.compact
@@ -19,19 +19,25 @@ pragma language_version >= 0.23.0;
  *
  * Underscore-prefixed circuits have no access control beyond the
  * preimage check inside `_drain`. State access is gated by the
- * `Initializable` module: every state-touching circuit asserts the
+ * initialization pattern: every state-touching circuit asserts the
  * module has been initialized via `initialize`. The pure
  * `_calculateParentCommitment` helper does not access state and is
  * intentionally callable without initialization.
  */
 module ForwarderPrivate {
   import CompactStandardLibrary;
-  import "../security/Initializable" prefix Initializable_;
   import "../utils/Utils" prefix Utils_;
 
   // ─── State ──────────────────────────────────────────────────────
 
   export sealed ledger _parentCommitment: Bytes<32>;
+
+  /**
+   * @description Initialization flag, tracked per-module to avoid the compiler's
+   * shared transitive-dependency state bug (LFDT-Minokawa/compact#270). See the
+   * Initializable module for rationale.
+   */
+  export ledger _isInitialized: Boolean;
 
   // ─── Init ───────────────────────────────────────────────────────
 
@@ -56,7 +62,8 @@ module ForwarderPrivate {
    */
   export circuit initialize(parentCommitment: Bytes<32>): [] {
     assert(parentCommitment != default<Bytes<32>>, "ForwarderPrivate: zero commitment");
-    Initializable_initialize();
+    assertNotInitialized();
+    _isInitialized = true;
     _parentCommitment = disclose(parentCommitment);
   }
 
@@ -77,7 +84,7 @@ module ForwarderPrivate {
    * @returns {[]} Empty tuple.
    */
   export circuit _deposit(coin: ShieldedCoinInfo): [] {
-    Initializable_assertInitialized();
+    assertInitialized();
     receiveShielded(disclose(coin));
   }
 
@@ -121,7 +128,7 @@ module ForwarderPrivate {
     opSecret: Bytes<32>,
     value: Uint<128>
   ): ShieldedSendResult {
-    Initializable_assertInitialized();
+    assertInitialized();
     assert(
       _calculateParentCommitment(parentAddr, opSecret) == _parentCommitment,
       "ForwarderPrivate: invalid parent"
@@ -170,5 +177,33 @@ module ForwarderPrivate {
     return persistentHash<Vector<3, Bytes<32>>>(
       [pad(32, "ForwarderPrivate:commitment"), parentAddr, opSecret]
     );
+  }
+
+  // ─── Init guards ────────────────────────────────────────────────
+
+  /**
+   * @description Asserts that the contract has been initialized, throwing an error if not.
+   *
+   * Requirements:
+   *
+   * - Contract must be initialized.
+   *
+   * @return {[]} - Empty tuple.
+   */
+  circuit assertInitialized(): [] {
+    assert(_isInitialized, "ForwarderPrivate: contract not initialized");
+  }
+
+  /**
+   * @description Asserts that the contract has not been initialized, throwing an error if it has.
+   *
+   * Requirements:
+   *
+   * - Contract must not be initialized.
+   *
+   * @return {[]} - Empty tuple.
+   */
+  circuit assertNotInitialized(): [] {
+    assert(!_isInitialized, "ForwarderPrivate: contract already initialized");
   }
 }

--- a/contracts/src/multisig/Signer.compact
+++ b/contracts/src/multisig/Signer.compact
@@ -45,13 +45,19 @@ pragma language_version >= 0.23.0;
  */
 module Signer<T> {
   import CompactStandardLibrary;
-  import "../security/Initializable" prefix Initializable_;
 
   // ─── State ──────────────────────────────────────────────────────────────────
 
   export ledger _signers: Set<T>;
   export ledger _signerCount: Uint<8>;
   export ledger _threshold: Uint<8>;
+
+  /**
+   * @description Initialization flag, tracked per-module to avoid the compiler's
+   * shared transitive-dependency state bug (LFDT-Minokawa/compact#270). See the
+   * Initializable module for rationale.
+   */
+  export ledger _isInitialized: Boolean;
 
   // ─── Initialization ─────────────────────────────────────────────────────────
 
@@ -77,7 +83,8 @@ module Signer<T> {
     signers: Vector<n, T>,
     thresh: Uint<8>
   ): [] {
-    Initializable_initialize();
+    assertNotInitialized();
+    _isInitialized = true;
 
     for (const signer of signers) {
       _addSigner(signer);
@@ -102,7 +109,7 @@ module Signer<T> {
    * @returns {[]} Empty tuple.
    */
   export circuit assertSigner(caller: T): [] {
-    Initializable_assertInitialized();
+    assertInitialized();
     assert(isSigner(caller), "Signer: not a signer");
   }
 
@@ -121,7 +128,7 @@ module Signer<T> {
    * @returns {[]} Empty tuple.
    */
   export circuit assertThresholdMet(approvalCount: Uint<8>): [] {
-    Initializable_assertInitialized();
+    assertInitialized();
     assert(_threshold != 0, "Signer: threshold not set");
     assert(approvalCount >= _threshold, "Signer: threshold not met");
   }
@@ -140,7 +147,7 @@ module Signer<T> {
    * @returns {Uint<8>} The number of active signers.
    */
   export circuit getSignerCount(): Uint<8> {
-    Initializable_assertInitialized();
+    assertInitialized();
     return _signerCount;
   }
 
@@ -156,7 +163,7 @@ module Signer<T> {
    * @returns {Uint<8>} The threshold.
    */
   export circuit getThreshold(): Uint<8> {
-    Initializable_assertInitialized();
+    assertInitialized();
     return _threshold;
   }
 
@@ -273,5 +280,33 @@ module Signer<T> {
   export circuit _setThreshold(newThreshold: Uint<8>): [] {
     assert(newThreshold != 0, "Signer: threshold must not be zero");
     _threshold = disclose(newThreshold);
+  }
+
+  // ─── Init guards ─────────────────────────────────────────────────────────
+
+  /**
+   * @description Asserts that the contract has been initialized, throwing an error if not.
+   *
+   * Requirements:
+   *
+   * - Contract must be initialized.
+   *
+   * @return {[]} - Empty tuple.
+   */
+  circuit assertInitialized(): [] {
+    assert(_isInitialized, "Signer: contract not initialized");
+  }
+
+  /**
+   * @description Asserts that the contract has not been initialized, throwing an error if it has.
+   *
+   * Requirements:
+   *
+   * - Contract must not be initialized.
+   *
+   * @return {[]} - Empty tuple.
+   */
+  circuit assertNotInitialized(): [] {
+    assert(!_isInitialized, "Signer: contract already initialized");
   }
 }

--- a/contracts/src/multisig/test/Forwarder.test.ts
+++ b/contracts/src/multisig/test/Forwarder.test.ts
@@ -61,9 +61,7 @@ describe('Forwarder module', () => {
     });
 
     it('should accept a shielded deposit and forward it', () => {
-      expect(() =>
-        mock.depositShielded(makeCoin(COLOR, AMOUNT)),
-      ).not.toThrow();
+      expect(() => mock.depositShielded(makeCoin(COLOR, AMOUNT))).not.toThrow();
     });
 
     it('should accept an unshielded deposit and forward it', () => {

--- a/contracts/src/multisig/test/Forwarder.test.ts
+++ b/contracts/src/multisig/test/Forwarder.test.ts
@@ -42,13 +42,13 @@ describe('Forwarder module', () => {
 
     it('should fail depositShielded when not initialized', () => {
       expect(() => mock.depositShielded(makeCoin(COLOR, AMOUNT))).toThrow(
-        'Initializable: contract not initialized',
+        'Forwarder: contract not initialized',
       );
     });
 
     it('should fail depositUnshielded when not initialized', () => {
       expect(() => mock.depositUnshielded(COLOR, AMOUNT)).toThrow(
-        'Initializable: contract not initialized',
+        'Forwarder: contract not initialized',
       );
     });
   });

--- a/contracts/src/multisig/test/ForwarderPrivate.test.ts
+++ b/contracts/src/multisig/test/ForwarderPrivate.test.ts
@@ -1,5 +1,5 @@
-import { beforeEach, describe, expect, it } from 'vitest';
 import fc from 'fast-check';
+import { beforeEach, describe, expect, it } from 'vitest';
 import * as utils from '#test-utils/address.js';
 import { MockForwarderPrivateSimulator } from './simulators/MockForwarderPrivateSimulator.js';
 
@@ -35,7 +35,10 @@ function makeQualifiedCoin(
 }
 
 function commitment(parent: Uint8Array, opSecret: Uint8Array): Uint8Array {
-  return MockForwarderPrivateSimulator.calculateParentCommitment(parent, opSecret);
+  return MockForwarderPrivateSimulator.calculateParentCommitment(
+    parent,
+    opSecret,
+  );
 }
 
 describe('ForwarderPrivate module', () => {
@@ -63,7 +66,10 @@ describe('ForwarderPrivate module', () => {
     let mock: MockForwarderPrivateSimulator;
 
     beforeEach(() => {
-      mock = new MockForwarderPrivateSimulator(commitment(PARENT, OP_SECRET), false);
+      mock = new MockForwarderPrivateSimulator(
+        commitment(PARENT, OP_SECRET),
+        false,
+      );
     });
 
     it('should fail deposit when not initialized', () => {
@@ -74,7 +80,12 @@ describe('ForwarderPrivate module', () => {
 
     it('should fail drain when not initialized', () => {
       expect(() =>
-        mock.drain(makeQualifiedCoin(COLOR, AMOUNT, 0n), PARENT, OP_SECRET, AMOUNT),
+        mock.drain(
+          makeQualifiedCoin(COLOR, AMOUNT, 0n),
+          PARENT,
+          OP_SECRET,
+          AMOUNT,
+        ),
       ).toThrow('ForwarderPrivate: contract not initialized');
     });
   });
@@ -94,14 +105,8 @@ describe('ForwarderPrivate module', () => {
           fc.uint8Array({ minLength: 32, maxLength: 32 }),
           (parent, s1, s2) => {
             fc.pre(s1.some((b, i) => b !== s2[i]));
-            const c1 = commitment(
-              Uint8Array.from(parent),
-              Uint8Array.from(s1),
-            );
-            const c2 = commitment(
-              Uint8Array.from(parent),
-              Uint8Array.from(s2),
-            );
+            const c1 = commitment(Uint8Array.from(parent), Uint8Array.from(s1));
+            const c2 = commitment(Uint8Array.from(parent), Uint8Array.from(s2));
             expect(c1).not.toEqual(c2);
           },
         ),
@@ -114,7 +119,10 @@ describe('ForwarderPrivate module', () => {
     let mock: MockForwarderPrivateSimulator;
 
     beforeEach(() => {
-      mock = new MockForwarderPrivateSimulator(commitment(PARENT, OP_SECRET), true);
+      mock = new MockForwarderPrivateSimulator(
+        commitment(PARENT, OP_SECRET),
+        true,
+      );
       mock.deposit(makeCoin(COLOR, AMOUNT));
     });
 

--- a/contracts/src/multisig/test/ForwarderPrivate.test.ts
+++ b/contracts/src/multisig/test/ForwarderPrivate.test.ts
@@ -68,14 +68,14 @@ describe('ForwarderPrivate module', () => {
 
     it('should fail deposit when not initialized', () => {
       expect(() => mock.deposit(makeCoin(COLOR, AMOUNT))).toThrow(
-        'Initializable: contract not initialized',
+        'ForwarderPrivate: contract not initialized',
       );
     });
 
     it('should fail drain when not initialized', () => {
       expect(() =>
         mock.drain(makeQualifiedCoin(COLOR, AMOUNT, 0n), PARENT, OP_SECRET, AMOUNT),
-      ).toThrow('Initializable: contract not initialized');
+      ).toThrow('ForwarderPrivate: contract not initialized');
     });
   });
 

--- a/contracts/src/multisig/test/Signer.test.ts
+++ b/contracts/src/multisig/test/Signer.test.ts
@@ -35,7 +35,7 @@ describe('Signer', () => {
             ...a: unknown[]
           ) => unknown
         )(...args);
-      }).toThrow('Initializable: contract not initialized');
+      }).toThrow('Signer: contract not initialized');
     });
 
     it('isSigner should succeed (no init guard)', () => {
@@ -90,7 +90,7 @@ describe('Signer', () => {
       contract = new SignerSimulator(SIGNERS, THRESHOLD, IS_INIT);
       expect(() => {
         contract.initialize(SIGNERS, THRESHOLD);
-      }).toThrow('Initializable: contract already initialized');
+      }).toThrow('Signer: contract already initialized');
     });
   });
 

--- a/turbo.json
+++ b/turbo.json
@@ -30,7 +30,7 @@
       "outputs": ["artifacts/**/"]
     },
     "compact:multisig": {
-      "dependsOn": ["^build", "compact:security", "compact:utils"],
+      "dependsOn": ["^build", "compact:utils"],
       "env": ["COMPACT_HOME", "SKIP_ZK"],
       "inputs": ["src/multisig/**/*.compact"],
       "outputLogs": "new-only",


### PR DESCRIPTION
Resolves #611 

This PR ignores Forwarder.compact because it will removed. Depends on #566 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Multisig contract suite refactored to manage initialization state internally, removing reliance on external helper modules while maintaining initialization enforcement semantics.

* **Tests**
  * Updated initialization guard test assertions to reflect new contract-specific error messages.

* **Chores**
  * Optimized build pipeline task dependencies for multisig compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->