### PR TITLE
fix(token): resolve zero-value revert audit findings (L-01, L-02)

### DIFF
--- a/contracts/src/token/FungibleToken.compact
+++ b/contracts/src/token/FungibleToken.compact
@@ -688,16 +688,19 @@ module FungibleToken {
     const canonOwner = Utils_canonicalize<Bytes<32>, ContractAddress>(owner);
     const canonSpender = Utils_canonicalize<Bytes<32>, ContractAddress>(spender);
 
-    assert((_allowances.member(disclose(canonOwner)) &&
-            _allowances.lookup(canonOwner).member(disclose(canonSpender))),
-           "FungibleToken: insufficient allowance"
-           );
-
-    const currentAllowance = _allowances.lookup(canonOwner).lookup(disclose(canonSpender));
-    const MAX_UINT128 = 340282366920938463463374607431768211455;
-    if (currentAllowance < MAX_UINT128) {
-      assert(currentAllowance >= value, "FungibleToken: insufficient allowance");
-      _approve(canonOwner, canonSpender, currentAllowance - value as Uint<128>);
+    // A missing allowance entry is treated as a zero allowance, mirroring
+    // `allowance`, and a zero-value spend is a no-op. Guarding on `value`
+    // avoids reverting (outside an assertion) on a missing entry and avoids
+    // writing a spurious zero entry for a zero-value spend (see audit L-02).
+    // Whether `value` is zero is already public (a non-zero spend discloses the
+    // updated allowance), so disclosing the guard leaks nothing new.
+    if (disclose(value > 0)) {
+      const currentAllowance = allowance(canonOwner, canonSpender);
+      const MAX_UINT128 = 340282366920938463463374607431768211455;
+      if (currentAllowance < MAX_UINT128) {
+        assert(currentAllowance >= value, "FungibleToken: insufficient allowance");
+        _approve(canonOwner, canonSpender, currentAllowance - value as Uint<128>);
+      }
     }
   }
 

--- a/contracts/src/token/FungibleToken.compact
+++ b/contracts/src/token/FungibleToken.compact
@@ -691,9 +691,7 @@ module FungibleToken {
     // A missing allowance entry is treated as a zero allowance, mirroring
     // `allowance`, and a zero-value spend is a no-op. Guarding on `value`
     // avoids reverting (outside an assertion) on a missing entry and avoids
-    // writing a spurious zero entry for a zero-value spend (see audit L-02).
-    // Whether `value` is zero is already public (a non-zero spend discloses the
-    // updated allowance), so disclosing the guard leaks nothing new.
+    // writing a spurious zero entry for a zero-value spend.
     if (disclose(value > 0)) {
       const currentAllowance = allowance(canonOwner, canonSpender);
       const MAX_UINT128 = 340282366920938463463374607431768211455;

--- a/contracts/src/token/MultiToken.compact
+++ b/contracts/src/token/MultiToken.compact
@@ -425,11 +425,19 @@ module MultiToken {
     if (!Utils_isTargetZero(disclose(canonFrom))) {
       const fromBalance = balanceOf(canonFrom, id);
       assert(fromBalance >= value, "MultiToken: insufficient balance");
-      const newBalance = fromBalance - value;
-      _balances.lookup(id).insert(disclose(canonFrom), disclose(newBalance));
+      // Skip the write when `value` is zero. A zero-value update leaves the
+      // balance unchanged, so there is nothing to write, and guarding here
+      // avoids `_balances.lookup(id)` reverting outside an assertion when `id`
+      // has never been initialized (see audit L-01). Whether `value` is zero is
+      // already public (every balance write discloses it), so disclosing the
+      // guard leaks nothing new.
+      if (disclose(value > 0)) {
+        const newBalance = fromBalance - value;
+        _balances.lookup(id).insert(disclose(canonFrom), disclose(newBalance));
+      }
     }
 
-    if (!Utils_isTargetZero(disclose(canonTo))) {
+    if (!Utils_isTargetZero(disclose(canonTo)) && disclose(value > 0)) {
       if (!_balances.member(disclose(id))) {
         _balances.insert(
           disclose(id),

--- a/contracts/src/token/MultiToken.compact
+++ b/contracts/src/token/MultiToken.compact
@@ -428,9 +428,7 @@ module MultiToken {
       // Skip the write when `value` is zero. A zero-value update leaves the
       // balance unchanged, so there is nothing to write, and guarding here
       // avoids `_balances.lookup(id)` reverting outside an assertion when `id`
-      // has never been initialized (see audit L-01). Whether `value` is zero is
-      // already public (every balance write discloses it), so disclosing the
-      // guard leaks nothing new.
+      // has never been initialized.
       if (disclose(value > 0)) {
         const newBalance = fromBalance - value;
         _balances.lookup(id).insert(disclose(canonFrom), disclose(newBalance));

--- a/contracts/src/token/test/FungibleToken.test.ts
+++ b/contracts/src/token/test/FungibleToken.test.ts
@@ -590,7 +590,7 @@ describe('FungibleToken', () => {
 
       it('should allow zero-value transferFrom without a pre-existing allowance', async () => {
         // A missing allowance entry is treated as zero, and a zero-value spend
-        // is a no-op, so this must not revert (audit L-02).
+        // is a no-op, so this must not revert.
         await token.privateState.injectSecretKey(UNAUTHORIZED.secretKey);
 
         const txSuccess = await token.transferFrom(
@@ -1161,7 +1161,7 @@ describe('FungibleToken', () => {
 
       it('should allow a zero-value spend without a pre-existing allowance', async () => {
         // A missing entry is treated as zero and a zero-value spend is a no-op,
-        // so this must not revert and must not create an entry (audit L-02).
+        // so this must not revert and must not create an entry.
         await token._spendAllowance(OWNER.either, OTHER.either, 0n);
         expect(await token.allowance(OWNER.either, OTHER.either)).toEqual(0n);
       });

--- a/contracts/src/token/test/FungibleToken.test.ts
+++ b/contracts/src/token/test/FungibleToken.test.ts
@@ -588,6 +588,27 @@ describe('FungibleToken', () => {
         ).rejects.toThrow('FungibleToken: insufficient allowance');
       });
 
+      it('should allow zero-value transferFrom without a pre-existing allowance', async () => {
+        // A missing allowance entry is treated as zero, and a zero-value spend
+        // is a no-op, so this must not revert (audit L-02).
+        await token.privateState.injectSecretKey(UNAUTHORIZED.secretKey);
+
+        const txSuccess = await token.transferFrom(
+          OWNER.either,
+          RECIPIENT.either,
+          0n,
+        );
+        expect(txSuccess).toBe(true);
+
+        // No allowance entry is created for the spender, matching `allowance`.
+        expect(
+          await token.allowance(OWNER.either, UNAUTHORIZED.either),
+        ).toEqual(0n);
+        // Balances are unchanged.
+        expect(await token.balanceOf(OWNER.either)).toEqual(AMOUNT);
+        expect(await token.balanceOf(RECIPIENT.either)).toEqual(0n);
+      });
+
       it('should fail to transferFrom to the zero address', async () => {
         await token.privateState.injectSecretKey(SPENDER.secretKey);
 
@@ -1136,6 +1157,21 @@ describe('FungibleToken', () => {
         await expect(
           token._spendAllowance(OWNER.either, SPENDER.either, AMOUNT + 1n),
         ).rejects.toThrow('FungibleToken: insufficient allowance');
+      });
+
+      it('should allow a zero-value spend without a pre-existing allowance', async () => {
+        // A missing entry is treated as zero and a zero-value spend is a no-op,
+        // so this must not revert and must not create an entry (audit L-02).
+        await token._spendAllowance(OWNER.either, OTHER.either, 0n);
+        expect(await token.allowance(OWNER.either, OTHER.either)).toEqual(0n);
+      });
+
+      it('should leave an existing allowance unchanged on a zero-value spend', async () => {
+        await token._approve(OWNER.either, SPENDER.either, AMOUNT);
+        await token._spendAllowance(OWNER.either, SPENDER.either, 0n);
+        expect(await token.allowance(OWNER.either, SPENDER.either)).toEqual(
+          AMOUNT,
+        );
       });
 
       it('should canonicalize when spending allowance', async () => {

--- a/contracts/src/token/test/MultiToken.test.ts
+++ b/contracts/src/token/test/MultiToken.test.ts
@@ -395,7 +395,7 @@ describe('MultiToken', () => {
         });
 
         it('should allow transfer of 0 tokens for an uninitialized id', async () => {
-          // A zero-value update must not revert on an uninitialized id (audit L-01).
+          // A zero-value update must not revert on an uninitialized id.
           await token.transferFrom(
             OWNER.either,
             RECIPIENT.either,
@@ -1035,7 +1035,7 @@ describe('MultiToken', () => {
       });
 
       it('should allow transfer of 0 tokens for an uninitialized id', async () => {
-        // A zero-value update must not revert on an uninitialized id (audit L-01).
+        // A zero-value update must not revert on an uninitialized id.
         await token._transfer(
           OWNER.either,
           RECIPIENT.either,
@@ -1327,7 +1327,7 @@ describe('MultiToken', () => {
 
       it('should allow minting 0 tokens of an uninitialized id', async () => {
         // A zero-value mint is a no-op: it must not revert and must not
-        // initialize the id (audit L-01).
+        // initialize the id.
         await token._mint(RECIPIENT.either, NONEXISTENT_ID, 0n);
         expect(await token.balanceOf(RECIPIENT.either, NONEXISTENT_ID)).toEqual(
           0n,
@@ -1468,7 +1468,7 @@ describe('MultiToken', () => {
       });
 
       it('should allow burning 0 tokens from an uninitialized id', async () => {
-        // A zero-value burn must not revert on an uninitialized id (audit L-01).
+        // A zero-value burn must not revert on an uninitialized id.
         await token._burn(OWNER.either, NONEXISTENT_ID, 0n);
         expect(await token.balanceOf(OWNER.either, NONEXISTENT_ID)).toEqual(0n);
       });

--- a/contracts/src/token/test/MultiToken.test.ts
+++ b/contracts/src/token/test/MultiToken.test.ts
@@ -394,6 +394,23 @@ describe('MultiToken', () => {
           expect(await token.balanceOf(RECIPIENT.either, TOKEN_ID)).toEqual(0n);
         });
 
+        it('should allow transfer of 0 tokens for an uninitialized id', async () => {
+          // A zero-value update must not revert on an uninitialized id (audit L-01).
+          await token.transferFrom(
+            OWNER.either,
+            RECIPIENT.either,
+            NONEXISTENT_ID,
+            0n,
+          );
+
+          expect(await token.balanceOf(OWNER.either, NONEXISTENT_ID)).toEqual(
+            0n,
+          );
+          expect(
+            await token.balanceOf(RECIPIENT.either, NONEXISTENT_ID),
+          ).toEqual(0n);
+        });
+
         it('should handle self-transfer', async () => {
           await token.transferFrom(
             OWNER.either,
@@ -1017,6 +1034,21 @@ describe('MultiToken', () => {
         expect(await token.balanceOf(RECIPIENT.either, TOKEN_ID)).toEqual(0n);
       });
 
+      it('should allow transfer of 0 tokens for an uninitialized id', async () => {
+        // A zero-value update must not revert on an uninitialized id (audit L-01).
+        await token._transfer(
+          OWNER.either,
+          RECIPIENT.either,
+          NONEXISTENT_ID,
+          0n,
+        );
+
+        expect(await token.balanceOf(OWNER.either, NONEXISTENT_ID)).toEqual(0n);
+        expect(await token.balanceOf(RECIPIENT.either, NONEXISTENT_ID)).toEqual(
+          0n,
+        );
+      });
+
       it('should fail with insufficient balance', async () => {
         await expect(
           token._transfer(
@@ -1293,6 +1325,15 @@ describe('MultiToken', () => {
         ).rejects.toThrow('MultiToken: arithmetic overflow');
       });
 
+      it('should allow minting 0 tokens of an uninitialized id', async () => {
+        // A zero-value mint is a no-op: it must not revert and must not
+        // initialize the id (audit L-01).
+        await token._mint(RECIPIENT.either, NONEXISTENT_ID, 0n);
+        expect(await token.balanceOf(RECIPIENT.either, NONEXISTENT_ID)).toEqual(
+          0n,
+        );
+      });
+
       it('should fail when minting to zero address (id)', async () => {
         await expect(
           token._mint(ZERO_ACCOUNT, TOKEN_ID, AMOUNT),
@@ -1424,6 +1465,12 @@ describe('MultiToken', () => {
         await expect(
           token._burn(OWNER.either, NONEXISTENT_ID, AMOUNT),
         ).rejects.toThrow('MultiToken: insufficient balance');
+      });
+
+      it('should allow burning 0 tokens from an uninitialized id', async () => {
+        // A zero-value burn must not revert on an uninitialized id (audit L-01).
+        await token._burn(OWNER.either, NONEXISTENT_ID, 0n);
+        expect(await token.balanceOf(OWNER.either, NONEXISTENT_ID)).toEqual(0n);
       });
 
       it('should handle non-canonical fromAddress (id)', async () => {


### PR DESCRIPTION
## Types of changes

What types of changes does your code introduce to OpenZeppelin Midnight Contracts?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

Fixes #425
Fixes #426

Resolves the two audit findings (L-01, L-02) that were parked behind the
unconditional-downcast compiler limitation
[LFDT-Minokawa/compact#226](https://github.com/LFDT-Minokawa/compact/issues/226),
now resolved upstream. With conditional downcasts available, a zero-value
balance/allowance update can be guarded without the constraint-level failure
the audit comments described.

### L-01 — `MultiToken._update` (#425)

A zero-value `transferFrom`, `_transfer`, `_mint` or `_burn` of a token `id`
that was never initialized reverted on the bare `_balances.lookup(id)` write
inside `_update`, rather than failing with an explicit assertion or succeeding
as a no-op.

**Fix:** guard both balance writes on `disclose(value > 0)`. A zero-value
update leaves balances unchanged, so the source write is skipped and the
recipient block no longer initializes the `id`. A non-zero transfer/burn of an
uninitialized id still fails with the explicit `"MultiToken: insufficient
balance"` assertion as before.

### L-02 — `FungibleToken._spendAllowance` (#426)

`transferFrom(owner, to, 0)` reverted unless a prior approval had created the
`_allowances` entry, because `_spendAllowance` asserted membership before
reading the allowance. This diverged from `allowance`, which treats a missing
entry as zero.

**Fix:** read the current allowance via `allowance` (missing entry → `0`) and
guard the spend on `disclose(value > 0)`. A zero-value spend is now a no-op that
neither reverts nor writes a spurious zero entry; a non-zero spend without
allowance still fails with `"FungibleToken: insufficient allowance"`.

### On `disclose(value > 0)`

The guard gates a ledger write, so its boolean must be disclosed. `value` is
already public on every balance write (and a non-zero spend already discloses
the updated allowance), so disclosing *whether* `value` is zero leaks nothing
new.

### Note on `@circuitInfo`

The touched circuits' constraint counts shift by a few rows. The `@circuitInfo`
annotations are intentionally left unchanged here: the existing values do not
match the toolchain in this environment even for circuits this PR does not touch
(e.g. `balanceOf`), so they are best regenerated wholesale with the canonical
release toolchain rather than edited piecemeal in this fix.

## PR Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md#your-first-code-contribution)
- [x] I have added tests that prove my fix is effective or that my feature works. See [GUIDELINES.md#testing](../GUIDELINES.md#testing) for more information.
- [ ] I have added documentation for new methods or changes to existing method behavior. See [GUIDELINES.md#documentation](../GUIDELINES.md#documentation) for more information.
- [ ] CI Workflows Are Passing

#### Further comments

Both fixes compile to valid ZKIR (prover/verifier keys generate for every mock
circuit), confirming the conditional downcast + disclosure is provable. Added
tests cover: zero-value `transferFrom` / `_transfer` / `_mint` / `_burn` on an
uninitialized `id` (MultiToken), and zero-value `transferFrom` / `_spendAllowance`
without a pre-existing allowance plus an existing-allowance-unchanged case
(FungibleToken). All 554 token suite tests pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Token transfers with zero amounts no longer fail when allowance entries don't exist; missing allowances are treated as zero.
* Zero-value balance operations no longer create unnecessary state entries.

## Tests
* Added comprehensive test coverage for zero-amount token operations with missing allowance entries.
* Extended tests for zero-value transfers, mints, and burns on uninitialized tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->