### PR TITLE
Consolidate repeated circuits

### DIFF
--- a/contracts/src/access/AccessControl.compact
+++ b/contracts/src/access/AccessControl.compact
@@ -442,38 +442,6 @@ module AccessControl {
    * @returns {Bytes<32>} accountId - The computed account identifier.
    */
   circuit _computeAccountId(): Bytes<32> {
-    return computeAccountId(wit_AccessControlSK());
-  }
-
-  /**
-   * @description Computes an account identifier without on-chain state, allowing a user to derive
-   * their identity commitment before submitting it in a grant or revoke operation.
-   * This is the off-chain counterpart to {_computeAccountId} and produces an identical result
-   * given the same inputs.
-   *
-   * @warning OpSec: The `secretKey` parameter is a sensitive secret. Mishandling it can
-   * permanently compromise the privacy guarantees of this system:
-   *
-   * - **Never log or persist** the `secretKey` in plaintext — avoid browser devtools,
-   *   application logs, analytics pipelines, or any observable side-channel.
-   * - **Store offline or in secure enclaves** — hardware security modules (HSMs),
-   *   air-gapped devices, or encrypted vaults are strongly preferred over hot storage.
-   * - **Use cryptographically secure randomness** — generate keys with `crypto.getRandomValues()`
-   *   or equivalent; weak or predictable keys can be brute-forced to reveal your identity.
-   * - **Treat key loss as identity loss** — a lost key cannot be recovered. Back up
-   *   keys securely before using them in role commitments.
-   * - **Avoid calling this circuit in untrusted environments** — executing this in an
-   *   unverified browser extension, compromised runtime, or shared machine may expose
-   *   the key to a malicious observer.
-   *
-   * ## ID Derivation
-   * `accountId = persistentHash(secretKey)`
-   *
-   * @param {Bytes<32>} secretKey - A 32-byte cryptographically secure random value.
-   *
-   * @returns {Bytes<32>} accountId - The computed account identifier.
-   */
-  export pure circuit computeAccountId(secretKey: Bytes<32>): Bytes<32> {
-    return persistentHash<Vector<1, Bytes<32>>>([secretKey]);
+    return Utils_computeAccountId(wit_AccessControlSK());
   }
 }

--- a/contracts/src/access/Ownable.compact
+++ b/contracts/src/access/Ownable.compact
@@ -125,7 +125,7 @@ module Ownable {
   export circuit initialize(initialOwner: Either<Bytes<32>, ContractAddress>): [] {
     assertNotInitialized();
     _isInitialized = true;
-    assert(!_isTargetZero(initialOwner), "Ownable: invalid initial owner");
+    assert(!Utils_isTargetZero(initialOwner), "Ownable: invalid initial owner");
     _transferOwnership(initialOwner);
   }
 
@@ -219,7 +219,7 @@ module Ownable {
   export circuit _unsafeTransferOwnership(newOwner: Either<Bytes<32>, ContractAddress>): [] {
     assertInitialized();
     assertOnlyOwner();
-    assert(!_isTargetZero(newOwner), "Ownable: invalid new owner");
+    assert(!Utils_isTargetZero(newOwner), "Ownable: invalid new owner");
     _unsafeUncheckedTransferOwnership(newOwner);
   }
 
@@ -335,52 +335,6 @@ module Ownable {
    * @returns {Bytes<32>} accountId - The computed account identifier.
    */
   circuit _computeAccountId(): Bytes<32> {
-    return computeAccountId(wit_OwnableSK());
-  }
-
-  /**
-   * @description Computes an account identifier without on-chain state, allowing a user to derive
-   * their identity commitment before submitting it in an ownership transfer.
-   * This is the off-chain counterpart to {_computeAccountId} and produces an identical result
-   * given the same inputs.
-   *
-   * @warning OpSec: The `secretKey` parameter is a sensitive secret. Mishandling it can
-   * permanently compromise the security of this system:
-   *
-   * - **Never log or persist** the `secretKey` in plaintext — avoid browser devtools,
-   *   application logs, analytics pipelines, or any observable side-channel.
-   * - **Store offline or in secure enclaves** — hardware security modules (HSMs),
-   *   air-gapped devices, or encrypted vaults are strongly preferred over hot storage.
-   * - **Use cryptographically secure randomness** — generate keys with `crypto.getRandomValues()`
-   *   or equivalent; weak or predictable keys can be brute-forced to reveal your identity.
-   * - **Treat key loss as identity loss** — a lost key cannot be recovered.
-   * - **Avoid calling this circuit in untrusted environments** — executing this in an
-   *   unverified browser extension, compromised runtime, or shared machine may expose
-   *   the key to a malicious observer.
-   *
-   * ## ID Derivation
-   * `accountId = persistentHash(secretKey)`
-   *
-   * @param {Bytes<32>} secretKey - A 32-byte cryptographically secure random value.
-   *
-   * @returns {Bytes<32>} accountId - The computed account identifier.
-   */
-  export pure circuit computeAccountId(secretKey: Bytes<32>): Bytes<32> {
-    return persistentHash<Vector<1, Bytes<32>>>([secretKey]);
-  }
-
-  /**
-   * @description Returns `true` if `target`'s active branch (as indicated by `is_left`)
-   * holds the zero value.
-   *
-   * @param {Either<Bytes<32>, ContractAddress>} target - The value to check.
-   * @returns {Boolean} - `true` if the active branch is zero, `false` otherwise.
-   */
-  circuit _isTargetZero(target: Either<Bytes<32>, ContractAddress>): Boolean {
-    if (target.is_left) {
-      return target.left == default<Bytes<32>>;
-    } else {
-      return target.right == default<ContractAddress>;
-    }
+    return Utils_computeAccountId(wit_OwnableSK());
   }
 }

--- a/contracts/src/access/test/AccessControl.test.ts
+++ b/contracts/src/access/test/AccessControl.test.ts
@@ -752,29 +752,6 @@ describe('AccessControl', () => {
     });
   });
 
