### PR TITLE
fix version in spdx

### DIFF
--- a/contracts/src/multisig/ForwarderPrivate.compact
+++ b/contracts/src/multisig/ForwarderPrivate.compact
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Compact Contracts v0.0.1-alpha.1 (multisig/ForwarderPrivate.compact)
+// OpenZeppelin Compact Contracts v0.2.0 (multisig/ForwarderPrivate.compact)
 
 pragma language_version >= 0.23.0;
 

--- a/contracts/src/multisig/ProposalManager.compact
+++ b/contracts/src/multisig/ProposalManager.compact
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Compact Contracts v0.0.1-alpha.1 (multisig/ProposalManager.compact)
+// OpenZeppelin Compact Contracts v0.2.0 (multisig/ProposalManager.compact)
 
 pragma language_version >= 0.23.0;
 

--- a/contracts/src/multisig/ShieldedTreasury.compact
+++ b/contracts/src/multisig/ShieldedTreasury.compact
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Compact Contracts v0.0.1-alpha.1 (multisig/ShieldedTreasury.compact)
+// OpenZeppelin Compact Contracts v0.2.0 (multisig/ShieldedTreasury.compact)
 
 pragma language_version >= 0.23.0;
 

--- a/contracts/src/multisig/ShieldedTreasuryStateless.compact
+++ b/contracts/src/multisig/ShieldedTreasuryStateless.compact
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Compact Contracts v0.0.1-alpha.1 (multisig/ShieldedTreasuryStateless.compact)
+// OpenZeppelin Compact Contracts v0.2.0 (multisig/ShieldedTreasuryStateless.compact)
 
 pragma language_version >= 0.23.0;
 

--- a/contracts/src/multisig/Signer.compact
+++ b/contracts/src/multisig/Signer.compact
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Compact Contracts v0.0.1-alpha.1 (multisig/Signer.compact)
+// OpenZeppelin Compact Contracts v0.2.0 (multisig/Signer.compact)
 
 pragma language_version >= 0.23.0;
 

--- a/contracts/src/multisig/SignerManager.compact
+++ b/contracts/src/multisig/SignerManager.compact
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Compact Contracts v0.0.1-alpha.1 (multisig/SignerManager.compact)
+// OpenZeppelin Compact Contracts v0.2.0 (multisig/SignerManager.compact)
 
 pragma language_version >= 0.23.0;
 

--- a/contracts/src/multisig/UnshieldedTreasury.compact
+++ b/contracts/src/multisig/UnshieldedTreasury.compact
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Compact Contracts v0.0.1-alpha.1 (multisig/UnshieldedTreasury.compact)
+// OpenZeppelin Compact Contracts v0.2.0 (multisig/UnshieldedTreasury.compact)
 
 pragma language_version >= 0.23.0;
 

--- a/contracts/src/multisig/presets/ShieldedMultiSig.compact
+++ b/contracts/src/multisig/presets/ShieldedMultiSig.compact
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Compact Contracts v0.0.1-alpha.1 (multisig/presets/ShieldedMultiSig.compact)
+// OpenZeppelin Compact Contracts v0.2.0 (multisig/presets/ShieldedMultiSig.compact)
 
 pragma language_version >= 0.23.0;
 

--- a/contracts/src/multisig/presets/ShieldedMultiSigV2.compact
+++ b/contracts/src/multisig/presets/ShieldedMultiSigV2.compact
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Compact Contracts v0.0.1-alpha.1 (multisig/presets/ShieldedMultiSigV2.compact)
+// OpenZeppelin Compact Contracts v0.2.0 (multisig/presets/ShieldedMultiSigV2.compact)
 
 pragma language_version >= 0.23.0;
 

--- a/contracts/src/multisig/presets/forwarder/ForwarderPrivate.compact
+++ b/contracts/src/multisig/presets/forwarder/ForwarderPrivate.compact
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Compact Contracts v0.0.1-alpha.1 (multisig/presets/forwarder/ForwarderPrivate.compact)
+// OpenZeppelin Compact Contracts v0.2.0 (multisig/presets/forwarder/ForwarderPrivate.compact)
 
 pragma language_version >= 0.23.0;
 

