### PR TITLE
Add allowlist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add allowList (#???)
 - Multisig contract suite under `contracts/src/multisig/`: configurable M-of-N `Signer` / `SignerManager` registry, `ProposalManager`, stateful `ShieldedTreasury` and `ShieldedTreasuryStateless`, `UnshieldedTreasury`, `Forwarder` + `ForwarderPrivate` modules with per-recipient presets, and the `ShieldedMultiSig` / `ShieldedMultiSigV2` presets. Signature verification is stubbed pending ECDSA + Keccak primitives (#475). (#378, #424, #526)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add allowList (#???)
+- Add allowList (#625)
 - Multisig contract suite under `contracts/src/multisig/`: configurable M-of-N `Signer` / `SignerManager` registry, `ProposalManager`, stateful `ShieldedTreasury` and `ShieldedTreasuryStateless`, `UnshieldedTreasury`, `Forwarder` + `ForwarderPrivate` modules with per-recipient presets, and the `ShieldedMultiSig` / `ShieldedMultiSigV2` presets. Signature verification is stubbed pending ECDSA + Keccak primitives (#475). (#378, #424, #526)
 
 ### Changed

--- a/contracts/src/security/Allowlist.compact
+++ b/contracts/src/security/Allowlist.compact
@@ -31,8 +31,8 @@ module Allowlist {
   // State
   // ---------------------------------------------------------------------------
 
-  /** @description Approved accounts. Absent or `false` means not allowed. */
-  export ledger _allowed: Map<Bytes<32>, Boolean>;
+  /** @description Approved accounts. Absent means not allowed. */
+  export ledger _allowed: Set<Bytes<32>>;
 
   // ---------------------------------------------------------------------------
   // Views
@@ -41,14 +41,13 @@ module Allowlist {
   /**
    * @description Returns whether `account` is currently allowed.
    *
-   * @circuitInfo k=9, rows=341
+   * @circuitInfo k=9, rows=305
    *
    * @param {Bytes<32>} account - The account to query.
    * @return {Boolean} - True if `account` is a member of the allowlist.
    */
   export circuit isAllowed(account: Bytes<32>): Boolean {
-    return _allowed.member(disclose(account)) &&
-           _allowed.lookup(disclose(account));
+    return _allowed.member(disclose(account));
   }
 
   // ---------------------------------------------------------------------------
@@ -59,7 +58,7 @@ module Allowlist {
    * @description Asserts that `account` is allowed. The composing contract
    * decides when this gate applies.
    *
-   * @circuitInfo k=9, rows=341
+   * @circuitInfo k=9, rows=305
    *
    * Requirements:
    *
@@ -85,7 +84,7 @@ module Allowlist {
    * @return {[]} - Empty tuple.
    */
   export circuit _allow(account: Bytes<32>): [] {
-    _allowed.insert(disclose(account), true);
+    _allowed.insert(disclose(account));
   }
 
   /**
@@ -97,6 +96,6 @@ module Allowlist {
    * @return {[]} - Empty tuple.
    */
   export circuit _disallow(account: Bytes<32>): [] {
-    _allowed.insert(disclose(account), false);
+    _allowed.remove(disclose(account));
   }
 }

--- a/contracts/src/security/Allowlist.compact
+++ b/contracts/src/security/Allowlist.compact
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Compact Contracts v0.2.0 (security/Allowlist.compact)
+
+pragma language_version >= 0.23.0;
+
+/**
+ * @module Allowlist
+ * @description A minimal, reusable permit-list keyed by an abstract `Bytes<32>`
+ * account identifier. It answers a single question: is this account a member?
+ *
+ * This module is a pure membership MECHANISM, not a policy. It holds no notion
+ * of "when" the list is enforced and no access control. The mutators (`_allow`,
+ * `_disallow`) are deliberately UNGATED composable primitives: a composing
+ * contract gates them behind its access-control module (the same way a token
+ * gates `_mint` / `_burn`), and decides when to call `assertAllowed` (for
+ * example, only while an "eligibility required" flag is set). Keeping the
+ * enforce-or-not decision in the composing layer leaves this module general
+ * enough to back KYC allowlists, permissioned mints, membership gates, and the
+ * like.
+ *
+ * @dev Eligibility seam. `assertAllowed` is the single check a composing
+ * contract calls. This is the swap point: a confidential / graph-private asset
+ * replaces the public-map backend here with a zero-knowledge membership proof
+ * against a published root, WITHOUT changing the composition. See the
+ * confidential graph-privacy findings doc.
+ *
+ * @notice This is the PUBLIC (transparent) allowlist: membership status is
+ * publicly readable and the approved set is publicly enumerable. That is the
+ * right posture for transparent or public-graph assets. A graph-private asset
+ * should instead use a shielded allowlist (a public allowlist would re-expose
+ * the candidate set and bound the anonymity set).
+ */
+module Allowlist {
+  import CompactStandardLibrary;
+
+  // ---------------------------------------------------------------------------
+  // State
+  // ---------------------------------------------------------------------------
+
+  /** @description Approved accounts. Absent or `false` means not allowed. */
+  export ledger _allowed: Map<Bytes<32>, Boolean>;
+
+  // ---------------------------------------------------------------------------
+  // Views
+  // ---------------------------------------------------------------------------
+
+  /**
+   * @description Returns whether `account` is currently allowed.
+   *
+   * @circuitInfo k=9, rows=341
+   *
+   * @param {Bytes<32>} account - The account to query.
+   * @return {Boolean} - True if `account` is a member of the allowlist.
+   */
+  export circuit isAllowed(account: Bytes<32>): Boolean {
+    return _allowed.member(disclose(account)) &&
+           _allowed.lookup(disclose(account));
+  }
+
+  // ---------------------------------------------------------------------------
+  // Check (the eligibility seam)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * @description Asserts that `account` is allowed. The composing contract
+   * decides when this gate applies.
+   *
+   * @circuitInfo k=9, rows=341
+   *
+   * Requirements:
+   *
+   * - `account` is a member of the allowlist.
+   *
+   * @param {Bytes<32>} account - The account that must be allowed.
+   * @return {[]} - Empty tuple.
+   */
+  export circuit assertAllowed(account: Bytes<32>): [] {
+    assert(isAllowed(account), "Allowlist: account not allowed");
+  }
+
+  // ---------------------------------------------------------------------------
+  // Mutators (UNGATED - the composing contract is responsible for gating these)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * @description Adds `account` to the allowlist.
+   *
+   * @circuitInfo k=9, rows=303
+   *
+   * @param {Bytes<32>} account - The account to allow.
+   * @return {[]} - Empty tuple.
+   */
+  export circuit _allow(account: Bytes<32>): [] {
+    _allowed.insert(disclose(account), true);
+  }
+
+  /**
+   * @description Removes `account` from the allowlist.
+   *
+   * @circuitInfo k=9, rows=303
+   *
+   * @param {Bytes<32>} account - The account to disallow.
+   * @return {[]} - Empty tuple.
+   */
+  export circuit _disallow(account: Bytes<32>): [] {
+    _allowed.insert(disclose(account), false);
+  }
+}

--- a/contracts/src/security/Allowlist.compact
+++ b/contracts/src/security/Allowlist.compact
@@ -18,12 +18,6 @@ pragma language_version >= 0.23.0;
  * enough to back KYC allowlists, permissioned mints, membership gates, and the
  * like.
  *
- * @dev Eligibility seam. `assertAllowed` is the single check a composing
- * contract calls. This is the swap point: a confidential / graph-private asset
- * replaces the public-map backend here with a zero-knowledge membership proof
- * against a published root, WITHOUT changing the composition. See the
- * confidential graph-privacy findings doc.
- *
  * @notice This is the PUBLIC (transparent) allowlist: membership status is
  * publicly readable and the approved set is publicly enumerable. That is the
  * right posture for transparent or public-graph assets. A graph-private asset

--- a/contracts/src/security/test/Allowlist.test.ts
+++ b/contracts/src/security/test/Allowlist.test.ts
@@ -52,6 +52,16 @@ describe('Allowlist', () => {
       allowlist.allow(ALICE);
       expect(allowlist.isAllowed(ALICE)).toBe(true);
     });
+
+    it('clears with a single disallow after being allowed multiple times', () => {
+      allowlist.allow(ALICE);
+      allowlist.allow(ALICE);
+      expect(allowlist.isAllowed(ALICE)).toBe(true);
+      allowlist.disallow(ALICE);
+      // Membership is binary, not a counter: one disallow clears it regardless
+      // of how many times it was allowed.
+      expect(allowlist.isAllowed(ALICE)).toBe(false);
+    });
   });
 
   describe('disallow', () => {
@@ -108,7 +118,6 @@ describe('Allowlist', () => {
       sim.allow(ALICE);
 
       expect(sim.getPublicState().Allowlist__allowed.member(ALICE)).toBe(true);
-      expect(sim.getPublicState().Allowlist__allowed.lookup(ALICE)).toBe(true);
     });
   });
 });

--- a/contracts/src/security/test/Allowlist.test.ts
+++ b/contracts/src/security/test/Allowlist.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { AllowlistSimulator } from './simulators/AllowlistSimulator.js';
+
+// Deterministic 32-byte account identifier seeded from a label.
+const account = (label: string): Uint8Array => {
+  const a = new Uint8Array(32);
+  a.set(new TextEncoder().encode(label).slice(0, 32));
+  return a;
+};
+
+const ALICE = account('ALICE');
+const BOB = account('BOB');
+
+let allowlist: AllowlistSimulator;
+
+describe('Allowlist', () => {
+  beforeEach(() => {
+    allowlist = new AllowlistSimulator();
+  });
+
+  describe('default state', () => {
+    it('is empty: no account is allowed', () => {
+      expect(allowlist.isAllowed(ALICE)).toBe(false);
+      expect(allowlist.isAllowed(BOB)).toBe(false);
+    });
+
+    it('assertAllowed throws for a non-member', () => {
+      expect(() => allowlist.assertAllowed(ALICE)).toThrow(
+        'Allowlist: account not allowed',
+      );
+    });
+  });
+
+  describe('allow', () => {
+    it('adds an account to the allowlist', () => {
+      allowlist.allow(ALICE);
+      expect(allowlist.isAllowed(ALICE)).toBe(true);
+    });
+
+    it('does not affect other accounts', () => {
+      allowlist.allow(ALICE);
+      expect(allowlist.isAllowed(BOB)).toBe(false);
+    });
+
+    it('assertAllowed passes for a member', () => {
+      allowlist.allow(ALICE);
+      expect(() => allowlist.assertAllowed(ALICE)).not.toThrow();
+    });
+
+    it('is idempotent', () => {
+      allowlist.allow(ALICE);
+      allowlist.allow(ALICE);
+      expect(allowlist.isAllowed(ALICE)).toBe(true);
+    });
+  });
+
+  describe('disallow', () => {
+    it('removes an account from the allowlist', () => {
+      allowlist.allow(ALICE);
+      allowlist.disallow(ALICE);
+      expect(allowlist.isAllowed(ALICE)).toBe(false);
+    });
+
+    it('assertAllowed throws again after disallow', () => {
+      allowlist.allow(ALICE);
+      allowlist.disallow(ALICE);
+      expect(() => allowlist.assertAllowed(ALICE)).toThrow(
+        'Allowlist: account not allowed',
+      );
+    });
+
+    it('is a no-op for a non-member', () => {
+      allowlist.disallow(BOB);
+      expect(allowlist.isAllowed(BOB)).toBe(false);
+    });
+  });
+
+  describe('multiple operations', () => {
+    it('handles allow -> disallow -> allow', () => {
+      allowlist.allow(ALICE);
+      expect(allowlist.isAllowed(ALICE)).toBe(true);
+
+      allowlist.disallow(ALICE);
+      expect(allowlist.isAllowed(ALICE)).toBe(false);
+
+      allowlist.allow(ALICE);
+      expect(allowlist.isAllowed(ALICE)).toBe(true);
+    });
+
+    it('tracks several accounts independently', () => {
+      allowlist.allow(ALICE);
+      expect(allowlist.isAllowed(ALICE)).toBe(true);
+      expect(allowlist.isAllowed(BOB)).toBe(false);
+
+      allowlist.allow(BOB);
+      allowlist.disallow(ALICE);
+      expect(allowlist.isAllowed(ALICE)).toBe(false);
+      expect(allowlist.isAllowed(BOB)).toBe(true);
+    });
+  });
+
+  describe('simulator wiring', () => {
+    it('exposes the public ledger via getPublicState', () => {
+      const sim = new AllowlistSimulator();
+
+      expect(sim.getPublicState().Allowlist__allowed.member(ALICE)).toBe(false);
+
+      sim.allow(ALICE);
+
+      expect(sim.getPublicState().Allowlist__allowed.member(ALICE)).toBe(true);
+      expect(sim.getPublicState().Allowlist__allowed.lookup(ALICE)).toBe(true);
+    });
+  });
+});

--- a/contracts/src/security/test/Allowlist.test.ts
+++ b/contracts/src/security/test/Allowlist.test.ts
@@ -14,110 +14,114 @@ const BOB = account('BOB');
 let allowlist: AllowlistSimulator;
 
 describe('Allowlist', () => {
-  beforeEach(() => {
-    allowlist = new AllowlistSimulator();
+  beforeEach(async () => {
+    allowlist = await AllowlistSimulator.create();
   });
 
   describe('default state', () => {
-    it('is empty: no account is allowed', () => {
-      expect(allowlist.isAllowed(ALICE)).toBe(false);
-      expect(allowlist.isAllowed(BOB)).toBe(false);
+    it('is empty: no account is allowed', async () => {
+      expect(await allowlist.isAllowed(ALICE)).toBe(false);
+      expect(await allowlist.isAllowed(BOB)).toBe(false);
     });
 
-    it('assertAllowed throws for a non-member', () => {
-      expect(() => allowlist.assertAllowed(ALICE)).toThrow(
+    it('assertAllowed throws for a non-member', async () => {
+      await expect(allowlist.assertAllowed(ALICE)).rejects.toThrow(
         'Allowlist: account not allowed',
       );
     });
   });
 
   describe('allow', () => {
-    it('adds an account to the allowlist', () => {
-      allowlist.allow(ALICE);
-      expect(allowlist.isAllowed(ALICE)).toBe(true);
+    it('adds an account to the allowlist', async () => {
+      await allowlist.allow(ALICE);
+      expect(await allowlist.isAllowed(ALICE)).toBe(true);
     });
 
-    it('does not affect other accounts', () => {
-      allowlist.allow(ALICE);
-      expect(allowlist.isAllowed(BOB)).toBe(false);
+    it('does not affect other accounts', async () => {
+      await allowlist.allow(ALICE);
+      expect(await allowlist.isAllowed(BOB)).toBe(false);
     });
 
-    it('assertAllowed passes for a member', () => {
-      allowlist.allow(ALICE);
-      expect(() => allowlist.assertAllowed(ALICE)).not.toThrow();
+    it('assertAllowed passes for a member', async () => {
+      await allowlist.allow(ALICE);
+      await allowlist.assertAllowed(ALICE);
     });
 
-    it('is idempotent', () => {
-      allowlist.allow(ALICE);
-      allowlist.allow(ALICE);
-      expect(allowlist.isAllowed(ALICE)).toBe(true);
+    it('is idempotent', async () => {
+      await allowlist.allow(ALICE);
+      await allowlist.allow(ALICE);
+      expect(await allowlist.isAllowed(ALICE)).toBe(true);
     });
 
-    it('clears with a single disallow after being allowed multiple times', () => {
-      allowlist.allow(ALICE);
-      allowlist.allow(ALICE);
-      expect(allowlist.isAllowed(ALICE)).toBe(true);
-      allowlist.disallow(ALICE);
+    it('clears with a single disallow after being allowed multiple times', async () => {
+      await allowlist.allow(ALICE);
+      await allowlist.allow(ALICE);
+      expect(await allowlist.isAllowed(ALICE)).toBe(true);
+      await allowlist.disallow(ALICE);
       // Membership is binary, not a counter: one disallow clears it regardless
       // of how many times it was allowed.
-      expect(allowlist.isAllowed(ALICE)).toBe(false);
+      expect(await allowlist.isAllowed(ALICE)).toBe(false);
     });
   });
 
   describe('disallow', () => {
-    it('removes an account from the allowlist', () => {
-      allowlist.allow(ALICE);
-      allowlist.disallow(ALICE);
-      expect(allowlist.isAllowed(ALICE)).toBe(false);
+    it('removes an account from the allowlist', async () => {
+      await allowlist.allow(ALICE);
+      await allowlist.disallow(ALICE);
+      expect(await allowlist.isAllowed(ALICE)).toBe(false);
     });
 
-    it('assertAllowed throws again after disallow', () => {
-      allowlist.allow(ALICE);
-      allowlist.disallow(ALICE);
-      expect(() => allowlist.assertAllowed(ALICE)).toThrow(
+    it('assertAllowed throws again after disallow', async () => {
+      await allowlist.allow(ALICE);
+      await allowlist.disallow(ALICE);
+      await expect(allowlist.assertAllowed(ALICE)).rejects.toThrow(
         'Allowlist: account not allowed',
       );
     });
 
-    it('is a no-op for a non-member', () => {
-      allowlist.disallow(BOB);
-      expect(allowlist.isAllowed(BOB)).toBe(false);
+    it('is a no-op for a non-member', async () => {
+      await allowlist.disallow(BOB);
+      expect(await allowlist.isAllowed(BOB)).toBe(false);
     });
   });
 
   describe('multiple operations', () => {
-    it('handles allow -> disallow -> allow', () => {
-      allowlist.allow(ALICE);
-      expect(allowlist.isAllowed(ALICE)).toBe(true);
+    it('handles allow -> disallow -> allow', async () => {
+      await allowlist.allow(ALICE);
+      expect(await allowlist.isAllowed(ALICE)).toBe(true);
 
-      allowlist.disallow(ALICE);
-      expect(allowlist.isAllowed(ALICE)).toBe(false);
+      await allowlist.disallow(ALICE);
+      expect(await allowlist.isAllowed(ALICE)).toBe(false);
 
-      allowlist.allow(ALICE);
-      expect(allowlist.isAllowed(ALICE)).toBe(true);
+      await allowlist.allow(ALICE);
+      expect(await allowlist.isAllowed(ALICE)).toBe(true);
     });
 
-    it('tracks several accounts independently', () => {
-      allowlist.allow(ALICE);
-      expect(allowlist.isAllowed(ALICE)).toBe(true);
-      expect(allowlist.isAllowed(BOB)).toBe(false);
+    it('tracks several accounts independently', async () => {
+      await allowlist.allow(ALICE);
+      expect(await allowlist.isAllowed(ALICE)).toBe(true);
+      expect(await allowlist.isAllowed(BOB)).toBe(false);
 
-      allowlist.allow(BOB);
-      allowlist.disallow(ALICE);
-      expect(allowlist.isAllowed(ALICE)).toBe(false);
-      expect(allowlist.isAllowed(BOB)).toBe(true);
+      await allowlist.allow(BOB);
+      await allowlist.disallow(ALICE);
+      expect(await allowlist.isAllowed(ALICE)).toBe(false);
+      expect(await allowlist.isAllowed(BOB)).toBe(true);
     });
   });
 
   describe('simulator wiring', () => {
-    it('exposes the public ledger via getPublicState', () => {
-      const sim = new AllowlistSimulator();
+    it('exposes the public ledger via getPublicState', async () => {
+      const sim = await AllowlistSimulator.create();
 
-      expect(sim.getPublicState().Allowlist__allowed.member(ALICE)).toBe(false);
+      expect(
+        (await sim.getPublicState()).Allowlist__allowed.member(ALICE),
+      ).toBe(false);
 
-      sim.allow(ALICE);
+      await sim.allow(ALICE);
 
-      expect(sim.getPublicState().Allowlist__allowed.member(ALICE)).toBe(true);
+      expect(
+        (await sim.getPublicState()).Allowlist__allowed.member(ALICE),
+      ).toBe(true);
     });
   });
 });

--- a/contracts/src/security/test/mocks/MockAllowlist.compact
+++ b/contracts/src/security/test/mocks/MockAllowlist.compact
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+
+// WARNING: FOR TESTING PURPOSES ONLY.
+// This contract exposes internal circuits and bypasses safety checks that the
+// corresponding production contract relies on. DO NOT deploy or use this
+// contract in any production application.
+
+pragma language_version >= 0.23.0;
+
+import CompactStandardLibrary;
+import "../../Allowlist" prefix Allowlist_;
+
+export { Allowlist__allowed };
+
+export circuit isAllowed(account: Bytes<32>): Boolean {
+  return Allowlist_isAllowed(account);
+}
+
+export circuit assertAllowed(account: Bytes<32>): [] {
+  return Allowlist_assertAllowed(account);
+}
+
+export circuit allow(account: Bytes<32>): [] {
+  return Allowlist__allow(account);
+}
+
+export circuit disallow(account: Bytes<32>): [] {
+  return Allowlist__disallow(account);
+}

--- a/contracts/src/security/test/simulators/AllowlistSimulator.ts
+++ b/contracts/src/security/test/simulators/AllowlistSimulator.ts
@@ -1,6 +1,6 @@
 import {
-  type BaseSimulatorOptions,
   createSimulator,
+  type SimulatorOptions,
 } from '@openzeppelin/compact-simulator';
 import {
   ledger,
@@ -29,47 +29,49 @@ const AllowlistSimulatorBase = createSimulator<
   contractArgs: () => [],
   ledgerExtractor: (state) => ledger(state),
   witnessesFactory: () => AllowlistWitnesses(),
+  artifactName: 'MockAllowlist',
 });
 
 /**
  * Allowlist Simulator
  */
 export class AllowlistSimulator extends AllowlistSimulatorBase {
-  constructor(
-    options: BaseSimulatorOptions<
+  static async create(
+    options: SimulatorOptions<
       AllowlistPrivateState,
       ReturnType<typeof AllowlistWitnesses>
     > = {},
-  ) {
-    super([], options);
+  ): Promise<AllowlistSimulator> {
+    // biome-ignore lint/complexity/noThisInStatic: super.create must keep the subclass `this`
+    return super.create([], options) as Promise<AllowlistSimulator>;
   }
 
   /**
    * @description Returns whether `account` is currently allowed.
    * @returns True if `account` is a member of the allowlist.
    */
-  public isAllowed(account: Uint8Array): boolean {
+  public isAllowed(account: Uint8Array): Promise<boolean> {
     return this.circuits.impure.isAllowed(account);
   }
 
   /**
    * @description Asserts that `account` is allowed.
    */
-  public assertAllowed(account: Uint8Array) {
-    this.circuits.impure.assertAllowed(account);
+  public assertAllowed(account: Uint8Array): Promise<[]> {
+    return this.circuits.impure.assertAllowed(account);
   }
 
   /**
    * @description Adds `account` to the allowlist.
    */
-  public allow(account: Uint8Array) {
-    this.circuits.impure.allow(account);
+  public allow(account: Uint8Array): Promise<[]> {
+    return this.circuits.impure.allow(account);
   }
 
   /**
    * @description Removes `account` from the allowlist.
    */
-  public disallow(account: Uint8Array) {
-    this.circuits.impure.disallow(account);
+  public disallow(account: Uint8Array): Promise<[]> {
+    return this.circuits.impure.disallow(account);
   }
 }

--- a/contracts/src/security/test/simulators/AllowlistSimulator.ts
+++ b/contracts/src/security/test/simulators/AllowlistSimulator.ts
@@ -1,0 +1,75 @@
+import {
+  type BaseSimulatorOptions,
+  createSimulator,
+} from '@openzeppelin/compact-simulator';
+import {
+  ledger,
+  Contract as MockAllowlist,
+} from '../../../../artifacts/MockAllowlist/contract/index.js';
+import {
+  AllowlistPrivateState,
+  AllowlistWitnesses,
+} from '../witnesses/AllowlistWitnesses.js';
+
+/**
+ * Type constructor args
+ */
+type AllowlistArgs = readonly [];
+
+const AllowlistSimulatorBase = createSimulator<
+  AllowlistPrivateState,
+  ReturnType<typeof ledger>,
+  ReturnType<typeof AllowlistWitnesses>,
+  MockAllowlist<AllowlistPrivateState>,
+  AllowlistArgs
+>({
+  contractFactory: (witnesses) =>
+    new MockAllowlist<AllowlistPrivateState>(witnesses),
+  defaultPrivateState: () => AllowlistPrivateState,
+  contractArgs: () => [],
+  ledgerExtractor: (state) => ledger(state),
+  witnessesFactory: () => AllowlistWitnesses(),
+});
+
+/**
+ * Allowlist Simulator
+ */
+export class AllowlistSimulator extends AllowlistSimulatorBase {
+  constructor(
+    options: BaseSimulatorOptions<
+      AllowlistPrivateState,
+      ReturnType<typeof AllowlistWitnesses>
+    > = {},
+  ) {
+    super([], options);
+  }
+
+  /**
+   * @description Returns whether `account` is currently allowed.
+   * @returns True if `account` is a member of the allowlist.
+   */
+  public isAllowed(account: Uint8Array): boolean {
+    return this.circuits.impure.isAllowed(account);
+  }
+
+  /**
+   * @description Asserts that `account` is allowed.
+   */
+  public assertAllowed(account: Uint8Array) {
+    this.circuits.impure.assertAllowed(account);
+  }
+
+  /**
+   * @description Adds `account` to the allowlist.
+   */
+  public allow(account: Uint8Array) {
+    this.circuits.impure.allow(account);
+  }
+
+  /**
+   * @description Removes `account` from the allowlist.
+   */
+  public disallow(account: Uint8Array) {
+    this.circuits.impure.disallow(account);
+  }
+}

--- a/contracts/src/security/test/witnesses/AllowlistWitnesses.ts
+++ b/contracts/src/security/test/witnesses/AllowlistWitnesses.ts
@@ -1,0 +1,8 @@
+// TEST-ONLY WITNESS. NOT FOR PRODUCTION USE.
+// Unaudited reference material that drives Compact circuits in
+// off-chain tests. Not shipped as a consumable artifact. Production
+// consumers must author and audit their own witnesses.
+
+export type AllowlistPrivateState = Record<string, never>;
+export const AllowlistPrivateState: AllowlistPrivateState = {};
+export const AllowlistWitnesses = () => ({});


### PR DESCRIPTION
Resolves #607 

The original idea was to consolidate allowlist with blocklist (similar to [ERC20Restricted](https://github.com/OpenZeppelin/openzeppelin-community-contracts/blob/master/contracts/token/ERC20/extensions/ERC20Restricted.sol)). The reason it was dismissed from this design was because we would not be able to cleanly support using both in a single contract due to compiler limitations. The other idea with consolidation would be to have two different sets: one for allows and one for blocks; however, this forces users who just want one to import ledger state that won't be used. Finally, keeping them as separate modules allows for it be explicit: There shouldn't be any confusion if a contract is using an allow list or a block list

As an aside, it is the author's opinion that these are `security` primitives; however, there is an argument that this belongs in `accesscontrol/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced allowlist functionality for account-based membership management and access control
  * Provides account validation capabilities and dynamic membership list management
  * Supports membership queries and enforcement mechanisms for access control

<!-- end of auto-generated comment: release notes by coderabbit.ai -->