### PR TITLE
add ecdhMask

### DIFF
--- a/contracts/src/crypto/EcdhMask.compact
+++ b/contracts/src/crypto/EcdhMask.compact
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Compact Contracts v0.3.0-alpha (crypto/EcdhMask.compact)
+
+pragma language_version >= 0.23.0;
+
+/**
+ * @module EcdhMask
+ * @description Stateless ECDH hybrid encryption of a single field element to a
+ * Jubjub public key. Delivers a value to whoever holds the secret behind a
+ * Jubjub public key WITHOUT encoding it in the exponent, so recovery needs no
+ * discrete-log search and the value is unbounded within `Uint<128>`. This is the
+ * direct-decrypt counterpart to the homomorphic `crypto/ElGamal`: use ElGamal to
+ * accumulate ciphertexts, use this to hand a recipient the plaintext.
+ *
+ * Construction (recipient key `pk = g^ek`, ephemeral scalar `e` fresh per call):
+ *   E    = g^e                      (ephemeral public key)
+ *   S    = pk^e = g^{ek*e}          (ECDH shared secret point)
+ *   mask = KDF(S)                   (domain-separated Field, see `kdf`)
+ *   ct   = value + mask             (field one-time-pad)
+ * Recipient recovers: S = E^ek, mask = KDF(S), value = ct - mask.
+ *
+ * @dev Freshness and secrecy precondition (CRITICAL). `e` MUST be both unique per
+ * call to the same recipient AND secret (unpredictable to observers), even across
+ * circuit invocations that reuse a randomness seed.
+ *
+ * Uniqueness: the mask is a one-time pad, so a repeated `e` repeats `S` and
+ * `mask`, and reusing a pad is catastrophic (subtracting two ciphertexts recovers
+ * both values).
+ *
+ * Secrecy: `recipientPk` is public, so anyone who learns `e` recomputes
+ * `S = recipientPk^e`, hence the mask, and opens the ciphertext. A unique but
+ * PREDICTABLE `e` (a plain counter, a public nonce) therefore breaks
+ * confidentiality completely. `e` must be high-entropy and secret, exactly like
+ * an ElGamal encryption randomness (see `crypto/ElGamal`), not merely distinct.
+ *
+ * The caller supplies `e` and owns both properties, e.g. by expanding a secret
+ * per-invocation seed bound to a per-recipient-unique nonce (a monotonic index).
+ * This is stronger than exponential ElGamal's uniqueness requirement (there,
+ * reuse merely leaks plaintext equality); do not treat `e` as "any randomness."
+ *
+ * @dev Weak inputs. Two degenerate inputs zero the shared secret and expose the
+ * value: `recipientPk = identity` gives `S = identity` for any `e`, and `e = 0`
+ * gives `S = identity` for any key. These are the only two (for a subgroup key,
+ * `S = identity` iff `e = 0`). Both yield `mask = KDF(identity, domain)`, a value
+ * any observer can recompute, so `ct = value + mask` opens trivially. The
+ * identity is a valid subgroup point, so the runtime subgroup guarantee does NOT
+ * catch it; `encrypt` therefore asserts `recipientPk != identity` and `e != 0`,
+ * mirroring `crypto/ElGamal`'s `encryptPoint` guards.
+ *
+ * @dev Integrity. The pad is malleable and NO authentication is added here. This
+ * is safe in the intended on-chain use, where the ciphertext is computed
+ * in-circuit from a value the same circuit commits to elsewhere (a producer
+ * cannot desync the two) and is immutable once written (no in-transit attacker).
+ * A corrupted ciphertext could only fail the recipient's own later proof, never
+ * enable theft. Consumers with a different threat model (mutable storage,
+ * in-transit tampering) MUST add their own authentication.
+ *
+ * @dev Security. This is hashed ElGamal (ECIES without a MAC) over Jubjub and
+ * inherits its guarantees: IND-CPA under the Oracle Diffie-Hellman assumption in
+ * the random-oracle model (the `persistentHash` KDF keyed by the secret point
+ * `S`). It is NOT IND-CCA: the additive pad is malleable (see Integrity), which
+ * is acceptable here only because the on-chain ciphertext is bound in-circuit to
+ * the value it commits to elsewhere. Hiding carries a large margin: `kdf` returns
+ * a `degradeToTransient` output in `[0, 2^248)` while `value < 2^128`, so even
+ * treating the KDF output as uniform the value is hidden with about `2^-120`
+ * statistical slack, leaving only the assumption that the hash of the DH secret
+ * is PRF-like. Confidentiality relies on the runtime constraining every
+ * `JubjubPoint` into the prime-order subgroup (see `crypto/ElGamal`), so `S`
+ * cannot be a low-order point that leaks `ek`. Binding the ephemeral `E` into the
+ * KDF is deliberately omitted: for a fixed `recipientPk`, `E = g^e` and
+ * `S = pk^e` are both determined by `e`, so `KDF(S)` already varies with `E` and
+ * folding it in buys nothing.
+ *
+ * @dev No ledger state, no witnesses. Every circuit is pure and takes its keys,
+ * value, and randomness as explicit arguments. `decrypt` is exposed as a pure
+ * circuit for wallet/off-chain use (recovering a received value needs no proof);
+ * the on-chain path only ever calls `encrypt`.
+ */
+module EcdhMask {
+  import CompactStandardLibrary;
+
+  /**
+   * @description An ECDH one-time-pad ciphertext: the ephemeral public key and
+   * the field-masked value.
+   */
+  export struct Ciphertext {
+    ephemeralPk: JubjubPoint;
+    ct: Field;
+  }
+
+  /**
+   * @description Derives the field mask from the ECDH shared secret point,
+   * domain-separated by a caller-supplied `domain` tag. Hashes the point to
+   * `Bytes<32>`, then re-hashes it with the domain tag and truncates into the
+   * field via `degradeToTransient`. The consumer chooses `domain` (so this
+   * module is not tied to any one protocol) and MUST use the same value on
+   * encrypt and decrypt.
+   *
+   * @dev Uses `persistentHash` deliberately: the recipient reproduces this mask
+   * to decrypt, possibly across a platform upgrade, so it must be upgrade-stable.
+   *
+   * @param sShared - The ECDH shared secret point (`pk^e` for the sender,
+   *                  `E^ek` for the recipient; equal by construction).
+   * @param domain - The consumer's domain-separation tag.
+   * @return The field mask.
+   */
+  export pure circuit kdf(sShared: JubjubPoint, domain: Bytes<32>): Field {
+    const pointHash = persistentHash<JubjubPoint>(sShared);
+    return degradeToTransient(
+      persistentHash<Vector<2, Bytes<32>>>([pointHash, domain])
+    );
+  }
+
+  /**
+   * @description Encrypts `value` to `recipientPk` under ephemeral scalar `e`.
+   *
+   * @notice `e` MUST be fresh per call (see the module freshness precondition).
+   *
+   * Requirements:
+   *
+   * - `recipientPk` is not the identity point.
+   * - `e` is non-zero, a valid Jubjub scalar (`< ℓ`), secret, and fresh per call.
+   *
+   * @param recipientPk - The recipient's Jubjub public key (`g^ek`).
+   * @param value - The value to deliver (any `Uint<128>`; no `2^48` bound).
+   * @param e - A fresh ephemeral scalar.
+   * @param domain - The consumer's domain-separation tag (must match decrypt).
+   * @return The ciphertext `{ ephemeralPk = g^e, ct = value + KDF(pk^e) }`.
+   */
+  export pure circuit encrypt(
+                        recipientPk: JubjubPoint,
+                        value: Uint<128>,
+                        e: Field,
+                        domain: Bytes<32>
+                        ): Ciphertext {
+    assert(recipientPk != ecMulGenerator(0 as Field), "EcdhMask: identity pk");
+    assert(e != 0 as Field, "EcdhMask: zero ephemeral");
+    const ephemeralPk = ecMulGenerator(e);
+    const sShared = ecMul(recipientPk, e);
+    const mask = kdf(sShared, domain);
+    return Ciphertext { ephemeralPk: ephemeralPk, ct: (value as Field) + mask };
+  }
+
+  /**
+   * @description Recovers the value from a ciphertext using the recipient's
+   * secret scalar. Pure and off-chain (no proof needed to read a received value).
+   *
+   * @param ciphertext - The ciphertext to decrypt.
+   * @param ekScalar - The recipient's secret scalar (`secretToScalar(EK)`).
+   * @param domain - The consumer's domain-separation tag (must match encrypt).
+   * @return The recovered value as a `Field` (equal to the original `value`,
+   *         which is `< 2^128`).
+   */
+  export pure circuit decrypt(ciphertext: Ciphertext, ekScalar: Field, domain: Bytes<32>): Field {
+    const sShared = ecMul(ciphertext.ephemeralPk, ekScalar);
+    const mask = kdf(sShared, domain);
+    return ciphertext.ct - mask;
+  }
+}

