### PR TITLE
Test subgroup enforcement, improve ElGamal doc

### DIFF
--- a/contracts/src/crypto/ElGamal.compact
+++ b/contracts/src/crypto/ElGamal.compact
@@ -34,16 +34,29 @@ pragma language_version >= 0.23.0;
  * scalar. Feeding a raw `persistentHash` output into `ecMulGenerator` would
  * occasionally exceed the Jubjub scalar field order and fault at runtime.
  *
- * @dev Subgroup membership. Every `JubjubPoint` reaching a curve operation is
- * in the Jubjub prime-order subgroup, including points supplied by a caller as
- * a witness or argument (e.g. a recipient `pk`, or the message point in
- * `encryptPoint`). The Midnight runtime enforces this at the ZK-constraint
+ * @dev TRUST ASSUMPTION — subgroup membership. This is the module's most
+ * load-bearing assumption. Every `JubjubPoint` reaching a curve operation is
+ * assumed to be in the Jubjub prime-order subgroup, including points supplied by
+ * a caller as a witness or argument (e.g. a recipient `pk`, or the message point
+ * in `encryptPoint`). The Midnight runtime enforces this at the ZK-constraint
  * level: the embedded-curve gadget assigns points via cofactor clearing, so an
  * off-curve / low-order / mixed-order point makes the circuit unsatisfiable.
- * This module therefore performs NO in-circuit subgroup check (one is neither
- * needed nor expressible: `ecMul` by the subgroup order faults, and
- * `JubjubPoint` is opaque). The `ecNeg` identity and the homomorphic algebra
- * rely on this guarantee.
+ * The module therefore performs NO in-circuit subgroup check: the runtime
+ * already constrains membership (so it is unnecessary), and the direct test
+ * `ℓ*P == O` is unavailable anyway because `ecMul` by `ℓ` faults (verified — `ℓ`
+ * exceeds the valid scalar range, while `ℓ-1` is accepted). The `ecNeg` identity
+ * (`(ℓ-1)*P = -P`) and the homomorphic algebra depend on this holding.
+ *
+ * Basis (and its limits): source-verified against `midnight-circuits` 6.0.0 —
+ * the version vendored by the Midnight onchain-runtime we compile against —
+ * specifically `ecc::native::edwards_chip`, where `assign` cofactor-clears the
+ * point and `q_mem`'s `create_membership_gate` enforces on-curve, reached from
+ * the ZKIR `ec_mul`/`ec_add` lowering via `ecc_from_parts`. This is NOT a
+ * team-confirmed or audited guarantee: compactc and midnight-ledger are
+ * unaudited, so treat it as a substantiated-but-unaudited assumption. It is
+ * pinned against regression by `crypto/test/CurveRuntimeInvariants.test.ts` (a
+ * runtime behavior canary) and MUST be re-verified in source on any Midnight
+ * runtime / circuits version bump.
  *
  * @dev Weak keys. Encrypting under the identity point yields `c2 = m` with no
  * masking (the plaintext is exposed), and the identity is a valid subgroup