-  describe('computeAccountId', () => {
-    it('should match the test helper derivation', () => {
-      const users = [OP1, OP2, OP3];
-
-      for (let i = 0; i < users.length; i++) {
-        expect(accessControl.computeAccountId(users[i].secretKey)).toEqual(
-          users[i].accountId,
-        );
-      }
-    });
-
-    it('should produce distinct identifiers for distinct keys', () => {
-      const users = [ADMIN, CUSTOM_ADMIN, OP1, OP2, OP3, UNAUTHORIZED];
-      const ids = users.map((u) => accessControl.computeAccountId(u.secretKey));
-
-      for (let i = 0; i < ids.length; i++) {
-        for (let j = i + 1; j < ids.length; j++) {
-          expect(ids[i]).not.toEqual(ids[j]);
-        }
-      }
-    });
-  });
-
   describe('privateState helpers', () => {
     describe('getCurrentSecretKey', () => {
       it('should return the injected secret key', () => {

--- a/contracts/src/access/test/Ownable.test.ts
+++ b/contracts/src/access/test/Ownable.test.ts
@@ -157,26 +157,6 @@ describe('Ownable', () => {
       });
     });
 
-    describe('computeAccountId', () => {
-      it('should match pre-computed accountId', () => {
-        expect(ownable.computeAccountId(OWNER.secretKey)).toEqual(
-          OWNER.accountId,
-        );
-      });
-
-      it('should produce different accountId with different key', () => {
-        expect(ownable.computeAccountId(UNAUTHORIZED.secretKey)).not.toEqual(
-          OWNER.accountId,
-        );
-      });
-
-      it('should match test helper derivation', () => {
-        expect(ownable.computeAccountId(OWNER.secretKey)).toEqual(
-          buildAccountIdHash(OWNER.secretKey),
-        );
-      });
-    });
-
     describe('assertOnlyOwner', () => {
       it('should allow owner to call', () => {
         expect(() => ownable.assertOnlyOwner()).not.toThrow();

--- a/contracts/src/access/test/mocks/MockAccessControl.compact
+++ b/contracts/src/access/test/mocks/MockAccessControl.compact
@@ -61,6 +61,3 @@ export circuit _revokeRole(roleId: Bytes<32>, account: Either<Bytes<32>, Contrac
   return AccessControl__revokeRole(roleId, account);
 }
 
-export pure circuit computeAccountId(secretKey: Bytes<32>): Bytes<32> {
-  return AccessControl_computeAccountId(secretKey);
-}

--- a/contracts/src/access/test/mocks/MockOwnable.compact
+++ b/contracts/src/access/test/mocks/MockOwnable.compact
@@ -54,6 +54,3 @@ export circuit _unsafeUncheckedTransferOwnership(newOwner: Either<Bytes<32>, Con
   return Ownable__unsafeUncheckedTransferOwnership(newOwner);
 }
 
-export pure circuit computeAccountId(secretKey: Bytes<32>): Bytes<32> {
-  return Ownable_computeAccountId(secretKey);
-}

--- a/contracts/src/access/test/simulators/AccessControlSimulator.ts
+++ b/contracts/src/access/test/simulators/AccessControlSimulator.ts
@@ -178,16 +178,6 @@ export class AccessControlSimulator extends AccessControlSimulatorBase {
     return this.circuits.impure._revokeRole(roleId, account);
   }
 
-  /**
-   * @description Computes an account identifier without on-chain state, allowing a user to derive
-   * their identity commitment before submitting it in a grant or revoke operation.
-   * @param {Bytes<32>} secretKey - A 32-byte cryptographically secure random value.
-   * @returns {Bytes<32>} accountId - The computed account identifier.
-   */
-  public computeAccountId(secretKey: Uint8Array): Uint8Array {
-    return this.circuits.pure.computeAccountId(secretKey);
-  }
-
   public readonly privateState = {
     /**
      * @description Replaces the secret key in the private state. Used in tests to

--- a/contracts/src/access/test/simulators/OwnableSimulator.ts
+++ b/contracts/src/access/test/simulators/OwnableSimulator.ts
@@ -112,16 +112,6 @@ export class OwnableSimulator extends OwnableSimulatorBase {
     this.circuits.impure._unsafeUncheckedTransferOwnership(newOwner);
   }
 
-  /**
-   * @description Computes an account identifier without on-chain state, allowing a user to derive
-   * their identity commitment before submitting it in a grant or revoke operation.
-   * @param {Bytes<32>} secretKey - A 32-byte cryptographically secure random value.
-   * @returns {Bytes<32>} accountId - The computed account identifier.
-   */
-  public computeAccountId(secretKey: Uint8Array): Uint8Array {
-    return this.circuits.pure.computeAccountId(secretKey);
-  }
-
   public readonly privateState = {
     /**
      * @description Replaces the secret key in the private state. Used in tests to

--- a/contracts/src/token/FungibleToken.compact
+++ b/contracts/src/token/FungibleToken.compact
@@ -598,7 +598,7 @@ module FungibleToken {
                    ): [] {
     assertInitialized();
     assert(!Utils_isTargetZero(account), "FungibleToken: invalid receiver");
-    _update(Utils_ZERO(), account, value);
+    _update(Utils_zeroAccount(), account, value);
   }
 
   /**
@@ -620,7 +620,7 @@ module FungibleToken {
   export circuit _burn(account: Either<Bytes<32>, ContractAddress>, value: Uint<128>): [] {
     assertInitialized();
     assert(!Utils_isTargetZero(account), "FungibleToken: invalid sender");
-    _update(account, Utils_ZERO(), value);
+    _update(account, Utils_zeroAccount(), value);
   }
 
   /**

--- a/contracts/src/token/FungibleToken.compact
+++ b/contracts/src/token/FungibleToken.compact
@@ -112,19 +112,6 @@ module FungibleToken {
   witness wit_FungibleTokenSK(): Bytes<32>;
 
   /**
-   * @description Returns a canonical zero Either value for Bytes<32> and ContractAddress.
-   * This circuit returns the left variant (Bytes<32>) to avoid misleading contract-to-contract
-   * error messages.
-   *
-   * @return {Either<Bytes<32>, ContractAddress>} - The zero value.
-   */
-  export pure circuit ZERO(): Either<Bytes<32>, ContractAddress> {
-    return Either<Bytes<32>, ContractAddress> {
-      is_left: true, left: default<Bytes<32>>, right: default<ContractAddress>
-    };
-  }
-
-  /**
    * @description Initializes the contract by setting the name, symbol, and decimals.
    * @dev This MUST be called in the implementing contract's constructor. Failure to do so
    * can lead to an irreparable contract.
@@ -509,8 +496,8 @@ module FungibleToken {
                    value: Uint<128>
                    ): [] {
     assertInitialized();
-    assert(!_isTargetZero(fromAddress), "FungibleToken: invalid sender");
-    assert(!_isTargetZero(to), "FungibleToken: invalid receiver");
+    assert(!Utils_isTargetZero(fromAddress), "FungibleToken: invalid sender");
+    assert(!Utils_isTargetZero(to), "FungibleToken: invalid receiver");
 
     _update(fromAddress, to, value);
   }
@@ -539,7 +526,7 @@ module FungibleToken {
     const canonFrom = Utils_canonicalize<Bytes<32>, ContractAddress>(fromAddress);
     const canonTo = Utils_canonicalize<Bytes<32>, ContractAddress>(to);
 
-    if (_isTargetZero(disclose(canonFrom))) {
+    if (Utils_isTargetZero(disclose(canonFrom))) {
       // Mint
       const MAX_UINT128 = 340282366920938463463374607431768211455;
       assert(MAX_UINT128 - _totalSupply >= value, "FungibleToken: arithmetic overflow");
@@ -551,7 +538,7 @@ module FungibleToken {
       _balances.insert(disclose(canonFrom), disclose(fromBal - value as Uint<128>));
     }
 
-    if (_isTargetZero(disclose(canonTo))) {
+    if (Utils_isTargetZero(disclose(canonTo))) {
       // Burn
       _totalSupply = disclose(_totalSupply - value as Uint<128>);
     } else {
@@ -610,8 +597,8 @@ module FungibleToken {
                    value: Uint<128>
                    ): [] {
     assertInitialized();
-    assert(!_isTargetZero(account), "FungibleToken: invalid receiver");
-    _update(ZERO(), account, value);
+    assert(!Utils_isTargetZero(account), "FungibleToken: invalid receiver");
+    _update(Utils_ZERO(), account, value);
   }
 
   /**
@@ -632,8 +619,8 @@ module FungibleToken {
    */
   export circuit _burn(account: Either<Bytes<32>, ContractAddress>, value: Uint<128>): [] {
     assertInitialized();
-    assert(!_isTargetZero(account), "FungibleToken: invalid sender");
-    _update(account, ZERO(), value);
+    assert(!Utils_isTargetZero(account), "FungibleToken: invalid sender");
+    _update(account, Utils_ZERO(), value);
   }
 
   /**
@@ -663,8 +650,8 @@ module FungibleToken {
     const canonOwner = Utils_canonicalize<Bytes<32>, ContractAddress>(owner);
     const canonSpender = Utils_canonicalize<Bytes<32>, ContractAddress>(spender);
 
-    assert(!_isTargetZero(canonOwner), "FungibleToken: invalid owner");
-    assert(!_isTargetZero(canonSpender), "FungibleToken: invalid spender");
+    assert(!Utils_isTargetZero(canonOwner), "FungibleToken: invalid owner");
+    assert(!Utils_isTargetZero(canonSpender), "FungibleToken: invalid spender");
 
     if (!_allowances.member(disclose(canonOwner))) {
       // If owner doesn't exist, create and insert a new sub-map directly
@@ -725,52 +712,6 @@ module FungibleToken {
    * @returns {Bytes<32>} accountId - The computed account identifier.
    */
   circuit _computeAccountId(): Bytes<32> {
-    return computeAccountId(wit_FungibleTokenSK());
-  }
-
-  /**
-   * @description Computes an account identifier without on-chain state, allowing a user to derive
-   * their identity commitment before submitting a token operation.
-   * This is the off-chain counterpart to {_computeAccountId} and produces an identical result
-   * given the same inputs.
-   *
-   * @warning OpSec: The `secretKey` parameter is a sensitive secret. Mishandling it can
-   * permanently compromise the security of this system:
-   *
-   * - **Never log or persist** the `secretKey` in plaintext — avoid browser devtools,
-   *   application logs, analytics pipelines, or any observable side-channel.
-   * - **Store offline or in secure enclaves** — hardware security modules (HSMs),
-   *   air-gapped devices, or encrypted vaults are strongly preferred over hot storage.
-   * - **Use cryptographically secure randomness** — generate keys with `crypto.getRandomValues()`
-   *   or equivalent; weak or predictable keys can be brute-forced to reveal your identity.
-   * - **Treat key loss as identity loss** — a lost key cannot be recovered.
-   * - **Avoid calling this circuit in untrusted environments** — executing this in an
-   *   unverified browser extension, compromised runtime, or shared machine may expose
-   *   the key to a malicious observer.
-   *
-   * ## ID Derivation
-   * `accountId = persistentHash(secretKey)`
-   *
-   * @param {Bytes<32>} secretKey - A 32-byte cryptographically secure random value.
-   *
-   * @returns {Bytes<32>} accountId - The computed account identifier.
-   */
-  export pure circuit computeAccountId(secretKey: Bytes<32>): Bytes<32> {
-    return persistentHash<Vector<1, Bytes<32>>>([secretKey]);
-  }
-
-  /**
-   * @description Returns `true` if `target`'s active branch (as indicated by `is_left`)
-   * holds the zero value.
-   *
-   * @param {Either<Bytes<32>, ContractAddress>} target - The value to check.
-   * @returns {Boolean} - `true` if the active branch is zero, `false` otherwise.
-   */
-  circuit _isTargetZero(target: Either<Bytes<32>, ContractAddress>): Boolean {
-    if (target.is_left) {
-      return target.left == default<Bytes<32>>;
-    } else {
-      return target.right == default<ContractAddress>;
-    }
+    return Utils_computeAccountId(wit_FungibleTokenSK());
   }
 }

--- a/contracts/src/token/MultiToken.compact
+++ b/contracts/src/token/MultiToken.compact
@@ -174,25 +174,6 @@ module MultiToken {
   witness wit_MultiTokenSK(): Bytes<32>;
 
   /**
-   * @description Returns a canonical zero Either value (left variant with zero Bytes<32>).
-   * Used as the zero value for mint/burn operations in `_update`, where a zero
-   * `fromAddress` signals a mint and a zero `to` signals a burn.
-   *
-   * The left variant is chosen so that `_isTargetZero` checks against `default<Bytes<32>>`,
-   * which is consistent with how `_update` dispatches on the zero check. A right variant
-   * with `default<ContractAddress>` would also pass `_isTargetZero`, but using the left
-   * variant avoids triggering contract address guards in circuits like `_mint` that check
-   * `!to.is_left` before delegating to `_unsafeMint`.
-   *
-   * @return {Either<Bytes<32>, ContractAddress>} - The zero value.
-   */
-  export pure circuit ZERO(): Either<Bytes<32>, ContractAddress> {
-    return Either<Bytes<32>, ContractAddress> {
-      is_left: true, left: default<Bytes<32>>, right: default<ContractAddress>
-    };
-  }
-
-  /**
    * @description Initializes the contract by setting the base URI for all tokens.
    *
    * @circuitInfo k=6, rows=33
@@ -441,14 +422,14 @@ module MultiToken {
     const canonFrom = Utils_canonicalize<Bytes<32>, ContractAddress>(fromAddress);
     const canonTo = Utils_canonicalize<Bytes<32>, ContractAddress>(to);
 
-    if (!_isTargetZero(disclose(canonFrom))) {
+    if (!Utils_isTargetZero(disclose(canonFrom))) {
       const fromBalance = balanceOf(canonFrom, id);
       assert(fromBalance >= value, "MultiToken: insufficient balance");
       const newBalance = fromBalance - value;
       _balances.lookup(id).insert(disclose(canonFrom), disclose(newBalance));
     }
 
-    if (!_isTargetZero(disclose(canonTo))) {
+    if (!Utils_isTargetZero(disclose(canonTo))) {
       if (!_balances.member(disclose(id))) {
         _balances.insert(
           disclose(id),
@@ -540,8 +521,8 @@ module MultiToken {
                    ): [] {
     assertInitialized();
 
-    assert(!_isTargetZero(fromAddress), "MultiToken: invalid sender");
-    assert(!_isTargetZero(to), "MultiToken: invalid receiver");
+    assert(!Utils_isTargetZero(fromAddress), "MultiToken: invalid sender");
+    assert(!Utils_isTargetZero(to), "MultiToken: invalid receiver");
     _update(fromAddress, to, id, value);
   }
 
@@ -627,8 +608,8 @@ module MultiToken {
                    value: Uint<128>
                    ): [] {
     assertInitialized();
-    assert(!_isTargetZero(to), "MultiToken: invalid receiver");
-    _update(ZERO(), to, id, value);
+    assert(!Utils_isTargetZero(to), "MultiToken: invalid receiver");
+    _update(Utils_ZERO(), to, id, value);
   }
 
   /**
@@ -652,8 +633,8 @@ module MultiToken {
                        value: Uint<128>
                        ): [] {
     assertInitialized();
-    assert(!_isTargetZero(fromAddress), "MultiToken: invalid sender");
-    _update(fromAddress, ZERO(), id, value);
+    assert(!Utils_isTargetZero(fromAddress), "MultiToken: invalid sender");
+    _update(fromAddress, Utils_ZERO(), id, value);
   }
 
   /**
@@ -684,10 +665,10 @@ module MultiToken {
                    ): [] {
     assertInitialized();
     const canonOwner = Utils_canonicalize<Bytes<32>, ContractAddress>(owner);
-    assert(!_isTargetZero(canonOwner), "MultiToken: invalid owner");
+    assert(!Utils_isTargetZero(canonOwner), "MultiToken: invalid owner");
 
     const canonOp = Utils_canonicalize<Bytes<32>, ContractAddress>(operator);
-    assert(!_isTargetZero(canonOp), "MultiToken: invalid operator");
+    assert(!Utils_isTargetZero(canonOp), "MultiToken: invalid operator");
 
     if (!_operatorApprovals.member(disclose(canonOwner))) {
       _operatorApprovals.insert(
@@ -710,52 +691,6 @@ module MultiToken {
    * @returns {Bytes<32>} accountId - The computed account identifier.
    */
   circuit _computeAccountId(): Bytes<32> {
-    return computeAccountId(wit_MultiTokenSK());
-  }
-
-  /**
-   * @description Computes an account identifier without on-chain state, allowing a user to derive
-   * their identity commitment before submitting it in a token operation.
-   * This is the off-chain counterpart to {_computeAccountId} and produces an identical result
-   * given the same inputs.
-   *
-   * @warning OpSec: The `secretKey` parameter is a sensitive secret. Mishandling it can
-   * permanently compromise the security of this system:
-   *
-   * - **Never log or persist** the `secretKey` in plaintext — avoid browser devtools,
-   *   application logs, analytics pipelines, or any observable side-channel.
-   * - **Store offline or in secure enclaves** — hardware security modules (HSMs),
-   *   air-gapped devices, or encrypted vaults are strongly preferred over hot storage.
-   * - **Use cryptographically secure randomness** — generate keys with `crypto.getRandomValues()`
-   *   or equivalent; weak or predictable keys can be brute-forced to reveal your identity.
-   * - **Treat key loss as identity loss** — a lost key cannot be recovered.
-   * - **Avoid calling this circuit in untrusted environments** — executing this in an
-   *   unverified browser extension, compromised runtime, or shared machine may expose
-   *   the key to a malicious observer.
-   *
-   * ## ID Derivation
-   * `accountId = persistentHash(secretKey)`
-   *
-   * @param {Bytes<32>} secretKey - A 32-byte cryptographically secure random value.
-   *
-   * @returns {Bytes<32>} accountId - The computed account identifier.
-   */
-  export pure circuit computeAccountId(secretKey: Bytes<32>): Bytes<32> {
-    return persistentHash<Vector<1, Bytes<32>>>([secretKey]);
-  }
-
-  /**
-   * @description Returns `true` if `target`'s active branch (as indicated by `is_left`)
-   * holds the zero value.
-   *
-   * @param {Either<Bytes<32>, ContractAddress>} target - The value to check.
-   * @returns {Boolean} - `true` if the active branch is zero, `false` otherwise.
-   */
-  circuit _isTargetZero(target: Either<Bytes<32>, ContractAddress>): Boolean {
-    if (target.is_left) {
-      return target.left == default<Bytes<32>>;
-    } else {
-      return target.right == default<ContractAddress>;
-    }
+    return Utils_computeAccountId(wit_MultiTokenSK());
   }
 }

--- a/contracts/src/token/MultiToken.compact
+++ b/contracts/src/token/MultiToken.compact
@@ -609,7 +609,7 @@ module MultiToken {
                    ): [] {
     assertInitialized();
     assert(!Utils_isTargetZero(to), "MultiToken: invalid receiver");
-    _update(Utils_ZERO(), to, id, value);
+    _update(Utils_zeroAccount(), to, id, value);
   }
 
   /**
@@ -634,7 +634,7 @@ module MultiToken {
                        ): [] {
     assertInitialized();
     assert(!Utils_isTargetZero(fromAddress), "MultiToken: invalid sender");
-    _update(fromAddress, Utils_ZERO(), id, value);
+    _update(fromAddress, Utils_zeroAccount(), id, value);
   }
 
   /**

--- a/contracts/src/token/NonFungibleToken.compact
+++ b/contracts/src/token/NonFungibleToken.compact
@@ -155,18 +155,6 @@ module NonFungibleToken {
   witness wit_NonFungibleTokenSK(): Bytes<32>;
 
   /**
-   * @description Returns a canonical zero Either value (left variant with zero Bytes<32>).
-   * Used as the zero value for mint/burn operations and cleared approvals.
-   *
-   * @return {Either<Bytes<32>, ContractAddress>} - The zero value.
-   */
-  export pure circuit ZERO(): Either<Bytes<32>, ContractAddress> {
-    return Either<Bytes<32>, ContractAddress> {
-      is_left: true, left: default<Bytes<32>>, right: default<ContractAddress>
-    };
-  }
-
-  /**
    * @description Initializes the contract by setting the name and symbol.
    *
    * This MUST be called in the implementing contract's constructor.
@@ -510,7 +498,7 @@ module NonFungibleToken {
                    tokenId: Uint<128>
                    ): [] {
     assertInitialized();
-    assert(!_isTargetZero(to), "NonFungibleToken: invalid receiver");
+    assert(!Utils_isTargetZero(to), "NonFungibleToken: invalid receiver");
     // Setting an "auth" argument enables the `_isAuthorized` check which verifies that the token exists
     // (fromAddress != 0). Therefore, it is not needed to verify that the return value is not 0 here.
     const auth = left<Bytes<32>, ContractAddress>(_computeAccountId());
@@ -535,7 +523,7 @@ module NonFungibleToken {
   export circuit _ownerOf(tokenId: Uint<128>): Either<Bytes<32>, ContractAddress> {
     assertInitialized();
     if (!_owners.member(disclose(tokenId))) {
-      return ZERO();
+      return Utils_ZERO();
     }
 
     return _owners.lookup(disclose(tokenId));
@@ -556,7 +544,7 @@ module NonFungibleToken {
   export circuit _getApproved(tokenId: Uint<128>): Either<Bytes<32>, ContractAddress> {
     assertInitialized();
     if (!_tokenApprovals.member(disclose(tokenId))) {
-      return ZERO();
+      return Utils_ZERO();
     }
     return _tokenApprovals.lookup(disclose(tokenId));
   }
@@ -588,7 +576,7 @@ module NonFungibleToken {
     const canonOwner = Utils_canonicalize<Bytes<32>, ContractAddress>(owner);
     const canonSpender = Utils_canonicalize<Bytes<32>, ContractAddress>(spender);
 
-    return (!_isTargetZero(disclose(canonSpender)) &&
+    return (!Utils_isTargetZero(disclose(canonSpender)) &&
             (disclose(canonOwner) == disclose(canonSpender) ||
              isApprovedForAll(canonOwner, canonSpender) ||
              _getApproved(tokenId) == disclose(canonSpender)));
@@ -619,7 +607,7 @@ module NonFungibleToken {
                    ): [] {
     assertInitialized();
     if (!_isAuthorized(owner, spender, tokenId)) {
-      assert(!_isTargetZero(owner), "NonFungibleToken: nonexistent token");
+      assert(!Utils_isTargetZero(owner), "NonFungibleToken: nonexistent token");
       assert(false, "NonFungibleToken: insufficient approval");
     }
   }
@@ -649,20 +637,20 @@ module NonFungibleToken {
     const fromAddress = _ownerOf(tokenId);
 
     // Perform (optional) operator check
-    if (!_isTargetZero(disclose(canonAuth))) {
+    if (!Utils_isTargetZero(disclose(canonAuth))) {
       _checkAuthorized(fromAddress, canonAuth, tokenId);
     }
 
     // Execute the update
-    if (!_isTargetZero(disclose(fromAddress))) {
+    if (!Utils_isTargetZero(disclose(fromAddress))) {
       // Clear approval. No need to re-authorize
-      _approve(ZERO(), tokenId, ZERO());
+      _approve(Utils_ZERO(), tokenId, Utils_ZERO());
       const canonFrom = Utils_canonicalize<Bytes<32>, ContractAddress>(fromAddress);
       const newBalance = _balances.lookup(disclose(canonFrom)) - 1 as Uint<128>;
       _balances.insert(disclose(canonFrom), disclose(newBalance));
     }
 
-    if (!_isTargetZero(disclose(canonTo))) {
+    if (!Utils_isTargetZero(disclose(canonTo))) {
       if (!_balances.member(disclose(canonTo))) {
         _balances.insert(disclose(canonTo), 0);
       }
@@ -723,11 +711,11 @@ module NonFungibleToken {
                    tokenId: Uint<128>
                    ): [] {
     assertInitialized();
-    assert(!_isTargetZero(to), "NonFungibleToken: invalid receiver");
+    assert(!Utils_isTargetZero(to), "NonFungibleToken: invalid receiver");
 
-    const previousOwner = _update(to, tokenId, ZERO());
+    const previousOwner = _update(to, tokenId, Utils_ZERO());
 
-    assert(_isTargetZero(previousOwner), "NonFungibleToken: invalid sender");
+    assert(Utils_isTargetZero(previousOwner), "NonFungibleToken: invalid sender");
   }
 
   /**
@@ -747,8 +735,8 @@ module NonFungibleToken {
    */
   export circuit _burn(tokenId: Uint<128>): [] {
     assertInitialized();
-    const previousOwner = _update(ZERO(), tokenId, ZERO());
-    assert(!_isTargetZero(previousOwner), "NonFungibleToken: invalid sender");
+    const previousOwner = _update(Utils_ZERO(), tokenId, Utils_ZERO());
+    assert(!Utils_isTargetZero(previousOwner), "NonFungibleToken: invalid sender");
     _tokenURIs.remove(disclose(tokenId));
   }
 
@@ -814,11 +802,11 @@ module NonFungibleToken {
                    tokenId: Uint<128>
                    ): [] {
     assertInitialized();
-    assert(!_isTargetZero(to), "NonFungibleToken: invalid receiver");
+    assert(!Utils_isTargetZero(to), "NonFungibleToken: invalid receiver");
 
-    const previousOwner = _update(to, tokenId, ZERO());
+    const previousOwner = _update(to, tokenId, Utils_ZERO());
 
-    assert(!_isTargetZero(previousOwner), "NonFungibleToken: nonexistent token");
+    assert(!Utils_isTargetZero(previousOwner), "NonFungibleToken: nonexistent token");
 
     const canonFrom = Utils_canonicalize<Bytes<32>, ContractAddress>(fromAddress);
     assert(previousOwner == canonFrom, "NonFungibleToken: incorrect owner");
@@ -848,12 +836,12 @@ module NonFungibleToken {
     assertInitialized();
     // Canonicalize + normalize `to`
     const canonTo = Utils_canonicalize<Bytes<32>, ContractAddress>(to);
-    const normalizedTo = _isTargetZero(canonTo) ? ZERO() : canonTo;
+    const normalizedTo = Utils_isTargetZero(canonTo) ? Utils_ZERO() : canonTo;
 
     // Canonicalize auth
     const canonAuth = Utils_canonicalize<Bytes<32>, ContractAddress>(auth);
 
-    if (!_isTargetZero(disclose(canonAuth))) {
+    if (!Utils_isTargetZero(disclose(canonAuth))) {
       const owner = _requireOwned(tokenId);
 
       // We do not use _isAuthorized because single-token approvals should not be able to call approve
@@ -888,10 +876,10 @@ module NonFungibleToken {
                    ): [] {
     assertInitialized();
     const canonOwner = Utils_canonicalize<Bytes<32>, ContractAddress>(owner);
-    assert(!_isTargetZero(canonOwner), "NonFungibleToken: invalid owner");
+    assert(!Utils_isTargetZero(canonOwner), "NonFungibleToken: invalid owner");
 
     const canonOp = Utils_canonicalize<Bytes<32>, ContractAddress>(operator);
-    assert(!_isTargetZero(canonOp), "NonFungibleToken: invalid operator");
+    assert(!Utils_isTargetZero(canonOp), "NonFungibleToken: invalid operator");
 
     if (!_operatorApprovals.member(disclose(canonOwner))) {
       _operatorApprovals.insert(
@@ -921,7 +909,7 @@ module NonFungibleToken {
     assertInitialized();
     const owner = _ownerOf(tokenId);
 
-    assert(!_isTargetZero(owner), "NonFungibleToken: nonexistent token");
+    assert(!Utils_isTargetZero(owner), "NonFungibleToken: nonexistent token");
     return owner;
   }
 
@@ -936,52 +924,6 @@ module NonFungibleToken {
    * @returns {Bytes<32>} accountId - The computed account identifier.
    */
   circuit _computeAccountId(): Bytes<32> {
-    return computeAccountId(wit_NonFungibleTokenSK());
-  }
-
-  /**
-   * @description Computes an account identifier without on-chain state, allowing a user to derive
-   * their identity commitment before submitting it in a token operation.
-   * This is the off-chain counterpart to {_computeAccountId} and produces an identical result
-   * given the same inputs.
-   *
-   * @warning OpSec: The `secretKey` parameter is a sensitive secret. Mishandling it can
-   * permanently compromise the security of this system:
-   *
-   * - **Never log or persist** the `secretKey` in plaintext — avoid browser devtools,
-   *   application logs, analytics pipelines, or any observable side-channel.
-   * - **Store offline or in secure enclaves** — hardware security modules (HSMs),
-   *   air-gapped devices, or encrypted vaults are strongly preferred over hot storage.
-   * - **Use cryptographically secure randomness** — generate keys with `crypto.getRandomValues()`
-   *   or equivalent; weak or predictable keys can be brute-forced to reveal your identity.
-   * - **Treat key loss as identity loss** — a lost key cannot be recovered.
-   * - **Avoid calling this circuit in untrusted environments** — executing this in an
-   *   unverified browser extension, compromised runtime, or shared machine may expose
-   *   the key to a malicious observer.
-   *
-   * ## ID Derivation
-   * `accountId = persistentHash(secretKey)`
-   *
-   * @param {Bytes<32>} secretKey - A 32-byte cryptographically secure random value.
-   *
-   * @returns {Bytes<32>} accountId - The computed account identifier.
-   */
-  export pure circuit computeAccountId(secretKey: Bytes<32>): Bytes<32> {
-    return persistentHash<Vector<1, Bytes<32>>>([secretKey]);
-  }
-
-  /**
-   * @description Returns `true` if `target`'s active branch (as indicated by `is_left`)
-   * holds the zero value.
-   *
-   * @param {Either<Bytes<32>, ContractAddress>} target - The value to check.
-   * @returns {Boolean} - `true` if the active branch is zero, `false` otherwise.
-   */
-  circuit _isTargetZero(target: Either<Bytes<32>, ContractAddress>): Boolean {
-    if (target.is_left) {
-      return target.left == default<Bytes<32>>;
-    } else {
-      return target.right == default<ContractAddress>;
-    }
+    return Utils_computeAccountId(wit_NonFungibleTokenSK());
   }
 }

--- a/contracts/src/token/NonFungibleToken.compact
+++ b/contracts/src/token/NonFungibleToken.compact
@@ -523,7 +523,7 @@ module NonFungibleToken {
   export circuit _ownerOf(tokenId: Uint<128>): Either<Bytes<32>, ContractAddress> {
     assertInitialized();
     if (!_owners.member(disclose(tokenId))) {
-      return Utils_ZERO();
+      return Utils_zeroAccount();
     }
 
     return _owners.lookup(disclose(tokenId));
@@ -544,7 +544,7 @@ module NonFungibleToken {
   export circuit _getApproved(tokenId: Uint<128>): Either<Bytes<32>, ContractAddress> {
     assertInitialized();
     if (!_tokenApprovals.member(disclose(tokenId))) {
-      return Utils_ZERO();
+      return Utils_zeroAccount();
     }
     return _tokenApprovals.lookup(disclose(tokenId));
   }
@@ -644,7 +644,7 @@ module NonFungibleToken {
     // Execute the update
     if (!Utils_isTargetZero(disclose(fromAddress))) {
       // Clear approval. No need to re-authorize
-      _approve(Utils_ZERO(), tokenId, Utils_ZERO());
+      _approve(Utils_zeroAccount(), tokenId, Utils_zeroAccount());
       const canonFrom = Utils_canonicalize<Bytes<32>, ContractAddress>(fromAddress);
       const newBalance = _balances.lookup(disclose(canonFrom)) - 1 as Uint<128>;
       _balances.insert(disclose(canonFrom), disclose(newBalance));
@@ -713,7 +713,7 @@ module NonFungibleToken {
     assertInitialized();
     assert(!Utils_isTargetZero(to), "NonFungibleToken: invalid receiver");
 
-    const previousOwner = _update(to, tokenId, Utils_ZERO());
+    const previousOwner = _update(to, tokenId, Utils_zeroAccount());
 
     assert(Utils_isTargetZero(previousOwner), "NonFungibleToken: invalid sender");
   }
@@ -735,7 +735,7 @@ module NonFungibleToken {
    */
   export circuit _burn(tokenId: Uint<128>): [] {
     assertInitialized();
-    const previousOwner = _update(Utils_ZERO(), tokenId, Utils_ZERO());
+    const previousOwner = _update(Utils_zeroAccount(), tokenId, Utils_zeroAccount());
     assert(!Utils_isTargetZero(previousOwner), "NonFungibleToken: invalid sender");
     _tokenURIs.remove(disclose(tokenId));
   }
@@ -804,7 +804,7 @@ module NonFungibleToken {
     assertInitialized();
     assert(!Utils_isTargetZero(to), "NonFungibleToken: invalid receiver");
 
-    const previousOwner = _update(to, tokenId, Utils_ZERO());
+    const previousOwner = _update(to, tokenId, Utils_zeroAccount());
 
     assert(!Utils_isTargetZero(previousOwner), "NonFungibleToken: nonexistent token");
 
@@ -836,7 +836,7 @@ module NonFungibleToken {
     assertInitialized();
     // Canonicalize + normalize `to`
     const canonTo = Utils_canonicalize<Bytes<32>, ContractAddress>(to);
-    const normalizedTo = Utils_isTargetZero(canonTo) ? Utils_ZERO() : canonTo;
+    const normalizedTo = Utils_isTargetZero(canonTo) ? Utils_zeroAccount() : canonTo;
 
     // Canonicalize auth
     const canonAuth = Utils_canonicalize<Bytes<32>, ContractAddress>(auth);

--- a/contracts/src/token/test/FungibleToken.test.ts
+++ b/contracts/src/token/test/FungibleToken.test.ts
@@ -158,33 +158,6 @@ describe('FungibleToken', () => {
       token = new FungibleTokenSimulator(NAME, SYMBOL, DECIMALS, INIT);
     });
 
-    describe('ZERO', () => {
-      it('should return a left variant', () => {
-        const zero = token.ZERO();
-        expect(zero.is_left).toBe(true);
-      });
-
-      it('should have zero left branch', () => {
-        const zero = token.ZERO();
-        expect(zero.left).toEqual(zeroBytes);
-      });
-
-      it('should have zero right branch', () => {
-        const zero = token.ZERO();
-        expect(zero.right).toEqual({ bytes: zeroBytes });
-      });
-
-      it('should be canonical', () => {
-        const zero = token.ZERO();
-        expect(zero).toEqual(ZERO_ACCOUNT);
-      });
-
-      it('should not equal a right-variant zero', () => {
-        const zero = token.ZERO();
-        expect(zero).not.toEqual(ZERO_CONTRACT);
-      });
-    });
-
     describe('totalSupply', () => {
       it('returns 0 when there is no supply', () => {
         expect(token.totalSupply()).toEqual(0n);
@@ -1150,27 +1123,6 @@ describe('FungibleToken', () => {
         token._burn(OWNER.either, 1n);
         expect(token.totalSupply()).toEqual(AMOUNT - 1n);
         expect(token.balanceOf(OWNER.either)).toEqual(0n);
-      });
-    });
-    describe('computeAccountId', () => {
-      const users = [OWNER, SPENDER, RECIPIENT, UNAUTHORIZED];
-
-      it('should match the test helper derivation', () => {
-        for (let i = 0; i < users.length; i++) {
-          expect(token.computeAccountId(users[i].secretKey)).toEqual(
-            users[i].accountId,
-          );
-        }
-      });
-
-      it('should produce distinct identifiers for distinct keys', () => {
-        const ids = users.map((u) => token.computeAccountId(u.secretKey));
-
-        for (let i = 0; i < ids.length; i++) {
-          for (let j = i + 1; j < ids.length; j++) {
-            expect(ids[i]).not.toEqual(ids[j]);
-          }
-        }
       });
     });
   });

--- a/contracts/src/token/test/MultiToken.test.ts
+++ b/contracts/src/token/test/MultiToken.test.ts
@@ -870,7 +870,7 @@ describe('MultiToken', () => {
           it('should fail with transfer from zero', () => {
             // With witness-based identity, the caller is H(sk) which is
             // always non-zero. Transferring from ZERO_ACCOUNT means
-            // canonFrom != caller → isApprovedForAll(ZERO, caller) → false
+            // canonFrom != caller → isApprovedForAll(zeroAccount, caller) → false
             // → "unauthorized operator"
             expect(() => {
               token._unsafeTransferFrom(

--- a/contracts/src/token/test/MultiToken.test.ts
+++ b/contracts/src/token/test/MultiToken.test.ts
@@ -189,27 +189,6 @@ describe('MultiToken', () => {
       token = new MultiTokenSimulator(initWithURI);
     });
 
-    describe('computeAccountId', () => {
-      const users = [OWNER, SPENDER, RECIPIENT, UNAUTHORIZED];
-
-      it('should match the test helper derivation', () => {
-        for (const user of users) {
-          expect(token.computeAccountId(user.secretKey)).toEqual(
-            user.accountId,
-          );
-        }
-      });
-
-      it('should produce distinct identifiers for distinct keys', () => {
-        const ids = users.map((u) => token.computeAccountId(u.secretKey));
-        for (let i = 0; i < ids.length; i++) {
-          for (let j = i + 1; j < ids.length; j++) {
-            expect(ids[i]).not.toEqual(ids[j]);
-          }
-        }
-      });
-    });
-
     describe('balanceOf', () => {
       const ownerTypes = [
         ['contract', OWNER_CONTRACT],
@@ -1350,33 +1329,6 @@ describe('MultiToken', () => {
 
         token._setApprovalForAll(nonCanonicalOwner, nonCanonicalOp, true);
         expect(token.isApprovedForAll(OWNER.either, SPENDER.either)).toBe(true);
-      });
-    });
-
-    describe('ZERO', () => {
-      it('should return a left variant', () => {
-        const zero = token.ZERO();
-        expect(zero.is_left).toBe(true);
-      });
-
-      it('should have zero left branch', () => {
-        const zero = token.ZERO();
-        expect(zero.left).toEqual(zeroBytes);
-      });
-
-      it('should have zero right branch', () => {
-        const zero = token.ZERO();
-        expect(zero.right).toEqual({ bytes: zeroBytes });
-      });
-
-      it('should be canonical', () => {
-        const zero = token.ZERO();
-        expect(zero).toEqual(ZERO_ACCOUNT);
-      });
-
-      it('should not equal a right-variant zero', () => {
-        const zero = token.ZERO();
-        expect(zero).not.toEqual(ZERO_CONTRACT);
       });
     });
   });

--- a/contracts/src/token/test/mocks/MockFungibleToken.compact
+++ b/contracts/src/token/test/mocks/MockFungibleToken.compact
@@ -31,10 +31,6 @@ constructor(
   }
 }
 
-export pure circuit ZERO(): Either<Bytes<32>, ContractAddress> {
-  return FungibleToken_ZERO();
-}
-
 export circuit name(): Opaque<"string"> {
   return FungibleToken_name();
 }
@@ -143,6 +139,3 @@ export circuit _spendAllowance(
   return FungibleToken__spendAllowance(owner, spender, value);
 }
 
-export pure circuit computeAccountId(secretKey: Bytes<32>): Bytes<32> {
-  return FungibleToken_computeAccountId(secretKey);
-}

--- a/contracts/src/token/test/mocks/MockMultiToken.compact
+++ b/contracts/src/token/test/mocks/MockMultiToken.compact
@@ -27,10 +27,6 @@ constructor(
   }
 }
 
-export pure circuit ZERO(): Either<Bytes<32>, ContractAddress> {
-  return MultiToken_ZERO();
-}
-
 export circuit initialize(_uri: Opaque<"string">): [] {
   return MultiToken_initialize(_uri);
 }
@@ -114,6 +110,3 @@ export circuit _setApprovalForAll(
   return MultiToken__setApprovalForAll(owner, operator, approved);
 }
 
-export pure circuit computeAccountId(secretKey: Bytes<32>): Bytes<32> {
-  return MultiToken_computeAccountId(secretKey);
-}

--- a/contracts/src/token/test/mocks/MockNonFungibleToken.compact
+++ b/contracts/src/token/test/mocks/MockNonFungibleToken.compact
@@ -29,10 +29,6 @@ constructor(
   }
 }
 
-export pure circuit ZERO(): Either<Bytes<32>, ContractAddress> {
-  return NonFungibleToken_ZERO();
-}
-
 export circuit name(): Opaque<"string"> {
   return NonFungibleToken_name();
 }
@@ -176,6 +172,3 @@ export circuit _unsafeMint(
   return NonFungibleToken__unsafeMint(to, tokenId);
 }
 
-export pure circuit computeAccountId(secretKey: Bytes<32>): Bytes<32> {
-  return NonFungibleToken_computeAccountId(secretKey);
-}

--- a/contracts/src/token/test/nonFungibleToken.test.ts
+++ b/contracts/src/token/test/nonFungibleToken.test.ts
@@ -120,52 +120,6 @@ describe('NonFungibleToken', () => {
     token = new NonFungibleTokenSimulator(NAME, SYMBOL, INIT);
   });
 
-  describe('computeAccountId', () => {
-    const users = [OWNER, SPENDER, RECIPIENT, UNAUTHORIZED];
-
-    it('should match the test helper derivation', () => {
-      for (const user of users) {
-        expect(token.computeAccountId(user.secretKey)).toEqual(user.accountId);
-      }
-    });
-
-    it('should produce distinct identifiers for distinct keys', () => {
-      const ids = users.map((u) => token.computeAccountId(u.secretKey));
-      for (let i = 0; i < ids.length; i++) {
-        for (let j = i + 1; j < ids.length; j++) {
-          expect(ids[i]).not.toEqual(ids[j]);
-        }
-      }
-    });
-  });
-
-  describe('ZERO', () => {
-    it('should return a left variant', () => {
-      const zero = token.ZERO();
-      expect(zero.is_left).toBe(true);
-    });
-
-    it('should have zero left branch', () => {
-      const zero = token.ZERO();
-      expect(zero.left).toEqual(zeroBytes);
-    });
-
-    it('should have zero right branch', () => {
-      const zero = token.ZERO();
-      expect(zero.right).toEqual({ bytes: zeroBytes });
-    });
-
-    it('should be canonical', () => {
-      const zero = token.ZERO();
-      expect(zero).toEqual(ZERO_ACCOUNT);
-    });
-
-    it('should not equal a right-variant zero', () => {
-      const zero = token.ZERO();
-      expect(zero).not.toEqual(ZERO_CONTRACT);
-    });
-  });
-
   describe('balanceOf', () => {
     it('should return zero when requested account has no balance', () => {
       expect(token.balanceOf(OWNER.either)).toEqual(0n);

--- a/contracts/src/token/test/nonFungibleToken.test.ts
+++ b/contracts/src/token/test/nonFungibleToken.test.ts
@@ -677,7 +677,7 @@ describe('NonFungibleToken', () => {
 
       token.transferFrom(OWNER.either, RECIPIENT.either, TOKENID_1);
 
-      // _update calls _approve(ZERO(), tokenId, ZERO()) internally,
+      // _update calls _approve(zeroAccount(), tokenId, zeroAccount()) internally,
       // which should store the left-variant zero
       expect(token.getApproved(TOKENID_1)).toEqual(ZERO_ACCOUNT);
     });
@@ -757,17 +757,17 @@ describe('NonFungibleToken', () => {
       expect(token.getApproved(TOKENID_1)).toEqual(SPENDER.either);
     });
 
-    it('should normalize right-variant zero to ZERO()', () => {
+    it('should normalize right-variant zero to zeroAccount()', () => {
       token._mint(OWNER.either, TOKENID_1);
 
       // Approve with a right-variant zero (contract address zero)
       token._approve(ZERO_CONTRACT, TOKENID_1, OWNER.either);
 
-      // getApproved should return the left-variant ZERO, not the right-variant
+      // getApproved should return the left-variant zeroAccount, not the right-variant
       expect(token.getApproved(TOKENID_1)).toEqual(ZERO_ACCOUNT);
     });
 
-    it('should normalize left-variant zero to ZERO()', () => {
+    it('should normalize left-variant zero to zeroAccount()', () => {
       token._mint(OWNER.either, TOKENID_1);
 
       // First set a real approval

--- a/contracts/src/token/test/simulators/FungibleTokenSimulator.ts
+++ b/contracts/src/token/test/simulators/FungibleTokenSimulator.ts
@@ -60,16 +60,6 @@ export class FungibleTokenSimulator extends FungibleTokenSimulatorBase {
     super([name, symbol, decimals, init], options);
   }
   /**
-   * @description Returns a canonical zero Either value for Bytes<32> and ContractAddress.
-   * This circuit returns the left variant (Bytes<32>) to avoid misleading contract-to-contract
-   * error messages.
-   * @returns The zero value.
-   */
-  public ZERO(): Either<Uint8Array, ContractAddress> {
-    return this.circuits.pure.ZERO();
-  }
-
-  /**
    * @description Returns the token name.
    * @returns The token name.
    */
@@ -289,16 +279,6 @@ export class FungibleTokenSimulator extends FungibleTokenSimulatorBase {
     value: bigint,
   ) {
     this.circuits.impure._spendAllowance(owner, spender, value);
-  }
-
-  /**
-   * @description Computes an account identifier without on-chain state, allowing a user to derive
-   * their identity commitment before submitting it in a grant or revoke operation.
-   * @param {Bytes<32>} secretKey - A 32-byte cryptographically secure random value.
-   * @returns {Bytes<32>} accountId - The computed account identifier.
-   */
-  public computeAccountId(secretKey: Uint8Array): Uint8Array {
-    return this.circuits.pure.computeAccountId(secretKey);
   }
 
   public readonly privateState = {

--- a/contracts/src/token/test/simulators/MultiTokenSimulator.ts
+++ b/contracts/src/token/test/simulators/MultiTokenSimulator.ts
@@ -48,10 +48,6 @@ export class MultiTokenSimulator extends MultiTokenSimulatorBase {
     super([_uri], options);
   }
 
-  public ZERO(): Either<Uint8Array, ContractAddress> {
-    return this.circuits.pure.ZERO();
-  }
-
   /**
    * @description Initializes the contract. This is already executed in the simulator constructor;
    * however, this method enables the tests to assert it cannot be called again.
@@ -243,16 +239,6 @@ export class MultiTokenSimulator extends MultiTokenSimulatorBase {
     approved: boolean,
   ) {
     this.circuits.impure._setApprovalForAll(owner, operator, approved);
-  }
-
-  /**
-   * @description Computes an account identifier without on-chain state, allowing a user to derive
-   * their identity commitment before submitting it in a grant or revoke operation.
-   * @param {Bytes<32>} secretKey - A 32-byte cryptographically secure random value.
-   * @returns {Bytes<32>} accountId - The computed account identifier.
-   */
-  public computeAccountId(secretKey: Uint8Array): Uint8Array {
-    return this.circuits.pure.computeAccountId(secretKey);
   }
 
   public readonly privateState = {

--- a/contracts/src/token/test/simulators/NonFungibleTokenSimulator.ts
+++ b/contracts/src/token/test/simulators/NonFungibleTokenSimulator.ts
@@ -54,14 +54,6 @@ export class NonFungibleTokenSimulator extends NonFungibleTokenSimulatorBase {
   }
 
   /**
-   * @description Returns a canonical zero Either value (left variant with zero Bytes<32>).
-   * @return The zero value.
-   */
-  public ZERO(): Either<Uint8Array, ContractAddress> {
-    return this.circuits.pure.ZERO();
-  }
-
-  /**
    * @description Returns the token name.
    * @returns The token name.
    */
@@ -434,16 +426,6 @@ export class NonFungibleTokenSimulator extends NonFungibleTokenSimulatorBase {
    */
   public _unsafeMint(to: Either<Uint8Array, ContractAddress>, tokenId: bigint) {
     this.circuits.impure._unsafeMint(to, tokenId);
-  }
-
-  /**
-   * @description Computes an account identifier without on-chain state, allowing a user to derive
-   * their identity commitment before submitting it in a grant or revoke operation.
-   * @param {Bytes<32>} secretKey - A 32-byte cryptographically secure random value.
-   * @returns {Bytes<32>} accountId - The computed account identifier.
-   */
-  public computeAccountId(secretKey: Uint8Array): Uint8Array {
-    return this.circuits.pure.computeAccountId(secretKey);
   }
 
   public readonly privateState = {

--- a/contracts/src/utils/Utils.compact
+++ b/contracts/src/utils/Utils.compact
@@ -97,6 +97,63 @@ module Utils {
   }
 
   /**
+   * @description Returns a canonical zero `Either<Bytes<32>, ContractAddress>` value.
+   * This circuit returns the left variant (`Bytes<32>`) to avoid misleading
+   * contract-to-contract error messages.
+   *
+   * @return {Either<Bytes<32>, ContractAddress>} - The zero value.
+   */
+  export pure circuit ZERO(): Either<Bytes<32>, ContractAddress> {
+    return Either<Bytes<32>, ContractAddress> {
+      is_left: true, left: default<Bytes<32>>, right: default<ContractAddress>
+    };
+  }
+
+  /**
+   * @description Returns `true` if `target`'s active branch (as indicated by `is_left`)
+   * holds the zero value.
+   *
+   * @param {Either<Bytes<32>, ContractAddress>} target - The value to check.
+   * @return {Boolean} - `true` if the active branch is zero, `false` otherwise.
+   */
+  export pure circuit isTargetZero(target: Either<Bytes<32>, ContractAddress>): Boolean {
+    if (target.is_left) {
+      return target.left == default<Bytes<32>>;
+    } else {
+      return target.right == default<ContractAddress>;
+    }
+  }
+
+  /**
+   * @description Computes an account identifier without on-chain state, allowing a user to derive
+   * their identity commitment before submitting an operation.
+   *
+   * @warning OpSec: The `secretKey` parameter is a sensitive secret. Mishandling it can
+   * permanently compromise the security of this system:
+   *
+   * - **Never log or persist** the `secretKey` in plaintext — avoid browser devtools,
+   *   application logs, analytics pipelines, or any observable side-channel.
+   * - **Store offline or in secure enclaves** — hardware security modules (HSMs),
+   *   air-gapped devices, or encrypted vaults are strongly preferred over hot storage.
+   * - **Use cryptographically secure randomness** — generate keys with `crypto.getRandomValues()`
+   *   or equivalent; weak or predictable keys can be brute-forced to reveal your identity.
+   * - **Treat key loss as identity loss** — a lost key cannot be recovered.
+   * - **Avoid calling this circuit in untrusted environments** — executing this in an
+   *   unverified browser extension, compromised runtime, or shared machine may expose
+   *   the key to a malicious observer.
+   *
+   * ## ID Derivation
+   * `accountId = persistentHash(secretKey)`
+   *
+   * @param {Bytes<32>} secretKey - A 32-byte cryptographically secure random value.
+   *
+   * @returns {Bytes<32>} accountId - The computed account identifier.
+   */
+  export pure circuit computeAccountId(secretKey: Bytes<32>): Bytes<32> {
+    return persistentHash<Vector<1, Bytes<32>>>([secretKey]);
+  }
+
+  /**
    * @description Returns the current contract's address as an
    * `Either<ZswapCoinPublicKey, ContractAddress>` for use as a
    * recipient in shielded send operations (deposits and receiving change).

--- a/contracts/src/utils/Utils.compact
+++ b/contracts/src/utils/Utils.compact
@@ -97,13 +97,18 @@ module Utils {
   }
 
   /**
-   * @description Returns a canonical zero `Either<Bytes<32>, ContractAddress>` value.
-   * This circuit returns the left variant (`Bytes<32>`) to avoid misleading
-   * contract-to-contract error messages.
+   * @description Returns the canonical zero `Either<Bytes<32>, ContractAddress>` value: the
+   * left variant (`Bytes<32>`) set to zero. Used as the sentinel for mint/burn operations
+   * (a zero `from` signals a mint, a zero `to` signals a burn) and for cleared approvals.
    *
-   * @return {Either<Bytes<32>, ContractAddress>} - The zero value.
+   * The left variant is chosen so that `isTargetZero` checks against `default<Bytes<32>>`,
+   * and to avoid triggering contract-address guards (e.g. circuits that check `!to.is_left`
+   * before delegating to an `_unsafe` variant). A right variant with `default<ContractAddress>`
+   * would also pass `isTargetZero`, but the left variant keeps guards and error messages consistent.
+   *
+   * @return {Either<Bytes<32>, ContractAddress>} - The canonical zero value.
    */
-  export pure circuit ZERO(): Either<Bytes<32>, ContractAddress> {
+  export pure circuit zeroAccount(): Either<Bytes<32>, ContractAddress> {
     return Either<Bytes<32>, ContractAddress> {
       is_left: true, left: default<Bytes<32>>, right: default<ContractAddress>
     };

--- a/contracts/src/utils/test/mocks/MockUtils.compact
+++ b/contracts/src/utils/test/mocks/MockUtils.compact
@@ -50,8 +50,8 @@ export pure circuit UINT128_MAX(): Uint<128> {
   return Utils_UINT128_MAX();
 }
 
-export pure circuit ZERO(): Either<Bytes<32>, ContractAddress> {
-  return Utils_ZERO();
+export pure circuit zeroAccount(): Either<Bytes<32>, ContractAddress> {
+  return Utils_zeroAccount();
 }
 
 export pure circuit isTargetZero(target: Either<Bytes<32>, ContractAddress>): Boolean {

--- a/contracts/src/utils/test/mocks/MockUtils.compact
+++ b/contracts/src/utils/test/mocks/MockUtils.compact
@@ -49,3 +49,15 @@ export circuit selfAsRecipient(): Either<ZswapCoinPublicKey, ContractAddress> {
 export pure circuit UINT128_MAX(): Uint<128> {
   return Utils_UINT128_MAX();
 }
+
+export pure circuit ZERO(): Either<Bytes<32>, ContractAddress> {
+  return Utils_ZERO();
+}
+
+export pure circuit isTargetZero(target: Either<Bytes<32>, ContractAddress>): Boolean {
+  return Utils_isTargetZero(target);
+}
+
+export pure circuit computeAccountId(secretKey: Bytes<32>): Bytes<32> {
+  return Utils_computeAccountId(secretKey);
+}

--- a/contracts/src/utils/test/simulators/UtilsSimulator.ts
+++ b/contracts/src/utils/test/simulators/UtilsSimulator.ts
@@ -128,4 +128,32 @@ export class UtilsSimulator extends UtilsSimulatorBase {
   public UINT128_MAX(): bigint {
     return this.circuits.pure.UINT128_MAX();
   }
+
+  /**
+   * @description Returns a canonical zero `Either<Bytes<32>, ContractAddress>` value
+   * (left variant with zero `Bytes<32>`).
+   * @returns The zero value.
+   */
+  public ZERO(): Either<Uint8Array, ContractAddress> {
+    return this.circuits.pure.ZERO();
+  }
+
+  /**
+   * @description Returns whether `target`'s active branch holds the zero value.
+   * @param target The value to check.
+   * @returns Returns true if the active branch is zero.
+   */
+  public isTargetZero(target: Either<Uint8Array, ContractAddress>): boolean {
+    return this.circuits.pure.isTargetZero(target);
+  }
+
+  /**
+   * @description Computes an account identifier without on-chain state, allowing a user to
+   * derive their identity commitment before submitting an operation.
+   * @param secretKey A 32-byte cryptographically secure random value.
+   * @returns The computed account identifier.
+   */
+  public computeAccountId(secretKey: Uint8Array): Uint8Array {
+    return this.circuits.pure.computeAccountId(secretKey);
+  }
 }

--- a/contracts/src/utils/test/simulators/UtilsSimulator.ts
+++ b/contracts/src/utils/test/simulators/UtilsSimulator.ts
@@ -130,12 +130,12 @@ export class UtilsSimulator extends UtilsSimulatorBase {
   }
 
   /**
-   * @description Returns a canonical zero `Either<Bytes<32>, ContractAddress>` value
+   * @description Returns the canonical zero `Either<Bytes<32>, ContractAddress>` value
    * (left variant with zero `Bytes<32>`).
-   * @returns The zero value.
+   * @returns The canonical zero value.
    */
-  public ZERO(): Either<Uint8Array, ContractAddress> {
-    return this.circuits.pure.ZERO();
+  public zeroAccount(): Either<Uint8Array, ContractAddress> {
+    return this.circuits.pure.zeroAccount();
   }
 
   /**

--- a/contracts/src/utils/test/utils.test.ts
+++ b/contracts/src/utils/test/utils.test.ts
@@ -1,3 +1,8 @@
+import {
+  CompactTypeBytes,
+  CompactTypeVector,
+  persistentHash,
+} from '@midnight-ntwrk/compact-runtime';
 import { describe, expect, it } from 'vitest';
 import * as contractUtils from '#test-utils/address.js';
 import { UtilsSimulator } from './simulators/UtilsSimulator.js';
@@ -10,6 +15,32 @@ const OTHER_CONTRACT =
   contractUtils.createEitherTestContractAddress('OTHER_CONTRACT');
 
 const EMPTY_STRING = '';
+
+// Helpers for the `Either<Bytes<32>, ContractAddress>` account-identifier domain.
+const zeroBytes = contractUtils.zeroUint8Array();
+
+const buildAccountIdHash = (sk: Uint8Array): Uint8Array => {
+  const rt_type = new CompactTypeVector(1, new CompactTypeBytes(32));
+  return persistentHash(rt_type, [sk]);
+};
+
+const createTestSK = (label: string): Uint8Array => {
+  const sk = new Uint8Array(32);
+  sk.set(new TextEncoder().encode(label).slice(0, 32));
+  return sk;
+};
+
+const eitherAccount = (accountId: Uint8Array) => ({
+  is_left: true,
+  left: accountId,
+  right: { bytes: zeroBytes },
+});
+
+const eitherContract = (str: string) => ({
+  is_left: false,
+  left: zeroBytes,
+  right: contractUtils.encodeToAddress(str),
+});
 
 let contract: UtilsSimulator;
 
@@ -169,6 +200,63 @@ describe('Utils', () => {
   describe('UINT128_MAX', () => {
     it('should return 2^128 - 1', () => {
       expect(contract.UINT128_MAX()).toBe((1n << 128n) - 1n);
+    });
+  });
+
+  describe('ZERO', () => {
+    it('should return a left variant', () => {
+      expect(contract.ZERO().is_left).toBe(true);
+    });
+
+    it('should have zero left and right branches', () => {
+      const zero = contract.ZERO();
+      expect(zero.left).toEqual(zeroBytes);
+      expect(zero.right).toEqual({ bytes: zeroBytes });
+    });
+  });
+
+  describe('isTargetZero', () => {
+    it('should return true for the canonical zero account', () => {
+      expect(contract.isTargetZero(contract.ZERO())).toBe(true);
+    });
+
+    it('should return true for a zero right-variant (contract)', () => {
+      expect(
+        contract.isTargetZero({
+          is_left: false,
+          left: zeroBytes,
+          right: { bytes: zeroBytes },
+        }),
+      ).toBe(true);
+    });
+
+    it('should return false for a nonzero account (left variant)', () => {
+      const account = eitherAccount(buildAccountIdHash(createTestSK('ACCT')));
+      expect(contract.isTargetZero(account)).toBe(false);
+    });
+
+    it('should return false for a nonzero contract (right variant)', () => {
+      expect(contract.isTargetZero(eitherContract('SOME_CONTRACT'))).toBe(
+        false,
+      );
+    });
+  });
+
+  describe('computeAccountId', () => {
+    it('should match the persistentHash derivation', () => {
+      const sk = createTestSK('SOME_SK');
+      expect(contract.computeAccountId(sk)).toEqual(buildAccountIdHash(sk));
+    });
+
+    it('should produce distinct identifiers for distinct keys', () => {
+      const ids = ['A', 'B', 'C'].map((label) =>
+        contract.computeAccountId(createTestSK(label)),
+      );
+      for (let i = 0; i < ids.length; i++) {
+        for (let j = i + 1; j < ids.length; j++) {
+          expect(ids[i]).not.toEqual(ids[j]);
+        }
+      }
     });
   });
 

--- a/contracts/src/utils/test/utils.test.ts
+++ b/contracts/src/utils/test/utils.test.ts
@@ -203,13 +203,13 @@ describe('Utils', () => {
     });
   });
 
-  describe('ZERO', () => {
+  describe('zeroAccount', () => {
     it('should return a left variant', () => {
-      expect(contract.ZERO().is_left).toBe(true);
+      expect(contract.zeroAccount().is_left).toBe(true);
     });
 
     it('should have zero left and right branches', () => {
-      const zero = contract.ZERO();
+      const zero = contract.zeroAccount();
       expect(zero.left).toEqual(zeroBytes);
       expect(zero.right).toEqual({ bytes: zeroBytes });
     });
@@ -217,7 +217,7 @@ describe('Utils', () => {
 
   describe('isTargetZero', () => {
     it('should return true for the canonical zero account', () => {
-      expect(contract.isTargetZero(contract.ZERO())).toBe(true);
+      expect(contract.isTargetZero(contract.zeroAccount())).toBe(true);
     });
 
     it('should return true for a zero right-variant (contract)', () => {


### PR DESCRIPTION
The tracked issues for this are not really clean bc we'd be putting in the same circuits into Utils for each PR if they were separate. Bundling into one PR seems appropriate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated account identifier computation and zero-value validation into centralized utility module.
  * Removed duplicate `ZERO()` and `computeAccountId()` implementations from individual token and access control modules.
  * Updated internal references to use shared utility functions across all modules.

* **Tests**
  * Removed test coverage for previously consolidated utility functions from individual module test suites.
  * Added comprehensive test coverage for new centralized utility functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->