--- a/contracts/src/crypto/EcdhMask.compact
+++ b/contracts/src/crypto/EcdhMask.compact
@@ -40,12 +40,17 @@ pragma language_version >= 0.23.0;
  *
  * @dev Weak inputs. Two degenerate inputs zero the shared secret and expose the
  * value: `recipientPk = identity` gives `S = identity` for any `e`, and `e = 0`
- * gives `S = identity` for any key. These are the only two (for a subgroup key,
- * `S = identity` iff `e = 0`). Both yield `mask = KDF(identity, domain)`, a value
- * any observer can recompute, so `ct = value + mask` opens trivially. The
+ * gives `S = identity` for any key. Both yield `mask = KDF(identity, domain)`, a
+ * value any observer can recompute, so `ct = value + mask` opens trivially. The
  * identity is a valid subgroup point, so the runtime subgroup guarantee does NOT
- * catch it; `encrypt` therefore asserts `recipientPk != identity` and `e != 0`,
- * mirroring `crypto/ElGamal`'s `encryptPoint` guards.
+ * catch it; `encrypt` therefore asserts `recipientPk != identity` and
+ * `ephemeralPk (= g^e) != identity`. Guarding the ephemeral POINT rather than the
+ * scalar subsumes `e != 0` and stays correct regardless of how the runtime treats
+ * an out-of-range scalar: `g^e = identity` captures both `e = 0` and any
+ * `e ≡ 0 (mod ℓ)`. (Guarding `e != 0` directly would instead lean on the runtime
+ * faulting `ecMul` for scalars `≥ ℓ`; the point guard removes that dependency.)
+ * These are the only weak inputs (for a subgroup key, `S = identity` iff the
+ * ephemeral point is the identity).
  *
  * @dev Integrity. The pad is malleable and NO authentication is added here. This
  * is safe in the intended on-chain use, where the ciphertext is computed
