### PR TITLE
feat(token): native shielded token derived-nonce extension

### DIFF
--- a/contracts/src/token/extensions/NativeShieldedTokenDerivedNonce.compact
+++ b/contracts/src/token/extensions/NativeShieldedTokenDerivedNonce.compact
@@ -40,7 +40,9 @@ pragma language_version >= 0.23.0;
  * - Access-control both mint paths, and avoid exposing them at different trust
  *   levels.
  * - Do not rely on retrying. The nonce is a pure function of the counter, and a
- *   reverted mint may not advance it, so the retry can collide again.
+ *   reverted mint will not advance it, so an identical retry collides again.
+ *   Recovery is a mint with different inputs (recipient or amount): it advances
+ *   the counter, so the original tuple then mints against a fresh nonce.
  */
 module NativeShieldedTokenDerivedNonce {
   import CompactStandardLibrary;

--- a/contracts/src/token/extensions/NativeShieldedTokenDerivedNonce.compact
+++ b/contracts/src/token/extensions/NativeShieldedTokenDerivedNonce.compact
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Compact Contracts v0.2.0 (token/extensions/NativeShieldedTokenDerivedNonce.compact)
+// OpenZeppelin Compact Contracts v0.3.0-alpha (token/extensions/NativeShieldedTokenDerivedNonce.compact)
 
 pragma language_version >= 0.23.0;
 
@@ -10,20 +10,21 @@ pragma language_version >= 0.23.0;
  * owns a monotonic `_counter` and exposes `_deriveNonce`; it imports no token
  * module and needs no initialization.
  *
- * @notice Pairs with `NativeShieldedToken`, `NativeShieldedTokenFamily`, and
- * `NativeTokenConverter`. The consuming contract composes the pieces:
+ * @notice Pairs with `NativeShieldedToken` and `NativeShieldedTokenFamily`. The
+ * consuming contract composes the pieces:
  *
  *   export circuit mint(recipient: ..., amount: Uint<64>): ShieldedCoinInfo {
  *     return Token__mint(recipient, amount, Derived__deriveNonce());
  *   }
  *
  * @dev Derivation
- * Each call derives `evolveNonce(_counter, pad(32, "NativeShieldedToken:nonce"))`:
- * the monotonic counter guarantees uniqueness, and the fixed tag pushes derived
- * nonces out of the small-integer space an honest caller of the base `_mint`
- * might pick, avoiding accidental cross-path collisions. One counter serves the
- * whole contract, so derived nonces never repeat across token types (domains)
- * or across the shielded/converter mint paths of one contract.
+ * Each call derives `evolveNonce(_counter, pad(32, "NativeShieldedToken:nonce"))`.
+ * `evolveNonce` hashes the counter into a full 32-byte nonce, so uniqueness comes
+ * from the monotonic counter, not the tag. The fixed tag is a domain separator:
+ * it keeps these derived nonces from clashing with any other `evolveNonce` call
+ * the implementing contract makes on the same counter for a different purpose.
+ * One counter serves the whole contract, so derived nonces never repeat across
+ * token types (domains) of one contract.
  *
  * @notice This variant is deterministic and recipient-PUBLIC by design: derived
  * nonces are predictable from public state, so anyone can recompute the coin
@@ -38,8 +39,9 @@ pragma language_version >= 0.23.0;
  * collides with a future derived-nonce mint of the same tuple, making that mint
  * fail on duplicate-commitment rejection. Gate both mint paths behind access
  * control, and prefer not exposing both to distinct trust levels. A failed mint
- * is recoverable: any subsequent derived mint advances the counter past the
- * collision.
+ * is recoverable with the same recipient and amount: the counter has already
+ * advanced, so the retry derives a fresh nonce and therefore a different
+ * commitment, which no longer collides.
  */
 module NativeShieldedTokenDerivedNonce {
   import CompactStandardLibrary;
@@ -51,8 +53,7 @@ module NativeShieldedTokenDerivedNonce {
 
   /**
    * @description Advances the counter and returns the next derived coin nonce,
-   * for use as the `nonce` argument of a native token mint or a converter
-   * shield.
+   * for use as the `nonce` argument of a native token mint.
    *
    * @notice The derivation input is public ledger state, so mints using this
    * nonce are recipient-public; see the module notes.

--- a/contracts/src/token/extensions/NativeShieldedTokenDerivedNonce.compact
+++ b/contracts/src/token/extensions/NativeShieldedTokenDerivedNonce.compact
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Compact Contracts v0.2.0 (token/extensions/NativeShieldedTokenDerivedNonce.compact)
+
+pragma language_version >= 0.23.0;
+
+/**
+ * @module NativeShieldedTokenDerivedNonce
+ * @description Optional standalone extension providing derived coin nonces for
+ * native shielded token mints, so callers need not manage nonces themselves. It
+ * owns a monotonic `_counter` and exposes `_deriveNonce`; it imports no token
+ * module and needs no initialization.
+ *
+ * @notice Pairs with `NativeShieldedToken`, `NativeShieldedTokenFamily`, and
+ * `NativeTokenConverter`. The consuming contract composes the pieces:
+ *
+ *   export circuit mint(recipient: ..., amount: Uint<64>): ShieldedCoinInfo {
+ *     return Token__mint(recipient, amount, Derived__deriveNonce());
+ *   }
+ *
+ * @dev Derivation
+ * Each call derives `evolveNonce(_counter, pad(32, "NativeShieldedToken:nonce"))`:
+ * the monotonic counter guarantees uniqueness, and the fixed tag pushes derived
+ * nonces out of the small-integer space an honest caller of the base `_mint`
+ * might pick, avoiding accidental cross-path collisions. One counter serves the
+ * whole contract, so derived nonces never repeat across token types (domains)
+ * or across the shielded/converter mint paths of one contract.
+ *
+ * @notice This variant is deterministic and recipient-PUBLIC by design: derived
+ * nonces are predictable from public state, so anyone can recompute the coin
+ * commitment for candidate recipient keys. For recipient privacy, call the base
+ * `_mint` with a secret, cryptographically random nonce instead. (An earlier
+ * design seeded a hash chain to make the sequence look random; that bought
+ * nothing here because the seed and chain are disclosed to public state, so it
+ * was removed.)
+ *
+ * @notice The predictability also enables deliberate collision-griefing: an
+ * actor with access to a caller-nonce mint can pre-mint a commitment that
+ * collides with a future derived-nonce mint of the same tuple, making that mint
+ * fail on duplicate-commitment rejection. Gate both mint paths behind access
+ * control, and prefer not exposing both to distinct trust levels. A failed mint
+ * is recoverable: any subsequent derived mint advances the counter past the
+ * collision.
+ */
+module NativeShieldedTokenDerivedNonce {
+  import CompactStandardLibrary;
+
+  /**
+   * @description Monotonic index feeding the derived-nonce derivation.
+   */
+  export ledger _counter: Counter;
+
+  /**
+   * @description Advances the counter and returns the next derived coin nonce,
+   * for use as the `nonce` argument of a native token mint or a converter
+   * shield.
+   *
+   * @notice The derivation input is public ledger state, so mints using this
+   * nonce are recipient-public; see the module notes.
+   *
+   * @circuitInfo k=9, rows=451
+   *
+   * @return {Bytes<32>} - The next derived coin nonce.
+   */
+  export circuit _deriveNonce(): Bytes<32> {
+    _counter.increment(1);
+    return evolveNonce(_counter, pad(32, "NativeShieldedToken:nonce"));
+  }
+}

--- a/contracts/src/token/extensions/NativeShieldedTokenDerivedNonce.compact
+++ b/contracts/src/token/extensions/NativeShieldedTokenDerivedNonce.compact
@@ -34,14 +34,13 @@ pragma language_version >= 0.23.0;
  * nothing here because the seed and chain are disclosed to public state, so it
  * was removed.)
  *
- * @notice The predictability also enables deliberate collision-griefing: an
- * actor with access to a caller-nonce mint can pre-mint a commitment that
- * collides with a future derived-nonce mint of the same tuple, making that mint
- * fail on duplicate-commitment rejection. Gate both mint paths behind access
- * control, and prefer not exposing both to distinct trust levels. A failed mint
- * is recoverable with the same recipient and amount: the counter has already
- * advanced, so the retry derives a fresh nonce and therefore a different
- * commitment, which no longer collides.
+ * @notice Collision-griefing. Derived nonces are predictable, so an actor with a
+ * caller-nonce mint can pre-mint a colliding commitment and make the matching
+ * derived-nonce mint fail. Mitigations:
+ * - Access-control both mint paths, and avoid exposing them at different trust
+ *   levels.
+ * - Do not rely on retrying. The nonce is a pure function of the counter, and a
+ *   reverted mint may not advance it, so the retry can collide again.
  */
 module NativeShieldedTokenDerivedNonce {
   import CompactStandardLibrary;

--- a/contracts/src/token/test/extensions/NativeShieldedTokenDerivedNonce.test.ts
+++ b/contracts/src/token/test/extensions/NativeShieldedTokenDerivedNonce.test.ts
@@ -36,4 +36,19 @@ describe('NativeShieldedTokenDerivedNonce (extension)', () => {
     }
     expect(seen.size).toBe(N);
   });
+
+  it('should derive an identical sequence across independent instances', async () => {
+    // The derivation is a pure function of the public counter, so two fresh
+    // deployments must yield byte-identical nonce sequences. This is a loud
+    // guard: any hidden randomness introduced into `_deriveNonce` would make
+    // the two sequences diverge and fail this assertion.
+    const other = await NativeShieldedTokenDerivedNonceSimulator.create();
+    const seqA: string[] = [];
+    const seqB: string[] = [];
+    for (let i = 0; i < 5; i++) {
+      seqA.push(toHex(await nonce._deriveNonce()));
+      seqB.push(toHex(await other._deriveNonce()));
+    }
+    expect(seqA).toStrictEqual(seqB);
+  });
 });