--- a/contracts/src/multisig/presets/forwarder/ForwarderShielded.compact
+++ b/contracts/src/multisig/presets/forwarder/ForwarderShielded.compact
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Compact Contracts v0.0.1-alpha.1 (multisig/presets/forwarder/ForwarderShielded.compact)
+// OpenZeppelin Compact Contracts v0.2.0 (multisig/presets/forwarder/ForwarderShielded.compact)
 
 pragma language_version >= 0.23.0;
 

--- a/contracts/src/multisig/presets/forwarder/ForwarderUnshielded.compact
+++ b/contracts/src/multisig/presets/forwarder/ForwarderUnshielded.compact
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Compact Contracts v0.0.1-alpha.1 (multisig/presets/forwarder/ForwarderUnshielded.compact)
+// OpenZeppelin Compact Contracts v0.2.0 (multisig/presets/forwarder/ForwarderUnshielded.compact)
 
 pragma language_version >= 0.23.0;
 

--- a/contracts/src/multisig/test/mocks/MockForwarder.compact
+++ b/contracts/src/multisig/test/mocks/MockForwarder.compact
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Compact Contracts v0.0.1-alpha.1 (multisig/test/mocks/MockForwarder.compact)
+// OpenZeppelin Compact Contracts v0.2.0 (multisig/test/mocks/MockForwarder.compact)
 
 pragma language_version >= 0.23.0;
 

--- a/contracts/src/multisig/test/mocks/MockForwarderPrivate.compact
+++ b/contracts/src/multisig/test/mocks/MockForwarderPrivate.compact
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Compact Contracts v0.0.1-alpha.1 (multisig/test/mocks/MockForwarderPrivate.compact)
+// OpenZeppelin Compact Contracts v0.2.0 (multisig/test/mocks/MockForwarderPrivate.compact)
 
 pragma language_version >= 0.23.0;
 

--- a/contracts/src/multisig/test/witnesses/MockForwarderPrivateWitnesses.ts
+++ b/contracts/src/multisig/test/witnesses/MockForwarderPrivateWitnesses.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Compact Contracts v0.0.1-alpha.1 (multisig/witnesses/MockForwarderPrivateWitnesses.ts)
+// OpenZeppelin Compact Contracts v0.2.0 (multisig/witnesses/MockForwarderPrivateWitnesses.ts)
 
 export type MockForwarderPrivatePrivateState = Record<string, never>;
 export const MockForwarderPrivatePrivateState: MockForwarderPrivatePrivateState = {};

--- a/contracts/src/multisig/test/witnesses/ShieldedMultiSigV2Witnesses.ts
+++ b/contracts/src/multisig/test/witnesses/ShieldedMultiSigV2Witnesses.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Compact Contracts v0.0.1-alpha.1 (multisig/witnesses/ShieldedMultiSigV2Witnesses.ts)
+// OpenZeppelin Compact Contracts v0.2.0 (multisig/witnesses/ShieldedMultiSigV2Witnesses.ts)
 
 export type ShieldedMultiSigV2PrivateState = Record<string, never>;
 export const ShieldedMultiSigV2PrivateState: ShieldedMultiSigV2PrivateState =

--- a/contracts/src/multisig/test/witnesses/ShieldedMultiSigWitnesses.ts
+++ b/contracts/src/multisig/test/witnesses/ShieldedMultiSigWitnesses.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Compact Contracts v0.0.1-alpha.1 (multisig/witnesses/ShieldedMultiSigWitnesses.ts)
+// OpenZeppelin Compact Contracts v0.2.0 (multisig/witnesses/ShieldedMultiSigWitnesses.ts)
 
 export type ShieldedMultiSigPrivateState = Record<string, never>;
 export const ShieldedMultiSigPrivateState: ShieldedMultiSigPrivateState = {};

--- a/contracts/src/multisig/test/witnesses/ShieldedTreasuryWitnesses.ts
+++ b/contracts/src/multisig/test/witnesses/ShieldedTreasuryWitnesses.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Compact Contracts v0.0.1-alpha.1 (multisig/witnesses/ShieldedTreasuryWitnesses.ts)
+// OpenZeppelin Compact Contracts v0.2.0 (multisig/witnesses/ShieldedTreasuryWitnesses.ts)
 
 export type ShieldedTreasuryPrivateState = Record<string, never>;
 export const ShieldedTreasuryPrivateState: ShieldedTreasuryPrivateState = {};

