### PR TITLE
ci(release): automate publishing with an approval gate

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -39,6 +39,9 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          # No git writes here (release is cut via gh/app token), so don't persist creds.
+          persist-credentials: false
 
       - name: Read package version
         id: version

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -60,7 +60,7 @@ jobs:
           GH_TOKEN: ${{ steps.gh-app-token.outputs.token }}
           VERSION: ${{ steps.version.outputs.version }}
           PRERELEASE: ${{ steps.version.outputs.prerelease }}
-          TARGET: ${{ github.ref_name }}
+          TARGET: ${{ github.sha }}
         run: |
           TAG="v${VERSION}"
 

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -34,6 +34,8 @@ jobs:
         with:
           app-id: ${{ vars.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          # Least privilege: only contents write (create the tag + release).
+          permission-contents: write
 
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,79 @@
+name: Create release on version bump
+
+# When a version bump merges into main (alpha line) or a release/* branch
+# (rc/stable line), cut the matching GitHub Release + tag. That fires
+# release.yml to publish to npm (behind the release approval gate).
+#
+# Idempotent: a release is cut only if its tag has no release yet, so any
+# push that does not change the version is a no-op and retries are safe.
+on:
+  push:
+    branches:
+      - main
+      - "release/**"
+    paths:
+      - "contracts/package.json"
+
+permissions:
+  contents: write
+
+jobs:
+  create-release:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      # App token (not GITHUB_TOKEN): a release created by GITHUB_TOKEN does
+      # not trigger release.yml, so the publish would never run.
+      - name: Get github app token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: gh-app-token
+        with:
+          app-id: ${{ vars.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Read package version
+        id: version
+        run: |
+          VERSION=$(node -p "require('./contracts/package.json').version")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          # A SemVer prerelease has a hyphen (e.g. -alpha.1, -rc.1); stable does not.
+          if [[ "$VERSION" == *-* ]]; then
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create release if the tag does not exist
+        env:
+          GH_TOKEN: ${{ steps.gh-app-token.outputs.token }}
+          VERSION: ${{ steps.version.outputs.version }}
+          PRERELEASE: ${{ steps.version.outputs.prerelease }}
+          TARGET: ${{ github.ref_name }}
+        run: |
+          TAG="v${VERSION}"
+
+          # Idempotent guard: never re-cut an existing release (safe retries,
+          # no manual tag deletion). Any non-bump push lands here and exits.
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists — nothing to do."
+            exit 0
+          fi
+
+          PRERELEASE_FLAG=""
+          if [ "$PRERELEASE" = "true" ]; then
+            PRERELEASE_FLAG="--prerelease"
+          fi
+
+          echo "Creating release $TAG on $TARGET (prerelease=$PRERELEASE)"
+          gh release create "$TAG" \
+            --target "$TARGET" \
+            --title "$TAG" \
+            --generate-notes \
+            $PRERELEASE_FLAG

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -17,6 +17,12 @@ on:
 permissions:
   contents: write
 
+# Serialize per branch so two overlapping pushes can't both pass the
+# "does this release exist yet?" guard and race to create the same tag.
+concurrency:
+  group: create-release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   create-release:
     runs-on: ubuntu-24.04

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -40,6 +40,8 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           token: ${{ steps.gh-app-token.outputs.token }}
+          # Commit/PR go through the app token via API, not git creds on disk.
+          persist-credentials: false
 
       - name: Enable Corepack
         run: corepack enable

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,15 +1,23 @@
-name: Update version on new release branch
+name: Prepare release (version bump PR)
 
+# Manually dispatched. Pick the branch to release from (main for alphas,
+# release/X.Y.x for rc/stable) and type the exact target version. Opens a
+# version-bump PR into that branch; merging it cuts the release (see
+# create-release.yml).
 on:
-  create:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Target version (exact SemVer, e.g. 0.3.0-alpha.3)"
+        required: true
+        type: string
 
 permissions:
   contents: write
   pull-requests: write
 
 jobs:
-  update_version:
-    if: github.ref_type == 'branch' && startsWith(github.ref, 'refs/heads/release-v')
+  prepare_release:
     runs-on: ubuntu-24.04
 
     steps:
@@ -44,31 +52,25 @@ jobs:
           CURRENT_VERSION=$(node -p "require('./contracts/package.json').version")
           echo "CURRENT_VERSION=$CURRENT_VERSION" >> "$GITHUB_ENV"
 
-      - name: Extract new version number
-        run: echo "NEW_VERSION=${GITHUB_REF#refs/heads/release-v}" >> "$GITHUB_ENV"
+      - name: Set new version
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: echo "NEW_VERSION=$INPUT_VERSION" >> "$GITHUB_ENV"
 
       - name: Validate new version
+        env:
+          BASE_BRANCH: ${{ github.ref_name }}
         run: |
-          BRANCH="${GITHUB_REF#refs/heads/}"
-          echo "Branch: $BRANCH"
+          echo "Base branch: $BASE_BRANCH"
           echo "Current version: $CURRENT_VERSION"
           echo "New version: $NEW_VERSION"
 
-          # 1) Branch must match release-v<semver>
-          if ! echo "$BRANCH" | grep -Eq '^release-v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'; then
-            echo "Error: Branch '$BRANCH' must match 'release-v<semver>' (e.g., release-v1.2.3)." >&2
-            exit 1
-          fi
+          # 1) NEW_VERSION must be valid semver
+          node -e "const v=process.env.NEW_VERSION; const semver=/^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-([0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*))?(?:\\+([0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*))?$/; if(!semver.test(v)){ console.error('Error: version is not valid semver:', v); process.exit(1); }"
 
-          # 2) NEW_VERSION must be valid semver
-          node -e "const v=process.env.NEW_VERSION; const semver=/^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-([0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*))?(?:\\+([0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*))?$/; if(!semver.test(v)){ console.error('Error: NEW_VERSION is not valid semver:', v); process.exit(1); }"
-          if [ $? -ne 0 ]; then
-            exit 1
-          fi
-
-          # 3) NEW_VERSION must differ from CURRENT_VERSION
+          # 2) NEW_VERSION must differ from CURRENT_VERSION
           if [ "$NEW_VERSION" = "$CURRENT_VERSION" ]; then
-            echo "Error: NEW_VERSION equals CURRENT_VERSION ($CURRENT_VERSION). Nothing to release." >&2
+            echo "Error: version equals current version ($CURRENT_VERSION). Nothing to release." >&2
             exit 1
           fi
 
@@ -111,11 +113,34 @@ jobs:
             echo 'EOF'
           } >> "$GITHUB_OUTPUT"
 
+      - name: Create bump branch
+        env:
+          GH_TOKEN: ${{ steps.gh-app-token.outputs.token }}
+        run: |
+          BUMP_BRANCH="chore/bump-${NEW_VERSION}"
+          echo "BUMP_BRANCH=$BUMP_BRANCH" >> "$GITHUB_ENV"
+          BASE_SHA=$(git rev-parse HEAD)
+          gh api "repos/${{ github.repository }}/git/refs" \
+            -f ref="refs/heads/${BUMP_BRANCH}" \
+            -f sha="${BASE_SHA}"
+
       # Uses GitHub API to create signed commits (requires creating blobs per file)
       - name: Commit version bump
         uses: iarekylew00t/verified-bot-commit@5b4e8852dc472093935b8debcb81459bb79f7986 # v2.3.2
         with:
-          message: Bump version to ${{ env.NEW_VERSION }}
+          message: "chore(release): bump version to ${{ env.NEW_VERSION }}"
           token: ${{ steps.gh-app-token.outputs.token }}
-          ref: ${{ github.ref_name }}
+          ref: ${{ env.BUMP_BRANCH }}
           files: ${{ steps.changes.outputs.files }}
+
+      - name: Open pull request
+        env:
+          GH_TOKEN: ${{ steps.gh-app-token.outputs.token }}
+          BASE_BRANCH: ${{ github.ref_name }}
+        run: |
+          BODY=$(printf 'Automated version bump to `%s`.\n\nMerging this PR into `%s` cuts `v%s` and publishes to npm after the release approval gate.' "$NEW_VERSION" "$BASE_BRANCH" "$NEW_VERSION")
+          gh pr create \
+            --base "$BASE_BRANCH" \
+            --head "$BUMP_BRANCH" \
+            --title "chore(release): bump version to $NEW_VERSION" \
+            --body "$BODY"

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -153,6 +153,9 @@ jobs:
           BUMP_BRANCH="chore/bump-${NEW_VERSION}"
           echo "BUMP_BRANCH=$BUMP_BRANCH" >> "$GITHUB_ENV"
           BASE_SHA=$(git rev-parse HEAD)
+          # Idempotent re-runs: drop a stale bump branch left by a failed prior run
+          # (closing any open PR from it) before recreating it at the current base.
+          gh api -X DELETE "repos/${{ github.repository }}/git/refs/heads/${BUMP_BRANCH}" >/dev/null 2>&1 || true
           gh api "repos/${{ github.repository }}/git/refs" \
             -f ref="refs/heads/${BUMP_BRANCH}" \
             -f sha="${BASE_SHA}"

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -32,6 +32,9 @@ jobs:
         with:
           app-id: ${{ vars.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          # Least privilege: commit the bump (contents) and open the PR (pull-requests).
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -16,6 +16,12 @@ permissions:
   contents: write
   pull-requests: write
 
+# Serialize per target version so a double-dispatch can't race on the
+# bump-branch delete/recreate; different versions still prepare in parallel.
+concurrency:
+  group: prepare-release-${{ inputs.version }}
+  cancel-in-progress: false
+
 jobs:
   prepare_release:
     runs-on: ubuntu-24.04

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -73,11 +73,39 @@ jobs:
           # 1) NEW_VERSION must be valid semver
           node -e "const v=process.env.NEW_VERSION; const semver=/^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-([0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*))?(?:\\+([0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*))?$/; if(!semver.test(v)){ console.error('Error: version is not valid semver:', v); process.exit(1); }"
 
-          # 2) NEW_VERSION must differ from CURRENT_VERSION
-          if [ "$NEW_VERSION" = "$CURRENT_VERSION" ]; then
-            echo "Error: version equals current version ($CURRENT_VERSION). Nothing to release." >&2
-            exit 1
-          fi
+          # 2) NEW_VERSION must be a forward bump (strictly greater than CURRENT_VERSION
+          #    by SemVer precedence) so a typo can't downgrade the published version.
+          node -e '
+            const cmp = (a, b) => {
+              const parse = (v) => {
+                const noBuild = v.split("+")[0];
+                const [core, pre] = noBuild.split("-");
+                const nums = core.split(".").map(Number);
+                return { nums, pre: pre ? pre.split(".") : null };
+              };
+              const A = parse(a), B = parse(b);
+              for (let i = 0; i < 3; i++) if (A.nums[i] !== B.nums[i]) return A.nums[i] - B.nums[i];
+              if (!A.pre && !B.pre) return 0;
+              if (!A.pre) return 1;   // release outranks prerelease
+              if (!B.pre) return -1;
+              const n = Math.max(A.pre.length, B.pre.length);
+              for (let i = 0; i < n; i++) {
+                const x = A.pre[i], y = B.pre[i];
+                if (x === undefined) return -1;
+                if (y === undefined) return 1;
+                const xn = /^\d+$/.test(x), yn = /^\d+$/.test(y);
+                if (xn && yn) { const d = Number(x) - Number(y); if (d !== 0) return d; }
+                else if (xn !== yn) return xn ? -1 : 1;   // numeric identifiers rank lower
+                else if (x !== y) return x < y ? -1 : 1;
+              }
+              return 0;
+            };
+            const nw = process.env.NEW_VERSION, cur = process.env.CURRENT_VERSION;
+            if (cmp(nw, cur) <= 0) {
+              console.error(`Error: NEW_VERSION (${nw}) must be strictly greater than CURRENT_VERSION (${cur}).`);
+              process.exit(1);
+            }
+          '
 
       - name: Replace version in files
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,9 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          # No git writes here (publish goes through the npm token), so don't persist creds.
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-24.04
+    # Manual approval gate: the `release` Environment must have required
+    # reviewers configured in repo Settings, else this pauses for no one.
+    environment: release
     permissions:
       contents: read
       id-token: write

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,42 +1,72 @@
 # Releasing
 
-(1) Checkout the branch to be released.
-This will usually be `main` except in the event of a hotfix.
-For hotfixes, checkout the release branch you want to fix.
+Releases are automated. You bump the version via a workflow, merge the bump PR,
+and the tag, GitHub Release, and npm publish happen on their own (behind a
+manual approval gate).
 
-(2) Create a new release branch.
+Notation: `X.Y.Z` is a concrete SemVer; `release/X.Y.x` is the audit branch for
+the `X.Y` line (the `x` is literal — it denotes the patch line, not a point);
+`N` is a prerelease counter.
 
-```sh
-git checkout -b release-v0.2.0
-```
+## Branch model
 
-(3) Push and open a PR targeting `main` to carefully review the release changes.
-This will trigger a GitHub workflow that automatically bumps the version number throughout the project.
+- **`main`** — the alpha line; always exists.
+- **`release/X.Y.x`** — the `X.Y` patch line; cut from `main` when an audit
+  starts, carries `X.Y.0-rc.N → X.Y.0` (and any later `X.Y.Z` hotfixes). Deleted
+  after back-merge; recreate it from the `vX.Y.Z` tag if a later hotfix is needed.
 
-```sh
-git push origin release-v0.2.0
-```
+There is no long-lived per-version branch: a version bump is just a PR into
+`main` or a `release/X.Y.x` branch.
 
-(4) Once merged, pull the changes from the release branch.
-Then, create a tag on the release branch and push it to the main repository.
-Note that the version changes must be pulled *before* the tag is created;
-otherwise, the version validation check will fail in the release workflow.
+## How it works
 
-```sh
-git pull
-git tag v0.2.0
-git push origin v0.2.0
-```
+1. Run **Prepare release** (`prepare-release.yml`) via *Actions → Run workflow*:
+   pick the branch, type the exact target version. It opens a `chore/bump-<version>`
+   PR into that branch.
+2. Review and merge the bump PR.
+3. On merge, **Create release** (`create-release.yml`) cuts `v<version>` + a
+   GitHub Release from that branch (`--prerelease` for any `-alpha`/`-rc`
+   version).
+4. That fires **Publish** (`release.yml`), which pauses at the `release`
+   approval gate. An authorized reviewer approves, then it publishes to npm.
 
-(5) After that, go to the repo's [releases page](https://github.com/OpenZeppelin/compact-contracts/releases/).
-[Create a new release](https://github.com/OpenZeppelin/compact-contracts/releases/new) with the new tag and the base branch as target (`main` except in the event of a hotfix).
-Make sure to write a detailed release description and a short changelog.
-Once published, this will trigger a workflow to upload the release tarball to npm.
+npm dist-tags: stable → `latest`, `-alpha`/`-rc` → `beta`.
 
-(6) Finally, from the released tag,
-create and push a doc branch to deploy the corresponding version to the doc-site.
+## Versioning
 
-```sh
-git checkout -b docs-v0.2.0
-git push origin docs-v0.2.0
-```
+Standard SemVer pre-release identifiers, in sort order:
+`X.Y.0-alpha.N → … → X.Y.0-rc.N → … → X.Y.0`. Counters start at `.1` (no
+`-rc.0`). Content drives the minor (`X.Y`); the 3-week cadence drives only the
+alpha counter.
+
+## Common flows
+
+**Scheduled alpha (from `main`)**
+- Prepare release on `main`, version `X.Y.0-alpha.N` → merge → publishes `beta`.
+
+**Audit starts (cut the release line)**
+- `git branch release/X.Y.x <audit-sha> && git push origin release/X.Y.x`
+  (creating the branch cuts nothing — its version is already tagged).
+- Prepare release on `release/X.Y.x`, version `X.Y.0-rc.1` → merge → publishes `beta`.
+- rc fixes later: repeat with `X.Y.0-rc.2`, etc.
+
+**Audit clears (stable + next alpha, same day)**
+- Merge audit fixes into `release/X.Y.x`.
+- Prepare release on `release/X.Y.x`, version `X.Y.0` → merge → publishes `latest`.
+- Prepare release on `main`, next minor's first alpha `X.(Y+1).0-alpha.1` → merge
+  → publishes `beta`.
+- Back-merge `release/X.Y.x` → `main` (keep `main`'s higher version on conflict),
+  then delete `release/X.Y.x`.
+
+## Retries
+
+Re-running is safe: `create-release.yml` only cuts a release if the tag has no
+release yet, so no manual tag/release deletion is needed.
+
+## One-time setup (repo admin)
+
+- **Settings → Environments → `release`**: add required reviewers (this is what
+  makes the approval gate real; without it the publish job pauses for no one).
+- **Variables/secrets**: `GH_APP_ID` (var) and `GH_APP_PRIVATE_KEY` (secret) must
+  be set — both `prepare-release.yml` and `create-release.yml` need the app token
+  (the latter so its release event chains to the publish workflow).


### PR DESCRIPTION
## What

Reworks the release pipeline into a dispatch-driven, two-line flow and gates npm publish behind a manual approval.

- **`prepare-release.yml`** — now `workflow_dispatch` with a `version` input; opens a signed `chore/bump-<version>` PR into the chosen branch (`main` for alphas, `release/X.Y.x` for rc/stable). Replaces the old `release-v*` branch trigger.
- **`create-release.yml`** (new) — on a version bump merged to `main` or `release/**`, cuts `v<version>` + a GitHub Release when the tag has no release yet (idempotent retries, no manual tag surgery). Uses the GitHub App token so the release event chains to `release.yml`.
- **`release.yml`** — publish job gated behind the `release` Environment.
- **`RELEASING.md`** — rewritten for the new flow with generic `X.Y.x` versioning.

## Flow

`prepare-release` (dispatch) → merge bump PR → `create-release` cuts the tag/release → `release` publishes to npm, paused at the approval gate. dist-tags: stable → `latest`, `-alpha`/`-rc` → `beta`.

## Closes

Closes #551
Closes #561
Closes #645

## Repo settings (verified present)

- [x] `release` Environment with required reviewers — approval gate is live
- [x] `GH_APP_ID` var + `GH_APP_PRIVATE_KEY` secret — bump + create→publish chain


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated release workflows to prepare version bumps, create GitHub Releases, and publish with an approval step.
  * Release creation now supports stable and pre-release versions, with safer reruns if a release already exists.

* **Documentation**
  * Updated release guidance to reflect the new workflow-based process, versioning rules, and required repository setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->