### PR TITLE
test: apply PR #620 simulator-migration review feedback

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ SERVICES := proof-server indexer node
 
 ## Start local environment and stream logs to logs/
 env-up: env-down
-	docker compose -f $(COMPOSE_FILE) up -d
+	docker compose -f $(COMPOSE_FILE) up -d --wait
 	@mkdir -p $(LOGS_DIR)
 	@for svc in $(SERVICES); do \
 		docker compose -f $(COMPOSE_FILE) logs -f --no-log-prefix $$svc > $(LOGS_DIR)/$$svc.log 2>&1 & \

--- a/contracts/src/access/test/AccessControl.test.ts
+++ b/contracts/src/access/test/AccessControl.test.ts
@@ -150,9 +150,7 @@ describe('AccessControl', () => {
       // Set secret key for OP1
       await accessControl.privateState.injectSecretKey(OP1.secretKey);
 
-      await expect(
-        accessControl.assertOnlyRole(OPERATOR_ROLE_1),
-      ).resolves.not.toThrow();
+      await accessControl.assertOnlyRole(OPERATOR_ROLE_1);
     });
 
     it('should fail if caller is unauthorized', async () => {
@@ -200,9 +198,7 @@ describe('AccessControl', () => {
         true,
       );
 
-      await expect(
-        accessControl._checkRole(OPERATOR_ROLE_1, OP1.either),
-      ).resolves.not.toThrow();
+      await accessControl._checkRole(OPERATOR_ROLE_1, OP1.either);
     });
 
     it('should not fail if contract has role', async () => {
@@ -210,9 +206,7 @@ describe('AccessControl', () => {
         true,
       );
 
-      await expect(
-        accessControl._checkRole(OPERATOR_ROLE_1, OP1_CONTRACT),
-      ).resolves.not.toThrow();
+      await accessControl._checkRole(OPERATOR_ROLE_1, OP1_CONTRACT);
     });
 
     it('should fail if operator is unauthorized', async () => {
@@ -346,9 +340,7 @@ describe('AccessControl', () => {
 
       // OP1 holds OPERATOR_ROLE_1 which is admin of OPERATOR_ROLE_2
       await accessControl.privateState.injectSecretKey(OP1.secretKey);
-      await expect(
-        accessControl.grantRole(OPERATOR_ROLE_2, OP2.either),
-      ).resolves.not.toThrow();
+      await accessControl.grantRole(OPERATOR_ROLE_2, OP2.either);
     });
 
     it('admin should re-grant a role after revoking it', async () => {
@@ -379,9 +371,7 @@ describe('AccessControl', () => {
       );
 
       // Second grant should not throw or corrupt state
-      await expect(
-        accessControl.grantRole(OPERATOR_ROLE_1, OP1.either),
-      ).resolves.not.toThrow();
+      await accessControl.grantRole(OPERATOR_ROLE_1, OP1.either);
       expect(await accessControl.hasRole(OPERATOR_ROLE_1, OP1.either)).toBe(
         true,
       );
@@ -546,17 +536,13 @@ describe('AccessControl', () => {
       await accessControl.privateState.injectSecretKey(CUSTOM_ADMIN.secretKey);
 
       // Grant role and check it's been granted
-      await expect(
-        accessControl.grantRole(OPERATOR_ROLE_1, OP1.either),
-      ).resolves.not.toThrow();
+      await accessControl.grantRole(OPERATOR_ROLE_1, OP1.either);
       expect(await accessControl.hasRole(OPERATOR_ROLE_1, OP1.either)).toBe(
         true,
       );
 
       // Revoke role and check it's been revoked
-      await expect(
-        accessControl.revokeRole(OPERATOR_ROLE_1, OP1.either),
-      ).resolves.not.toThrow();
+      await accessControl.revokeRole(OPERATOR_ROLE_1, OP1.either);
       expect(await accessControl.hasRole(OPERATOR_ROLE_1, OP1.either)).toBe(
         false,
       );
@@ -589,9 +575,7 @@ describe('AccessControl', () => {
 
       // CUSTOM_ADMIN can grant
       await accessControl.privateState.injectSecretKey(CUSTOM_ADMIN.secretKey);
-      await expect(
-        accessControl.grantRole(OPERATOR_ROLE_1, OP1.either),
-      ).resolves.not.toThrow();
+      await accessControl.grantRole(OPERATOR_ROLE_1, OP1.either);
 
       // Overwrite admin role
       await accessControl._setRoleAdmin(OPERATOR_ROLE_1, NEW_ADMIN_ROLE);
@@ -603,9 +587,7 @@ describe('AccessControl', () => {
 
       // NEW_ADMIN should gain authority
       await accessControl.privateState.injectSecretKey(NEW_ADMIN.secretKey);
-      await expect(
-        accessControl.grantRole(OPERATOR_ROLE_1, OP2.either),
-      ).resolves.not.toThrow();
+      await accessControl.grantRole(OPERATOR_ROLE_1, OP2.either);
     });
   });
 

--- a/contracts/src/access/test/Ownable.test.ts
+++ b/contracts/src/access/test/Ownable.test.ts
@@ -161,7 +161,7 @@ describe('Ownable', () => {
 
     describe('assertOnlyOwner', () => {
       it('should allow owner to call', async () => {
-        await expect(ownable.assertOnlyOwner()).resolves.not.toThrow();
+        await ownable.assertOnlyOwner();
       });
 
       it('should fail when called by unauthorized', async () => {
@@ -208,7 +208,7 @@ describe('Ownable', () => {
 
         // New owner can call
         await ownable.privateState.injectSecretKey(NEW_OWNER.secretKey);
-        await expect(ownable.assertOnlyOwner()).resolves.not.toThrow();
+        await ownable.assertOnlyOwner();
       });
 
       it('should fail when unauthorized transfers ownership', async () => {
@@ -261,7 +261,7 @@ describe('Ownable', () => {
 
         // New owner can call
         await ownable.privateState.injectSecretKey(NEW_OWNER.secretKey);
-        await expect(ownable.assertOnlyOwner()).resolves.not.toThrow();
+        await ownable.assertOnlyOwner();
       });
 
       it('should transfer ownership to contract', async () => {
@@ -309,7 +309,7 @@ describe('Ownable', () => {
 
         // New owner can call
         await ownable.privateState.injectSecretKey(NEW_OWNER.secretKey);
-        await expect(ownable.assertOnlyOwner()).resolves.not.toThrow();
+        await ownable.assertOnlyOwner();
       });
 
       it('should transfer multiple times', async () => {
@@ -374,7 +374,7 @@ describe('Ownable', () => {
 
         // New owner can call
         await ownable.privateState.injectSecretKey(NEW_OWNER.secretKey);
-        await expect(ownable.assertOnlyOwner()).resolves.not.toThrow();
+        await ownable.assertOnlyOwner();
       });
 
       it('should fail when transferring to contract address zero', async () => {
@@ -424,7 +424,7 @@ describe('Ownable', () => {
 
         // New owner can call
         await ownable.privateState.injectSecretKey(NEW_OWNER.secretKey);
-        await expect(ownable.assertOnlyOwner()).resolves.not.toThrow();
+        await ownable.assertOnlyOwner();
       });
 
       it('should transfer ownership to contract', async () => {
@@ -453,7 +453,7 @@ describe('Ownable', () => {
 
         // New owner can call
         await ownable.privateState.injectSecretKey(NEW_OWNER.secretKey);
-        await expect(ownable.assertOnlyOwner()).resolves.not.toThrow();
+        await ownable.assertOnlyOwner();
       });
 
       it('should transfer multiple times', async () => {

--- a/contracts/src/access/test/ShieldedAccessControl.test.ts
+++ b/contracts/src/access/test/ShieldedAccessControl.test.ts
@@ -157,13 +157,11 @@ describe('ShieldedAccessControl', () => {
     it.each(
       circuitsNotRequiringInit,
     )('%s should succeed', async (circuitName, args) => {
-      await expect(
-        (
-          contract[circuitName as keyof ShieldedAccessControlSimulator] as (
-            ...a: unknown[]
-          ) => Promise<unknown>
-        )(...args),
-      ).resolves.not.toThrow();
+      await (
+        contract[circuitName as keyof ShieldedAccessControlSimulator] as (
+          ...a: unknown[]
+        ) => Promise<unknown>
+      )(...args);
     });
 
     it('should fail with zero instanceSalt', async () => {
@@ -324,9 +322,7 @@ describe('ShieldedAccessControl', () => {
 
       describe('should succeed', () => {
         it('when caller has correct key and valid path', async () => {
-          await expect(
-            contract.assertOnlyRole(ROLE_ADMIN),
-          ).resolves.not.toThrow();
+          await contract.assertOnlyRole(ROLE_ADMIN);
         });
 
         it('when caller holds multiple roles with same key', async () => {
@@ -348,9 +344,7 @@ describe('ShieldedAccessControl', () => {
           const newAccountId = buildAccountIdHash(newKey);
           await contract._grantRole(ROLE_ADMIN, newAccountId);
 
-          await expect(
-            contract.assertOnlyRole(ROLE_ADMIN),
-          ).resolves.not.toThrow();
+          await contract.assertOnlyRole(ROLE_ADMIN);
         });
       });
     });
@@ -536,23 +530,15 @@ describe('ShieldedAccessControl', () => {
 
       describe('should succeed', () => {
         it('when caller has admin role', async () => {
-          await expect(
-            contract.grantRole(ROLE_OP1, OP1_ACCOUNT_ID),
-          ).resolves.not.toThrow();
+          await contract.grantRole(ROLE_OP1, OP1_ACCOUNT_ID);
           await contract.privateState.injectSecretKey(OPERATOR_1_SK);
           expect(await contract.canProveRole(ROLE_OP1)).toBe(true);
         });
 
         it('when granting the same role multiple times to the same accountId', async () => {
-          await expect(
-            contract.grantRole(ROLE_OP1, OP1_ACCOUNT_ID),
-          ).resolves.not.toThrow();
-          await expect(
-            contract.grantRole(ROLE_OP1, OP1_ACCOUNT_ID),
-          ).resolves.not.toThrow();
-          await expect(
-            contract.grantRole(ROLE_OP1, OP1_ACCOUNT_ID),
-          ).resolves.not.toThrow();
+          await contract.grantRole(ROLE_OP1, OP1_ACCOUNT_ID);
+          await contract.grantRole(ROLE_OP1, OP1_ACCOUNT_ID);
+          await contract.grantRole(ROLE_OP1, OP1_ACCOUNT_ID);
 
           await contract.privateState.injectSecretKey(OPERATOR_1_SK);
           expect(await contract.canProveRole(ROLE_OP1)).toBe(true);
@@ -564,9 +550,7 @@ describe('ShieldedAccessControl', () => {
 
           // Switch to operator 1
           await contract.privateState.injectSecretKey(OPERATOR_1_SK);
-          await expect(
-            contract.grantRole(ROLE_OP2, OP2_ACCOUNT_ID),
-          ).resolves.not.toThrow();
+          await contract.grantRole(ROLE_OP2, OP2_ACCOUNT_ID);
           await contract.privateState.injectSecretKey(OPERATOR_2_SK);
           expect(await contract.canProveRole(ROLE_OP2)).toBe(true);
         });
@@ -579,9 +563,7 @@ describe('ShieldedAccessControl', () => {
           const newAccountId = buildAccountIdHash(newKey);
           await contract._grantRole(ROLE_ADMIN, newAccountId);
 
-          await expect(
-            contract.grantRole(ROLE_OP1, OP1_ACCOUNT_ID),
-          ).resolves.not.toThrow();
+          await contract.grantRole(ROLE_OP1, OP1_ACCOUNT_ID);
           await contract.privateState.injectSecretKey(OPERATOR_1_SK);
           expect(await contract.canProveRole(ROLE_OP1)).toBe(true);
         });
@@ -592,32 +574,24 @@ describe('ShieldedAccessControl', () => {
 
           // Admin 1 can grant
           await contract.privateState.injectSecretKey(OPERATOR_1_SK);
-          await expect(
-            contract.grantRole(ROLE_OP1, OP1_ACCOUNT_ID),
-          ).resolves.not.toThrow();
+          await contract.grantRole(ROLE_OP1, OP1_ACCOUNT_ID);
 
           // Admin 2 can grant
           await contract.privateState.injectSecretKey(OPERATOR_2_SK);
-          await expect(
-            contract.grantRole(ROLE_OP2, OP2_ACCOUNT_ID),
-          ).resolves.not.toThrow();
+          await contract.grantRole(ROLE_OP2, OP2_ACCOUNT_ID);
         });
 
         it('when admin holds multiple roles', async () => {
           await contract._grantRole(ROLE_OP1, ADMIN_ACCOUNT_ID);
           await contract._grantRole(ROLE_OP2, ADMIN_ACCOUNT_ID);
 
-          await expect(
-            contract.grantRole(ROLE_OP3, OP3_ACCOUNT_ID),
-          ).resolves.not.toThrow();
+          await contract.grantRole(ROLE_OP3, OP3_ACCOUNT_ID);
           await contract.privateState.injectSecretKey(OPERATOR_3_SK);
           expect(await contract.canProveRole(ROLE_OP3)).toBe(true);
         });
 
         it('when re-granting an active role (duplicate)', async () => {
-          await expect(
-            contract.grantRole(ROLE_ADMIN, ADMIN_ACCOUNT_ID),
-          ).resolves.not.toThrow();
+          await contract.grantRole(ROLE_ADMIN, ADMIN_ACCOUNT_ID);
           expect(await contract.canProveRole(ROLE_ADMIN)).toBe(true);
         });
       });
@@ -729,9 +703,7 @@ describe('ShieldedAccessControl', () => {
         await contract._revokeRole(ROLE_OP1, OP1_ACCOUNT_ID);
 
         // Different accountId for the same role
-        await expect(
-          contract._grantRole(ROLE_OP1, OP2_ACCOUNT_ID),
-        ).resolves.not.toThrow();
+        await contract._grantRole(ROLE_OP1, OP2_ACCOUNT_ID);
         await contract.privateState.injectSecretKey(OPERATOR_2_SK);
         expect(await contract.canProveRole(ROLE_OP1)).toBe(true);
       });
@@ -795,9 +767,7 @@ describe('ShieldedAccessControl', () => {
 
       describe('should succeed', () => {
         it('when caller has admin role', async () => {
-          await expect(
-            contract.revokeRole(ROLE_OP1, OP1_ACCOUNT_ID),
-          ).resolves.not.toThrow();
+          await contract.revokeRole(ROLE_OP1, OP1_ACCOUNT_ID);
           await contract.privateState.injectSecretKey(OPERATOR_1_SK);
           expect(await contract.canProveRole(ROLE_OP1)).toBe(false);
         });
@@ -809,9 +779,7 @@ describe('ShieldedAccessControl', () => {
           await contract.privateState.injectSecretKey(OPERATOR_1_SK);
           await contract._grantRole(ROLE_OP1, OP1_ACCOUNT_ID);
 
-          await expect(
-            contract.revokeRole(ROLE_OP2, OP2_ACCOUNT_ID),
-          ).resolves.not.toThrow();
+          await contract.revokeRole(ROLE_OP2, OP2_ACCOUNT_ID);
           await contract.privateState.injectSecretKey(OPERATOR_2_SK);
           expect(await contract.canProveRole(ROLE_OP2)).toBe(false);
         });
@@ -828,16 +796,12 @@ describe('ShieldedAccessControl', () => {
         });
 
         it('when revoking a role that was never granted', async () => {
-          await expect(
-            contract.revokeRole(ROLE_NONEXISTENT, ADMIN_ACCOUNT_ID),
-          ).resolves.not.toThrow();
+          await contract.revokeRole(ROLE_NONEXISTENT, ADMIN_ACCOUNT_ID);
           expect(await contract.canProveRole(ROLE_NONEXISTENT)).toBe(false);
         });
 
         it('when revoking a role from an unauthorized accountId that was never granted', async () => {
-          await expect(
-            contract.revokeRole(ROLE_OP1, UNAUTHORIZED_ACCOUNT_ID),
-          ).resolves.not.toThrow();
+          await contract.revokeRole(ROLE_OP1, UNAUTHORIZED_ACCOUNT_ID);
 
           await expect(
             contract._grantRole(ROLE_OP1, UNAUTHORIZED_ACCOUNT_ID),
@@ -860,9 +824,7 @@ describe('ShieldedAccessControl', () => {
           const newAccountId = buildAccountIdHash(newKey);
           await contract._grantRole(ROLE_ADMIN, newAccountId);
 
-          await expect(
-            contract.revokeRole(ROLE_OP1, OP1_ACCOUNT_ID),
-          ).resolves.not.toThrow();
+          await contract.revokeRole(ROLE_OP1, OP1_ACCOUNT_ID);
           await contract.privateState.injectSecretKey(OPERATOR_1_SK);
           expect(await contract.canProveRole(ROLE_OP1)).toBe(false);
         });
@@ -920,9 +882,7 @@ describe('ShieldedAccessControl', () => {
       });
 
       it('should allow revoking a role that was never granted', async () => {
-        await expect(
-          contract._revokeRole(ROLE_NONEXISTENT, ADMIN_ACCOUNT_ID),
-        ).resolves.not.toThrow();
+        await contract._revokeRole(ROLE_NONEXISTENT, ADMIN_ACCOUNT_ID);
       });
     });
 
@@ -932,9 +892,7 @@ describe('ShieldedAccessControl', () => {
       });
 
       it('should allow caller to renounce their own role', async () => {
-        await expect(
-          contract.renounceRole(ROLE_ADMIN, ADMIN_ACCOUNT_ID),
-        ).resolves.not.toThrow();
+        await contract.renounceRole(ROLE_ADMIN, ADMIN_ACCOUNT_ID);
         expect(await contract.canProveRole(ROLE_ADMIN)).toBe(false);
       });
 
@@ -1016,9 +974,7 @@ describe('ShieldedAccessControl', () => {
         await contract._grantRole(ROLE_OP1, OP1_ACCOUNT_ID);
 
         // ADMIN renounces ROLE_OP1 despite never holding it
-        await expect(
-          contract.renounceRole(ROLE_OP1, ADMIN_ACCOUNT_ID),
-        ).resolves.not.toThrow();
+        await contract.renounceRole(ROLE_OP1, ADMIN_ACCOUNT_ID);
 
         // OP1's grant is unaffected — different accountId, different nullifier
         await contract.privateState.injectSecretKey(OPERATOR_1_SK);
@@ -1056,17 +1012,13 @@ describe('ShieldedAccessControl', () => {
         await contract._setRoleAdmin(ROLE_OP1, new Uint8Array(32));
 
         // DEFAULT_ADMIN_ROLE holder can grant ROLE_OP1 again
-        await expect(
-          contract.grantRole(ROLE_OP1, OP1_ACCOUNT_ID),
-        ).resolves.not.toThrow();
+        await contract.grantRole(ROLE_OP1, OP1_ACCOUNT_ID);
         await contract.privateState.injectSecretKey(OPERATOR_1_SK);
         expect(await contract.canProveRole(ROLE_OP1)).toBe(true);
 
         // And can revoke
         await contract.privateState.injectSecretKey(ADMIN_SK);
-        await expect(
-          contract.revokeRole(ROLE_OP1, OP1_ACCOUNT_ID),
-        ).resolves.not.toThrow();
+        await contract.revokeRole(ROLE_OP1, OP1_ACCOUNT_ID);
         await contract.privateState.injectSecretKey(OPERATOR_1_SK);
         expect(await contract.canProveRole(ROLE_OP1)).toBe(false);
       });
@@ -1135,9 +1087,7 @@ describe('ShieldedAccessControl', () => {
 
         // Switch to operator 1 who is now admin of ROLE_OP2
         await contract.privateState.injectSecretKey(OPERATOR_1_SK);
-        await expect(
-          contract.revokeRole(ROLE_OP2, OP2_ACCOUNT_ID),
-        ).resolves.not.toThrow();
+        await contract.revokeRole(ROLE_OP2, OP2_ACCOUNT_ID);
         await contract.privateState.injectSecretKey(OPERATOR_2_SK);
         expect(await contract.canProveRole(ROLE_OP2)).toBe(false);
       });
@@ -1148,9 +1098,7 @@ describe('ShieldedAccessControl', () => {
         await contract._grantRole(ROLE_OP1, OP1_ACCOUNT_ID);
 
         // ADMIN can grant ROLE_OP1 (admin is DEFAULT_ADMIN_ROLE)
-        await expect(
-          contract.grantRole(ROLE_OP1, OP2_ACCOUNT_ID),
-        ).resolves.not.toThrow();
+        await contract.grantRole(ROLE_OP1, OP2_ACCOUNT_ID);
 
         // But ADMIN cannot directly grant ROLE_OP2 (admin is ROLE_OP1, not DEFAULT_ADMIN_ROLE)
         await expect(
@@ -1159,9 +1107,7 @@ describe('ShieldedAccessControl', () => {
 
         // OP1 holder can grant ROLE_OP2
         await contract.privateState.injectSecretKey(OPERATOR_1_SK);
-        await expect(
-          contract.grantRole(ROLE_OP2, OP3_ACCOUNT_ID),
-        ).resolves.not.toThrow();
+        await contract.grantRole(ROLE_OP2, OP3_ACCOUNT_ID);
       });
     });
 

--- a/contracts/src/access/test/ZOwnablePK.test.ts
+++ b/contracts/src/access/test/ZOwnablePK.test.ts
@@ -135,9 +135,11 @@ describe('ZOwnablePK', () => {
     it('should allow pure computeOwnerId', async () => {
       const eitherOwner = utils.createEitherTestUser('OWNER');
 
-      await expect(
-        ownable._computeOwnerId(eitherOwner, randomByteArray),
-      ).resolves.not.toThrow();
+      const ownerId = await ownable._computeOwnerId(
+        eitherOwner,
+        randomByteArray,
+      );
+      expect(ownerId).toHaveLength(32);
     });
   });
 
@@ -211,9 +213,7 @@ describe('ZOwnablePK', () => {
         await ownable.privateState.injectSecretNonce(
           Buffer.from(newOwnerNonce),
         );
-        await expect(
-          ownable.as('NEW_OWNER').assertOnlyOwner(),
-        ).resolves.not.toThrow();
+        await ownable.as('NEW_OWNER').assertOnlyOwner();
       });
 
       it('should fail when transferring to id zero', async () => {
@@ -225,7 +225,7 @@ describe('ZOwnablePK', () => {
 
       it('should fail when unauthorized transfers ownership', async () => {
         await expect(
-          ownable.as('UNAUTHORIZED').transferOwnership(newOwnerCommitment),
+          ownable.as('UNAUTHORIZED').transferOwnership(newIdHash),
         ).rejects.toThrow('ZOwnablePK: caller is not the owner');
       });
 
@@ -237,7 +237,7 @@ describe('ZOwnablePK', () => {
           .ZOwnablePK__counter;
 
         // Transfer
-        await ownable.as('OWNER').transferOwnership(newOwnerCommitment);
+        await ownable.as('OWNER').transferOwnership(newIdHash);
 
         // Check counter
         const afterInstance = (await ownable.getPublicState())
@@ -273,9 +273,7 @@ describe('ZOwnablePK', () => {
         expect(newCommitment).toEqual(expNewCommitment);
 
         // Check same owner maintains permissions after transfer
-        await expect(
-          ownable.as('OWNER').assertOnlyOwner(),
-        ).resolves.not.toThrow();
+        await ownable.as('OWNER').assertOnlyOwner();
       });
     });
 
@@ -320,9 +318,7 @@ describe('ZOwnablePK', () => {
           secretNonce,
         );
 
-        await expect(
-          ownable.as('OWNER').assertOnlyOwner(),
-        ).resolves.not.toThrow();
+        await ownable.as('OWNER').assertOnlyOwner();
       });
 
       it('should fail when the authorized caller has the wrong nonce', async () => {
@@ -503,13 +499,9 @@ describe('ZOwnablePK', () => {
 
       it('should allow anyone to transfer', async () => {
         const id = createIdHash(Z_OWNER, secretNonce);
-        await expect(
-          ownable.as('OWNER')._transferOwnership(id),
-        ).resolves.not.toThrow();
+        await ownable.as('OWNER')._transferOwnership(id);
 
-        await expect(
-          ownable.as('UNAUTHORIZED')._transferOwnership(id),
-        ).resolves.not.toThrow();
+        await ownable.as('UNAUTHORIZED')._transferOwnership(id);
       });
     });
   });

--- a/contracts/src/token/test/MultiToken.test.ts
+++ b/contracts/src/token/test/MultiToken.test.ts
@@ -180,9 +180,7 @@ describe('MultiToken', () => {
     it('should allow initialization post deployment', async () => {
       await token.initialize(URI);
 
-      await expect(
-        token.balanceOf(OWNER.either, TOKEN_ID),
-      ).resolves.not.toThrow();
+      expect(await token.balanceOf(OWNER.either, TOKEN_ID)).toBe(0n);
     });
   });
 

--- a/contracts/src/token/test/nonFungibleToken.test.ts
+++ b/contracts/src/token/test/nonFungibleToken.test.ts
@@ -627,9 +627,7 @@ describe('NonFungibleToken', () => {
       await token._setApprovalForAll(OWNER.either, SPENDER.either, true);
 
       await token.privateState.injectSecretKey(OWNER.secretKey);
-      await expect(
-        token.transferFrom(OWNER.either, OWNER.either, TOKENID_1),
-      ).resolves.not.toThrow();
+      await token.transferFrom(OWNER.either, OWNER.either, TOKENID_1);
       expect(await token.ownerOf(TOKENID_1)).toEqual(OWNER.either);
       expect(await token.balanceOf(OWNER.either)).toEqual(1n);
       expect(await token.getApproved(TOKENID_1)).toEqual(ZERO_ACCOUNT);
@@ -1189,9 +1187,7 @@ describe('NonFungibleToken', () => {
 
   describe('_unsafeMint', () => {
     it('should mint to ContractAddress', async () => {
-      await expect(
-        token._unsafeMint(SOME_CONTRACT, TOKENID_1),
-      ).resolves.not.toThrow();
+      await token._unsafeMint(SOME_CONTRACT, TOKENID_1);
     });
 
     it('should not mint to zero address (accountId)', async () => {
@@ -1230,9 +1226,7 @@ describe('NonFungibleToken', () => {
     });
 
     it('should transfer to ContractAddress', async () => {
-      await expect(
-        token._unsafeTransfer(OWNER.either, SOME_CONTRACT, TOKENID_1),
-      ).resolves.not.toThrow();
+      await token._unsafeTransfer(OWNER.either, SOME_CONTRACT, TOKENID_1);
     });
 
     it('should transfer token to account', async () => {
@@ -1312,9 +1306,7 @@ describe('NonFungibleToken', () => {
 
     it('should transfer to ContractAddress', async () => {
       await token.privateState.injectSecretKey(OWNER.secretKey);
-      await expect(
-        token._unsafeTransferFrom(OWNER.either, SOME_CONTRACT, TOKENID_1),
-      ).resolves.not.toThrow();
+      await token._unsafeTransferFrom(OWNER.either, SOME_CONTRACT, TOKENID_1);
     });
 
     it('should not transfer to zero address (accountId)', async () => {

--- a/local-env.yml
+++ b/local-env.yml
@@ -1,7 +1,7 @@
 # WARNING: Insecure default credentials below. For local development only — do not use in production.
 services:
   proof-server:
-    image: 'midnightntwrk/proof-server:latest'
+    image: 'midnightntwrk/proof-server:8.0.3'
     command: ['midnight-proof-server -v']
     ports:
       - '6300:6300'
@@ -15,7 +15,10 @@ services:
       start_period: 10s
 
   indexer:
-    image: 'midnightntwrk/indexer-standalone:latest'
+    # Pinned: `latest` drifted to the Cardano-bridge indexer line, whose config
+    # requires an `infra.spo_node.blockfrost_id` not set here, so it crash-loops
+    # on boot. 4.0.1 is the last pre-bridge release compatible with node 0.22.2.
+    image: 'midnightntwrk/indexer-standalone:4.0.1'
     ports:
       - '8088:8088'
     environment:


### PR DESCRIPTION
## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

Follow-up to #620. Applies the CodeRabbit + Andrew review feedback that
landed after #620 was merged.

### Applied

- **Drop the redundant `resolves.not.toThrow()` matcher** across the access
  and token unit specs (54 sites). On a resolving promise the matcher is
  vacuous (`.resolves` already fails the test on rejection), so the calls
  are now a plain `await`, which is what Andrew suggested.
- **Assert resolved values** where the call returns data: MultiToken
  `balanceOf` is `0n` after init, and ZOwnablePK `_computeOwnerId` returns
  32 bytes.
- **`transferOwnership` now receives `newIdHash`** (the new owner id) rather
  than the commitment, so the id-to-commitment path and the counter-bump
  case are actually exercised.
- **Pin the live-stack images**: `proof-server:8.0.3` and
  `indexer-standalone:4.0.1`, the validated combo for `midnight-node:0.22.2`.
  `latest` drifts onto the Cardano-bridge indexer line, which crash-loops on
  boot against this stack.
- **`make env-up` waits for health** (`docker compose up -d --wait`), so
  `yarn test:live` straight after env-up no longer races the stack during
  startup.

### Not applied (with reason)

- **`await this.setPrivateState(...)` in the three `injectSecretKey` helpers.**
  `setPrivateState` is synchronous (`: void`) in
  `@openzeppelin/compact-simulator@0.2.0`, so there is no promise to await
  and no race. Awaiting it would await `undefined` and falsely imply
  asynchrony.
- **Splitting the proof-server `command` into `['midnight-proof-server', '-v']`.**
  The image `ENTRYPOINT` is `bash -c`, so `['midnight-proof-server -v']` is
  parsed correctly. Splitting would push `-v` into `$0` and silently drop the
  verbose flag.
- **Removing `src/archive/`.** Deferred to #621, which replaces it with the
  final feature (agreed in review).

## PR Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md#your-first-code-contribution)
- [x] I have added tests that prove my fix is effective or that my feature works. See [GUIDELINES.md#testing](../GUIDELINES.md#testing) for more information.
- [ ] I have added documentation for new methods or changes to existing method behavior. See [GUIDELINES.md#documentation](../GUIDELINES.md#documentation) for more information.
- [ ] CI Workflows Are Passing

#### Further comments

Local validation was limited to `tsc --noEmit` (green) in this environment;
the dry unit suite (`yarn test`) runs in CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved local environment startup reliability by waiting for services to become ready before completing setup.
  * Pinned key local services to specific versions to reduce unexpected boot failures and crash loops.

* **Tests**
  * Strengthened automated coverage around access control, ownership, and token behaviors to better validate successful flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->