--- a/contracts/src/multisig/test/witnesses/SignerManagerWitnesses.ts
+++ b/contracts/src/multisig/test/witnesses/SignerManagerWitnesses.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Compact Contracts v0.0.1-alpha.1 (multisig/witnesses/SignerManagerWitnesses.ts)
+// OpenZeppelin Compact Contracts v0.2.0 (multisig/witnesses/SignerManagerWitnesses.ts)
 
 export type SignerManagerPrivateState = Record<string, never>;
 export const SignerManagerPrivateState: SignerManagerPrivateState = {};

--- a/contracts/src/multisig/test/witnesses/SignerWitnesses.ts
+++ b/contracts/src/multisig/test/witnesses/SignerWitnesses.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Compact Contracts v0.0.1-alpha.1 (multisig/witnesses/SignerWitnesses.ts)
+// OpenZeppelin Compact Contracts v0.2.0 (multisig/witnesses/SignerWitnesses.ts)
 
 export type SignerPrivateState = Record<string, never>;
 export const SignerPrivateState: SignerPrivateState = {};

--- a/contracts/src/multisig/test/witnesses/UnshieldedTreasuryWitnesses.ts
+++ b/contracts/src/multisig/test/witnesses/UnshieldedTreasuryWitnesses.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Compact Contracts v0.0.1-alpha.1 (multisig/witnesses/UnshieldedTreasuryWitnesses.ts)
+// OpenZeppelin Compact Contracts v0.2.0 (multisig/witnesses/UnshieldedTreasuryWitnesses.ts)
 
 export type UnshieldedTreasuryPrivateState = Record<string, never>;
 export const UnshieldedTreasuryPrivateState: UnshieldedTreasuryPrivateState =

--- a/contracts/src/multisig/test/witnesses/presets/ForwarderPrivateWitnesses.ts
+++ b/contracts/src/multisig/test/witnesses/presets/ForwarderPrivateWitnesses.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Compact Contracts v0.0.1-alpha.1 (multisig/witnesses/presets/ForwarderPrivateWitnesses.ts)
+// OpenZeppelin Compact Contracts v0.2.0 (multisig/witnesses/presets/ForwarderPrivateWitnesses.ts)
 
 export type ForwarderPrivatePrivateState = Record<string, never>;
 export const ForwarderPrivatePrivateState: ForwarderPrivatePrivateState = {};

--- a/contracts/src/multisig/test/witnesses/presets/ForwarderShieldedWitnesses.ts
+++ b/contracts/src/multisig/test/witnesses/presets/ForwarderShieldedWitnesses.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Compact Contracts v0.0.1-alpha.1 (multisig/witnesses/presets/ForwarderShieldedWitnesses.ts)
+// OpenZeppelin Compact Contracts v0.2.0 (multisig/witnesses/presets/ForwarderShieldedWitnesses.ts)
 
 export type ForwarderShieldedPrivateState = Record<string, never>;
 export const ForwarderShieldedPrivateState: ForwarderShieldedPrivateState = {};

--- a/contracts/src/multisig/test/witnesses/presets/ForwarderUnshieldedWitnesses.ts
+++ b/contracts/src/multisig/test/witnesses/presets/ForwarderUnshieldedWitnesses.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Compact Contracts v0.0.1-alpha.1 (multisig/witnesses/presets/ForwarderUnshieldedWitnesses.ts)
+// OpenZeppelin Compact Contracts v0.2.0 (multisig/witnesses/presets/ForwarderUnshieldedWitnesses.ts)
 
 export type ForwarderUnshieldedPrivateState = Record<string, never>;
 export const ForwarderUnshieldedPrivateState: ForwarderUnshieldedPrivateState = {};


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated OpenZeppelin Compact Contracts version markers across all multisig contracts and test utilities from v0.0.1-alpha.1 to v0.2.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->