@@ -70,6 +75,13 @@ pragma language_version >= 0.23.0;
  * KDF is deliberately omitted: for a fixed `recipientPk`, `E = g^e` and
  * `S = pk^e` are both determined by `e`, so `KDF(S)` already varies with `E` and
  * folding it in buys nothing.
+ *
+ * @dev Shared key with `crypto/ElGamal` (in scope). A consumer MAY use the same
+ * recipient Jubjub key for both these memos (hashed ElGamal) and exponential-
+ * ElGamal balance ciphertexts, as the confidential token does. This joint use is
+ * safe: the two schemes share only the public key, this KDF is domain-separated
+ * and keyed by the secret DH point, and neither exposes a decryption oracle, so
+ * under CPA / ODH a ciphertext of one scheme does not help attack the other.
  *
  * @dev No ledger state, no witnesses. Every circuit is pure and takes its keys,
  * value, and randomness as explicit arguments. `decrypt` is exposed as a pure
@@ -133,9 +145,14 @@ module EcdhMask {
                         e: Field,
                         domain: Bytes<32>
                         ): Ciphertext {
-    assert(recipientPk != ecMulGenerator(0 as Field), "EcdhMask: identity pk");
-    assert(e != 0 as Field, "EcdhMask: zero ephemeral");
+    const identity = ecMulGenerator(0 as Field);
+    assert(recipientPk != identity, "EcdhMask: identity pk");
     const ephemeralPk = ecMulGenerator(e);
+    // Guard the ephemeral POINT, not the scalar: `ephemeralPk == identity`
+    // captures `e == 0` and any `e` that reduces to 0 mod l, so the guard is
+    // correct regardless of how the runtime treats an out-of-range scalar. This
+    // subsumes `e != 0` (see the weak-inputs note).
+    assert(ephemeralPk != identity, "EcdhMask: zero ephemeral");
     const sShared = ecMul(recipientPk, e);
     const mask = kdf(sShared, domain);
     return Ciphertext { ephemeralPk: ephemeralPk, ct: (value as Field) + mask };
@@ -146,7 +163,8 @@ module EcdhMask {
    * secret scalar. Pure and off-chain (no proof needed to read a received value).
    *
    * @param ciphertext - The ciphertext to decrypt.
-   * @param ekScalar - The recipient's secret scalar (`secretToScalar(EK)`).
+   * @param ekScalar - The recipient's secret scalar (`crypto/ElGamal`'s
+   *                   `secretToScalar(EK)`).
    * @param domain - The consumer's domain-separation tag (must match encrypt).
    * @return The recovered value as a `Field` (equal to the original `value`,
    *         which is `< 2^128`).

--- a/contracts/src/crypto/test/CurveRuntimeInvariants.test.ts
+++ b/contracts/src/crypto/test/CurveRuntimeInvariants.test.ts
@@ -27,6 +27,12 @@ import { pureCircuits } from '../../../artifacts/MockCurveOps/contract/index.js'
 const Q =
   52435875175126190479447740508185965837690552500527637822603658699938581184513n;
 
+// Jubjub prime-order subgroup order ell. Valid ecMul scalars are [0, ell-1]; the
+// runtime faults on scalars >= ell. crypto/ElGamal (negation by ell-1) and
+// EcdhMask's ephemeral-point guard both lean on this range fault.
+const L =
+  6554484396890773809930967563523245729705921265872317281365359162392183254199n;
+
 // (0, q-1) = (0, -1): on-curve, order 2 -> NOT in the prime-order subgroup.
 const ORDER_2 = constructJubjubPoint(0n, Q - 1n);
 // (1, 1): off-curve (fails the twisted Edwards equation).
@@ -125,6 +131,24 @@ describe('JubjubPoint subgroup enforcement (runtime invariant)', () => {
       expect(classify(() => pureCircuits.doEcAdd(GARBAGE, inSubgroup)).ok).toBe(
         false,
       );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Scalar-range fault: ecMulGenerator (and ecMul) must fault on scalars >= ell.
+  // EcdhMask's "only two weak inputs" reasoning and ElGamal's negation-by-(ell-1)
+  // both depend on it. Pinning it means a runtime that silently reduced mod ell
+  // (letting e = ell pass as e = 0, yielding a publicly recomputable mask) fails
+  // loudly here. Note EcdhMask's encrypt no longer relies on this: it guards the
+  // ephemeral POINT (g^e != identity), which catches e = ell regardless.
+  // -------------------------------------------------------------------------
+  describe('scalar-range fault (ecMulGenerator)', () => {
+    it('accepts the maximum valid scalar (ell - 1)', () => {
+      expect(classify(() => pureCircuits.genMul(L - 1n)).ok).toBe(true);
+    });
+
+    it('TRAPS on scalar == ell (out of range)', () => {
+      expect(classify(() => pureCircuits.genMul(L)).ok).toBe(false);
     });
   });
 });

--- a/contracts/src/crypto/test/EcdhMask.test.ts
+++ b/contracts/src/crypto/test/EcdhMask.test.ts
@@ -2,9 +2,16 @@ import { ecMulGenerator } from '@midnight-ntwrk/compact-runtime';
 import fc from 'fast-check';
 import { describe, expect, it } from 'vitest';
 import { pureCircuits } from '../../../artifacts/MockEcdhMask/contract/index.js';
+import { pureCircuits as elgamal } from '../../../artifacts/MockElGamal/contract/index.js';
 
 // The EcdhMask circuits are pure, so tests drive them directly via the compiled
 // artifact's `pureCircuits` (no proof, no simulator needed).
+
+// Jubjub prime-order subgroup order. Valid scalars are [1, L-1]; the runtime
+// faults ecMul on scalars >= L (see crypto/ElGamal), so L-1 is the largest
+// valid scalar.
+const L =
+  6554484396890773809930967563523245729705921265872317281365359162392183254199n;
 
 // A recipient's secret scalar and their derived public key g^ek.
 const EK = 111222333444555n;
@@ -38,12 +45,36 @@ describe('EcdhMask', () => {
       expect(pureCircuits.decrypt(ciphertext, EK, DOMAIN)).toBe(big);
     });
 
-    it('round-trips the maximum Uint<128> value (no field wrap)', () => {
-      // mask < 2^248 and value < 2^128, so value + mask never reaches the field
-      // order: even the largest value recovers exactly.
+    it('round-trips the maximum Uint<128> value', () => {
+      // Recovery is field subtraction (ct - mask), which is exact even if
+      // value + mask wrapped the field modulus, so the max value round-trips
+      // regardless of wrap.
       const max = (1n << 128n) - 1n;
       const ciphertext = pureCircuits.encrypt(PK, max, 42n, DOMAIN);
       expect(pureCircuits.decrypt(ciphertext, EK, DOMAIN)).toBe(max);
+    });
+
+    it('round-trips at the maximum valid scalar (L - 1) for key and ephemeral', () => {
+      // Exercise the top of the valid scalar range: both the recipient key's
+      // secret and the ephemeral are L - 1, the largest scalar the runtime
+      // accepts (L and above fault ecMul).
+      const ek = L - 1n;
+      const e = L - 1n;
+      const max = (1n << 128n) - 1n;
+      const pk = ecMulGenerator(ek);
+      const ciphertext = pureCircuits.encrypt(pk, max, e, DOMAIN);
+      expect(pureCircuits.decrypt(ciphertext, ek, DOMAIN)).toBe(max);
+    });
+
+    it('round-trips through the real crypto/ElGamal key derivation', () => {
+      // The CFT memo path derives the recipient pair from a Bytes<32> EK via
+      // crypto/ElGamal: pk = derivePk(EK), ekScalar = secretToScalar(EK). Pin
+      // that shared-key infrastructure end to end rather than using raw scalars.
+      const ekBytes = new Uint8Array(32).fill(0x11);
+      const pk = elgamal.derivePk(ekBytes);
+      const ekScalar = elgamal.secretToScalar(ekBytes);
+      const ciphertext = pureCircuits.encrypt(pk, 4242n, 99n, DOMAIN);
+      expect(pureCircuits.decrypt(ciphertext, ekScalar, DOMAIN)).toBe(4242n);
     });
 
     it('round-trips for arbitrary keys, ephemerals, and values (property)', () => {
@@ -136,6 +167,17 @@ describe('EcdhMask', () => {
       expect(pureCircuits.kdf(PK, domain('a'))).not.toBe(
         pureCircuits.kdf(PK, domain('b')),
       );
+    });
+
+    it('produces a mask below 2^248 (hiding-margin regression)', () => {
+      // The module's ~2^-120 hiding margin rests on the kdf output staying in
+      // [0, 2^248) (the degradeToTransient range). Pin that stdlib behavior over
+      // several points so a regression surfaces here rather than silently
+      // shrinking the margin.
+      const bound = 1n << 248n;
+      for (const s of [2n, 5n, 222n, 999999n]) {
+        expect(pureCircuits.kdf(ecMulGenerator(s), DOMAIN)).toBeLessThan(bound);
+      }
     });
   });
 });

--- a/contracts/src/crypto/test/EcdhMask.test.ts
+++ b/contracts/src/crypto/test/EcdhMask.test.ts
@@ -140,7 +140,9 @@ describe('EcdhMask', () => {
     it('does not recover the value under the wrong secret key', () => {
       const ciphertext = pureCircuits.encrypt(PK, 1000n, 42n, DOMAIN);
       const WRONG_EK = 999999n;
-      expect(pureCircuits.decrypt(ciphertext, WRONG_EK, DOMAIN)).not.toBe(1000n);
+      expect(pureCircuits.decrypt(ciphertext, WRONG_EK, DOMAIN)).not.toBe(
+        1000n,
+      );
     });
 
     it('does not recover the value under the wrong domain', () => {

--- a/contracts/src/crypto/test/EcdhMask.test.ts
+++ b/contracts/src/crypto/test/EcdhMask.test.ts
@@ -1,0 +1,141 @@
+import { ecMulGenerator } from '@midnight-ntwrk/compact-runtime';
+import fc from 'fast-check';
+import { describe, expect, it } from 'vitest';
+import { pureCircuits } from '../../../artifacts/MockEcdhMask/contract/index.js';
+
+// The EcdhMask circuits are pure, so tests drive them directly via the compiled
+// artifact's `pureCircuits` (no proof, no simulator needed).
+
+// A recipient's secret scalar and their derived public key g^ek.
+const EK = 111222333444555n;
+const PK = ecMulGenerator(EK);
+
+// A consumer-supplied domain-separation tag. Must match on encrypt/decrypt.
+const domain = (label: string): Uint8Array => {
+  const d = new Uint8Array(32);
+  d.set(new TextEncoder().encode(label).slice(0, 32));
+  return d;
+};
+const DOMAIN = domain('ecdh_mask_test');
+
+describe('EcdhMask', () => {
+  describe('encrypt / decrypt round-trip', () => {
+    it('recovers the encrypted value', () => {
+      const ciphertext = pureCircuits.encrypt(PK, 1000n, 42n, DOMAIN);
+      expect(pureCircuits.decrypt(ciphertext, EK, DOMAIN)).toBe(1000n);
+    });
+
+    it('round-trips zero', () => {
+      const ciphertext = pureCircuits.encrypt(PK, 0n, 42n, DOMAIN);
+      expect(pureCircuits.decrypt(ciphertext, EK, DOMAIN)).toBe(0n);
+    });
+
+    it('round-trips a value far above 2^48 (no discrete-log bound)', () => {
+      // This is the whole point of the ECDH mask: values are delivered
+      // directly, so there is no BSGS table and no 2^48 cap.
+      const big = 1n << 120n;
+      const ciphertext = pureCircuits.encrypt(PK, big, 42n, DOMAIN);
+      expect(pureCircuits.decrypt(ciphertext, EK, DOMAIN)).toBe(big);
+    });
+
+    it('round-trips the maximum Uint<128> value (no field wrap)', () => {
+      // mask < 2^248 and value < 2^128, so value + mask never reaches the field
+      // order: even the largest value recovers exactly.
+      const max = (1n << 128n) - 1n;
+      const ciphertext = pureCircuits.encrypt(PK, max, 42n, DOMAIN);
+      expect(pureCircuits.decrypt(ciphertext, EK, DOMAIN)).toBe(max);
+    });
+
+    it('round-trips for arbitrary keys, ephemerals, and values (property)', () => {
+      fc.assert(
+        fc.property(
+          // Keys and ephemerals stay well under the Jubjub subgroup order ℓ
+          // (~2^252) so they are valid scalars; values span the full Uint<128>.
+          fc.bigInt({ min: 1n, max: 1n << 200n }),
+          fc.bigInt({ min: 1n, max: 1n << 200n }),
+          fc.bigInt({ min: 0n, max: (1n << 128n) - 1n }),
+          (ek, e, value) => {
+            const pk = ecMulGenerator(ek);
+            const ciphertext = pureCircuits.encrypt(pk, value, e, DOMAIN);
+            expect(pureCircuits.decrypt(ciphertext, ek, DOMAIN)).toBe(value);
+          },
+        ),
+      );
+    });
+  });
+
+  describe('freshness / pad reuse', () => {
+    it('reusing the ephemeral to one recipient leaks the value difference', () => {
+      // The freshness footgun in executable form: a repeated `e` to the same
+      // recipient reuses the one-time pad, so the ciphertext difference equals
+      // the plaintext difference. This is exactly why `e` MUST be fresh; the
+      // test also pins the pad semantics against a KDF regression.
+      const e = 7n;
+      const c1 = pureCircuits.encrypt(PK, 1000n, e, DOMAIN);
+      const c2 = pureCircuits.encrypt(PK, 250n, e, DOMAIN);
+      expect(c1.ct - c2.ct).toBe(1000n - 250n);
+    });
+  });
+
+  describe('weak-input guards', () => {
+    it('rejects encryption to the identity public key', () => {
+      const identity = ecMulGenerator(0n);
+      expect(() => pureCircuits.encrypt(identity, 1000n, 42n, DOMAIN)).toThrow(
+        'identity pk',
+      );
+    });
+
+    it('rejects a zero ephemeral', () => {
+      expect(() => pureCircuits.encrypt(PK, 1000n, 0n, DOMAIN)).toThrow(
+        'zero ephemeral',
+      );
+    });
+  });
+
+  describe('confidentiality / correctness properties', () => {
+    it('distinct ephemerals yield distinct ciphertexts for the same value', () => {
+      const c1 = pureCircuits.encrypt(PK, 1000n, 1n, DOMAIN);
+      const c2 = pureCircuits.encrypt(PK, 1000n, 2n, DOMAIN);
+      expect(c1.ct).not.toBe(c2.ct);
+      expect(c1.ephemeralPk).not.toEqual(c2.ephemeralPk);
+    });
+
+    it('distinct values yield distinct ciphertexts under the same ephemeral', () => {
+      const c1 = pureCircuits.encrypt(PK, 1000n, 5n, DOMAIN);
+      const c2 = pureCircuits.encrypt(PK, 2000n, 5n, DOMAIN);
+      expect(c1.ct).not.toBe(c2.ct);
+    });
+
+    it('does not recover the value under the wrong secret key', () => {
+      const ciphertext = pureCircuits.encrypt(PK, 1000n, 42n, DOMAIN);
+      const WRONG_EK = 999999n;
+      expect(pureCircuits.decrypt(ciphertext, WRONG_EK, DOMAIN)).not.toBe(1000n);
+    });
+
+    it('does not recover the value under the wrong domain', () => {
+      const ciphertext = pureCircuits.encrypt(PK, 1000n, 42n, DOMAIN);
+      expect(pureCircuits.decrypt(ciphertext, EK, domain('other'))).not.toBe(
+        1000n,
+      );
+    });
+  });
+
+  describe('kdf', () => {
+    it('is deterministic for the same shared point and domain', () => {
+      expect(pureCircuits.kdf(PK, DOMAIN)).toBe(pureCircuits.kdf(PK, DOMAIN));
+    });
+
+    it('differs for distinct shared points', () => {
+      const other = ecMulGenerator(222n);
+      expect(pureCircuits.kdf(PK, DOMAIN)).not.toBe(
+        pureCircuits.kdf(other, DOMAIN),
+      );
+    });
+
+    it('differs for distinct domains (domain separation)', () => {
+      expect(pureCircuits.kdf(PK, domain('a'))).not.toBe(
+        pureCircuits.kdf(PK, domain('b')),
+      );
+    });
+  });
+});

--- a/contracts/src/crypto/test/mocks/MockEcdhMask.compact
+++ b/contracts/src/crypto/test/mocks/MockEcdhMask.compact
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT
+
+// WARNING: FOR TESTING PURPOSES ONLY.
+// Exposes the EcdhMask module's pure circuits so they can be driven from
+// off-chain tests. DO NOT deploy or use this contract in any production
+// application.
+
+pragma language_version >= 0.23.0;
+
+import CompactStandardLibrary;
+import "../../EcdhMask" prefix EcdhMask_;
+
+export { EcdhMask_Ciphertext }
+
+export pure circuit kdf(sShared: JubjubPoint, domain: Bytes<32>): Field {
+  return EcdhMask_kdf(sShared, domain);
+}
+
+export pure circuit encrypt(
+                      recipientPk: JubjubPoint,
+                      value: Uint<128>,
+                      e: Field,
+                      domain: Bytes<32>
+                      ): EcdhMask_Ciphertext {
+  return EcdhMask_encrypt(recipientPk, value, e, domain);
+}
+
+export pure circuit decrypt(ciphertext: EcdhMask_Ciphertext, ekScalar: Field, domain: Bytes<32>): Field {
+  return EcdhMask_decrypt(ciphertext, ekScalar, domain);
+}


### PR DESCRIPTION
Fixes #654 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for encrypting and decrypting a single value using recipient public keys and a domain-specific mask.
  * Returned encrypted values now include the needed ephemeral component for later recovery.
  * Added test coverage for round trips, invalid inputs, wrong keys/domains, and mask consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->