--- a/contracts/src/token/test/extensions/NativeShieldedTokenDerivedNonce.test.ts
+++ b/contracts/src/token/test/extensions/NativeShieldedTokenDerivedNonce.test.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { NativeShieldedTokenDerivedNonceSimulator } from '../simulators/NativeShieldedTokenDerivedNonceSimulator.js';
+
+const toHex = (u: Uint8Array): string => Buffer.from(u).toString('hex');
+
+// The derived-nonce extension is counter-only: it needs no initialization, and
+// `_deriveNonce` is callable immediately after deploy.
+
+let nonce: NativeShieldedTokenDerivedNonceSimulator;
+
+describe('NativeShieldedTokenDerivedNonce (extension)', () => {
+  beforeEach(async () => {
+    nonce = await NativeShieldedTokenDerivedNonceSimulator.create();
+  });
+
+  it('should derive a 32-byte nonce without any initialization', async () => {
+    expect(await nonce.nonceCounter()).toBe(0n);
+    const n = await nonce._deriveNonce();
+    expect(n).toBeInstanceOf(Uint8Array);
+    expect(n.length).toBe(32);
+  });
+
+  it('should advance the counter on each call', async () => {
+    expect(await nonce.nonceCounter()).toBe(0n);
+    await nonce._deriveNonce();
+    expect(await nonce.nonceCounter()).toBe(1n);
+    await nonce._deriveNonce();
+    expect(await nonce.nonceCounter()).toBe(2n);
+  });
+
+  it('should never repeat a derived nonce across N calls', async () => {
+    const N = 25;
+    const seen = new Set<string>();
+    for (let i = 0; i < N; i++) {
+      seen.add(toHex(await nonce._deriveNonce()));
+    }
+    expect(seen.size).toBe(N);
+  });
+});