@@ -142,13 +155,15 @@ module ElGamal {
   /**
    * @description Negates a Jubjub point.
    *
-   * @notice Implemented as scalar multiplication by `ORDER - 1` rather than the
-   * obvious `ecMul(p, -1)`: the scalar `-1` computed in the `Field` type is
-   * `BLS_modulus - 1`, which exceeds the Jubjub scalar field order and faults
-   * `ecMul` ("failed to decode for built-in type EmbeddedFr"). `JubjubPoint`
-   * is opaque (no coordinate access), so coordinate negation is unavailable.
-   * The `(ORDER-1)*P = -P` identity holds only in the prime-order subgroup, but
-   * that always applies here: the runtime constrains every assigned `JubjubPoint`
+   * @notice Implemented as scalar multiplication by `ℓ-1` (via
+   * `JUBJUB_SUBGROUP_ORDER_MINUS_ONE`) rather than the obvious `ecMul(p, -1)`:
+   * the scalar `-1` computed in the `Field` type is `BLS_modulus - 1`, which
+   * exceeds the Jubjub scalar field order and faults `ecMul` ("failed to decode
+   * for built-in type EmbeddedFr"). (Coordinate negation `(-x, y)` via
+   * `constructJubjubPoint`/`jubjubPointX`/`jubjubPointY` is an equivalent
+   * alternative that does not depend on the subgroup assumption.) The
+   * `(ℓ-1)*P = -P` identity holds only in the prime-order subgroup, but that
+   * always applies here: the runtime constrains every assigned `JubjubPoint`
    * into the prime-order subgroup (the embedded-curve gadget assigns points via
    * cofactor clearing), so no in-subgroup precondition needs to be checked or
    * assumed. See the module-level subgroup note.

--- a/contracts/src/crypto/test/CurveRuntimeInvariants.test.ts
+++ b/contracts/src/crypto/test/CurveRuntimeInvariants.test.ts
@@ -1,0 +1,130 @@
+import {
+  constructJubjubPoint,
+  type JubjubPoint,
+} from '@midnight-ntwrk/compact-runtime';
+import { describe, expect, it } from 'vitest';
+import { pureCircuits } from '../../../artifacts/MockCurveOps/contract/index.js';
+
+// ---------------------------------------------------------------------------
+// RUNTIME-INVARIANTS REGRESSION TEST.
+//
+// The ElGamal module relies on every JubjubPoint reaching a curve operation
+// being in the prime-order subgroup. The Midnight runtime guarantees this at
+// the ZK-constraint level: the embedded-curve gadget (midnight-circuits
+// `ecc::native::edwards_chip`) assigns points via cofactor clearing. It
+// constrains the witnessed coordinates to a cofactor-cleared point, whose image
+// is exactly the prime-order subgroup, with `q_mem`'s membership gate
+// (-x^2 + y^2 = 1 + d*x^2*y^2) enforcing on-curve. So a point outside the
+// subgroup (off-curve, low-order, or mixed-order) makes the circuit
+// unsatisfiable, surfacing here as a runtime trap.
+//
+// This test pins that property. If a future runtime stops enforcing it, the
+// trap-expectations below fail loudly as a signal that the module's check-free
+// reliance on subgroup membership must be revisited.
+// ---------------------------------------------------------------------------
+
+// Jubjub base field modulus q = BLS12-381 scalar field order.
+const Q =
+  52435875175126190479447740508185965837690552500527637822603658699938581184513n;
+
+// (0, q-1) = (0, -1): on-curve, order 2 -> NOT in the prime-order subgroup.
+const ORDER_2 = constructJubjubPoint(0n, Q - 1n);
+// (1, 1): off-curve (fails the twisted Edwards equation).
+const OFF_CURVE = constructJubjubPoint(1n, 1n);
+// arbitrary coords < q, unknown structure.
+const GARBAGE = constructJubjubPoint(12345n, 67890n);
+
+// Classify a runtime call as a returned value or a trap.
+const classify = <T>(
+  fn: () => T,
+): { ok: true; value: T } | { ok: false; err: string } => {
+  try {
+    return { ok: true, value: fn() };
+  } catch (e) {
+    return { ok: false, err: (e as Error).message };
+  }
+};
+
+const threw = (p: JubjubPoint, fn: (p: JubjubPoint) => unknown): boolean =>
+  !classify(() => fn(p)).ok;
+
+describe('JubjubPoint subgroup enforcement (runtime invariant)', () => {
+  const inSubgroup = pureCircuits.genMul(5n); // generator-derived -> in subgroup
+
+  // MIXED-ORDER point of order 2*ℓ: an in-subgroup point plus the order-2 point.
+  // In twisted Edwards, (x,y) + (0,-1) = (-x,-y), so this is just coordinate
+  // negation of a real point. It is on-curve, NOT in the prime-order subgroup,
+  // and (crucially) NOT a low-order point, so it should not hit any
+  // addition-formula exception. This is the realistic attack vector.
+  const MIXED = constructJubjubPoint(Q - inSubgroup.x, Q - inSubgroup.y);
+
+  it('FACT: a JubjubPoint is fabricable from arbitrary coordinates', () => {
+    expect(ORDER_2).toEqual({ x: 0n, y: Q - 1n });
+  });
+
+  // -------------------------------------------------------------------------
+  // MIXED-ORDER point: the case that distinguishes "real subgroup enforcement"
+  // from "incidental low-order formula exception".
+  // -------------------------------------------------------------------------
+  describe('mixed-order point (order 2*ℓ) — the decisive case', () => {
+    it('TRAPS ecMul on a mixed-order point (genuine subgroup enforcement)', () => {
+      expect(classify(() => pureCircuits.doEcMul(MIXED, 3n)).ok).toBe(false);
+    });
+
+    it('TRAPS ecAdd on a mixed-order point', () => {
+      expect(classify(() => pureCircuits.doEcAdd(MIXED, inSubgroup)).ok).toBe(
+        false,
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // ecMul: does it reject non-subgroup / off-curve points?
+  // -------------------------------------------------------------------------
+  describe('ecMul input validation', () => {
+    it('accepts an in-subgroup point', () => {
+      expect(threw(inSubgroup, (p) => pureCircuits.doEcMul(p, 3n))).toBe(false);
+    });
+
+    it('TRAPS on an on-curve order-2 point (off-subgroup)', () => {
+      expect(threw(ORDER_2, (p) => pureCircuits.doEcMul(p, 3n))).toBe(true);
+    });
+
+    it('TRAPS on an off-curve point', () => {
+      expect(threw(OFF_CURVE, (p) => pureCircuits.doEcMul(p, 3n))).toBe(true);
+    });
+
+    it('TRAPS on a garbage point', () => {
+      expect(threw(GARBAGE, (p) => pureCircuits.doEcMul(p, 3n))).toBe(true);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // ecAdd: THE linchpin for encryptPoint (m flows through ecAdd, not ecMul).
+  // -------------------------------------------------------------------------
+  describe('ecAdd input validation', () => {
+    it('accepts two in-subgroup points', () => {
+      expect(
+        classify(() => pureCircuits.doEcAdd(inSubgroup, inSubgroup)).ok,
+      ).toBe(true);
+    });
+
+    it('TRAPS when an order-2 point is added', () => {
+      expect(classify(() => pureCircuits.doEcAdd(ORDER_2, inSubgroup)).ok).toBe(
+        false,
+      );
+    });
+
+    it('TRAPS when an off-curve point is added', () => {
+      expect(
+        classify(() => pureCircuits.doEcAdd(OFF_CURVE, inSubgroup)).ok,
+      ).toBe(false);
+    });
+
+    it('TRAPS when a garbage point is added', () => {
+      expect(classify(() => pureCircuits.doEcAdd(GARBAGE, inSubgroup)).ok).toBe(
+        false,
+      );
+    });
+  });
+});

--- a/contracts/src/crypto/test/mocks/MockCurveOps.compact
+++ b/contracts/src/crypto/test/mocks/MockCurveOps.compact
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+
+// TEST-ONLY. NOT FOR PRODUCTION USE.
+// Exposes the raw Jubjub curve built-ins so the runtime-invariants regression
+// test (CurveRuntimeInvariants.test.ts) can assert that the Midnight runtime
+// rejects any point outside the prime-order subgroup. This pins a property the
+// ElGamal module's safety depends on (see the module's subgroup note): if a
+// future runtime stops enforcing subgroup membership on curve ops, that test
+// fails loudly. DO NOT deploy.
+
+pragma language_version >= 0.23.0;
+
+import CompactStandardLibrary;
+
+export pure circuit doEcMul(p: JubjubPoint, k: Field): JubjubPoint {
+  return ecMul(p, k);
+}
+
+export pure circuit doEcAdd(a: JubjubPoint, b: JubjubPoint): JubjubPoint {
+  return ecAdd(a, b);
+}
+
+export pure circuit genMul(k: Field): JubjubPoint {
+  return ecMulGenerator(k);
+}


### PR DESCRIPTION
Address one point in #633:

> This identity (ecNeg(P) = (ℓ-1)·P = -P) holds only for prime-order-subgroup points, which rests on the module's Subgroup membership note: every assigned JubjubPoint is cofactor-cleared into the subgroup. Is that confirmed with the compactc / ledger team, or inferred from observed behaviour? Since compactc and midnight-ledger are unaudited, it is the most load-bearing assumption in the module. If it is an assumption rather than a guarantee, consider promoting it from @dev prose to a named trust assumption.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified curve-operation safety notes with a stronger trust-assumption statement and more explicit guidance on subgroup handling.
  - Updated developer-facing notes to better explain edge cases in point negation.

- **Tests**
  - Added regression coverage for elliptic-curve operations to verify correct behavior for valid points and failures for invalid, low-order, and mixed-order points.
  - Added test-only helpers to exercise curve operations directly in a controlled environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->