--- a/contracts/src/token/test/mocks/MockNativeShieldedTokenDerivedNonce.compact
+++ b/contracts/src/token/test/mocks/MockNativeShieldedTokenDerivedNonce.compact
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+
+// WARNING: FOR TESTING PURPOSES ONLY.
+// This contract exposes internal circuits and bypasses safety checks that the
+// corresponding production contract relies on. DO NOT deploy or use this
+// contract in any production application.
+
+pragma language_version >= 0.23.0;
+
+import CompactStandardLibrary;
+
+import "../../extensions/NativeShieldedTokenDerivedNonce" prefix NativeShieldedTokenDerivedNonce_;
+
+// Unit mock for the NativeShieldedTokenDerivedNonce extension in isolation. It
+// imports no token module and needs no initialization (counter-only). The
+// counter is re-exported so tests can read it via the typed `Ledger`.
+export { NativeShieldedTokenDerivedNonce__counter };
+
+export circuit _deriveNonce(): Bytes<32> {
+  return NativeShieldedTokenDerivedNonce__deriveNonce();
+}

--- a/contracts/src/token/test/simulators/NativeShieldedTokenDerivedNonceSimulator.ts
+++ b/contracts/src/token/test/simulators/NativeShieldedTokenDerivedNonceSimulator.ts
@@ -1,0 +1,69 @@
+import {
+  createSimulator,
+  type SimulatorOptions,
+} from '@openzeppelin/compact-simulator';
+import {
+  Contract as MockNativeShieldedTokenDerivedNonce,
+  ledger,
+} from '../../../../artifacts/MockNativeShieldedTokenDerivedNonce/contract/index.js';
+
+/**
+ * The derived-nonce extension declares no witnesses, so the private state is
+ * empty and the witnesses object is `{}`.
+ */
+export type NativeShieldedTokenDerivedNoncePrivateState = Record<string, never>;
+export const NativeShieldedTokenDerivedNoncePrivateState: NativeShieldedTokenDerivedNoncePrivateState =
+  {};
+export const NativeShieldedTokenDerivedNonceWitnesses = () => ({});
+
+/** Counter-only: the extension needs no initialization, so the ctor is nullary. */
+type NativeShieldedTokenDerivedNonceArgs = readonly [];
+
+const NativeShieldedTokenDerivedNonceSimulatorBase = createSimulator<
+  NativeShieldedTokenDerivedNoncePrivateState,
+  ReturnType<typeof ledger>,
+  ReturnType<typeof NativeShieldedTokenDerivedNonceWitnesses>,
+  MockNativeShieldedTokenDerivedNonce<NativeShieldedTokenDerivedNoncePrivateState>,
+  NativeShieldedTokenDerivedNonceArgs
+>({
+  contractFactory: (witnesses) =>
+    new MockNativeShieldedTokenDerivedNonce<NativeShieldedTokenDerivedNoncePrivateState>(
+      witnesses,
+    ),
+  defaultPrivateState: () => NativeShieldedTokenDerivedNoncePrivateState,
+  contractArgs: () => [],
+  ledgerExtractor: (state) => ledger(state),
+  witnessesFactory: () => NativeShieldedTokenDerivedNonceWitnesses(),
+  artifactName: 'MockNativeShieldedTokenDerivedNonce',
+});
+
+/**
+ * NativeShieldedTokenDerivedNonce (extension) Simulator.
+ *
+ * Drives `_deriveNonce` directly and reads the counter; the extension imports
+ * no token module and needs no initialization.
+ */
+export class NativeShieldedTokenDerivedNonceSimulator extends NativeShieldedTokenDerivedNonceSimulatorBase {
+  static async create(
+    options: SimulatorOptions<
+      NativeShieldedTokenDerivedNoncePrivateState,
+      ReturnType<typeof NativeShieldedTokenDerivedNonceWitnesses>
+    > = {},
+  ): Promise<NativeShieldedTokenDerivedNonceSimulator> {
+    // biome-ignore lint/complexity/noThisInStatic: super.create must keep the subclass `this`
+    return super.create(
+      [],
+      options,
+    ) as Promise<NativeShieldedTokenDerivedNonceSimulator>;
+  }
+
+  /** @description Advances the counter and returns the next derived coin nonce. */
+  public _deriveNonce(): Promise<Uint8Array> {
+    return this.circuits.impure._deriveNonce();
+  }
+
+  /** @description Current value of the derived-nonce counter. */
+  public async nonceCounter(): Promise<bigint> {
+    return (await this.getPublicState()).NativeShieldedTokenDerivedNonce__counter;
+  }
+}


### PR DESCRIPTION
## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

Stacked on #621 (core native shielded token). **Base this PR's review on the diff against `feat/native-shielded-token-supply`, not `main`.**

Optional derived coin nonces for native shielded token mints, so callers need not manage nonces themselves:

- Counter-only: owns a monotonic `_counter` and derives `evolveNonce(_counter, tag)` in a single hash. Uniqueness comes from the counter; the fixed tag namespaces derived nonces away from raw caller-supplied ones. No seed, no init.
- Deterministic and recipient-public by design. For recipient privacy, call the base `_mint` with a secret, random nonce instead.
- Standalone mock, simulator, and unit suite (imports no token module).

## PR Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md#your-first-code-contribution)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added documentation for new methods or changes to existing method behavior.
- [ ] CI Workflows Are Passing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deterministic nonce derivation for shielded token flows, with a counter-based 32-byte nonce that advances on each use.
  * Included simulator support so the new behavior can be exercised in test environments.

* **Tests**
  * Added coverage for nonce length, counter progression, uniqueness across repeated derivations, and consistent results across separate runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->