### PR TITLE
ci(release): adopt npm OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      attestations: write # Write SLSA build provenance to the attestation store
 
     steps:
       - name: Harden Runner
@@ -99,6 +100,14 @@ jobs:
             echo "❌ Tarball contains private: true - cannot publish"
             exit 1
           fi
+
+      - name: Attest build provenance
+        # Signed SLSA v1 provenance over the exact tarball, stored in the
+        # GitHub attestation store (verifiable with `gh attestation verify`).
+        # Complements the npm-registry provenance from NPM_CONFIG_PROVENANCE.
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-path: ${{ steps.pack.outputs.tarball }}
 
       - name: Publish to npm
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,14 +28,21 @@ jobs:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          # No git writes here (publish goes through the npm token), so don't persist creds.
+          # No git writes here (publish uses npm OIDC, not git creds), so don't persist creds.
           persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: ".nvmrc"
+          registry-url: https://registry.npmjs.org
           package-manager-cache: false # Prevent cache poisoning issues
+
+      - name: Ensure npm supports trusted publishing
+        # OIDC trusted publishing requires npm >= 11.5.1. The .nvmrc Node may
+        # bundle an older npm, so pin the floor explicitly: stays on the
+        # vetted 11.x major, avoids a surprise npm major in a release run.
+        run: npm install -g npm@^11.5.1
 
       - name: Enable Corepack
         run: corepack enable
@@ -60,13 +67,6 @@ jobs:
             exit 1
           fi
           echo "✅ Version consistency validated: $RELEASE_VERSION"
-
-      - name: Setup npm registry
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: "24"
-          registry-url: https://registry.npmjs.org
-          package-manager-cache: false
 
       - name: Pack tarball
         id: pack

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,10 +56,10 @@ jobs:
 
       - name: Setup npm registry
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-         with:
-             node-version: "24"
-             registry-url: https://registry.npmjs.org
-             package-manager-cache: false
+        with:
+          node-version: "24"
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
 
       - name: Pack tarball
         id: pack

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,13 +56,10 @@ jobs:
 
       - name: Setup npm registry
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          registry-url: "https://registry.npmjs.org"
-
-      - name: Ensure npm supports trusted publishing
-        # OIDC trusted publishing needs npm >= 11.5.1; the version bundled with
-        # the .nvmrc Node may be older.
-        run: npm install -g npm@latest
+         with:
+             node-version: "24"
+             registry-url: https://registry.npmjs.org
+             package-manager-cache: false
 
       - name: Pack tarball
         id: pack

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,7 @@
+# Publishes to npm via OIDC trusted publishing — no NPM_TOKEN.
+# Prerequisite: this repo + this workflow must be registered as a Trusted
+# Publisher for the package on npmjs.org (package → Settings → Trusted
+# Publishers), otherwise the publish step fails with an auth error.
 name: Publish Package on Release
 
 on:
@@ -55,6 +59,11 @@ jobs:
         with:
           registry-url: "https://registry.npmjs.org"
 
+      - name: Ensure npm supports trusted publishing
+        # OIDC trusted publishing needs npm >= 11.5.1; the version bundled with
+        # the .nvmrc Node may be older.
+        run: npm install -g npm@latest
+
       - name: Pack tarball
         id: pack
         run: |
@@ -99,9 +108,8 @@ jobs:
           # Publish the tarball with appropriate tag
           npm publish "${{ steps.pack.outputs.tarball }}" --tag "${{ steps.pack.outputs.tag }}" --access public
         env:
+          # No NODE_AUTH_TOKEN — OIDC trusted publishing mints per-run credentials.
           NPM_CONFIG_PROVENANCE: true
-          # Token required for actions/setup-node
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Log success
         run: |


### PR DESCRIPTION
## What

Switches npm publishing to **OIDC trusted publishing** — no `NPM_TOKEN`.

- Remove `NODE_AUTH_TOKEN` / `NPM_TOKEN` from the publish step; npm mints short-lived, repo-scoped credentials per run via the OIDC `id-token` (`id-token: write` was already set).
- Ensure npm ≥ 11.5.1 (`npm install -g npm@^11.5.1`) — trusted publishing requires it, and the `.nvmrc` Node may bundle an older npm. Pinned to the vetted 11.x major so a release run can't pull an unvetted npm major (the rest of the workflow pins every tool).
- Single `setup-node` (the `.nvmrc` one) with `registry-url` set, so there is one Node source for build and publish.
- Attest SLSA build provenance over the packed tarball (`attest-build-provenance`) into the GitHub attestation store; complements the npm-registry provenance.
- Keep provenance (`NPM_CONFIG_PROVENANCE: true`).

Result: no standing npm secret to rotate, no token expiry/scope failures, provenance on npm.

## Notes

- Independent of [#657](https://github.com/OpenZeppelin/compact-contracts/issues/657) (release automation + approval gate). Both touch `release.yml` but in different regions (job-level gate vs. publish-step auth), so they merge cleanly in either order.
- Reference pattern: `OpenZeppelin/openzeppelin-ui/.github/workflows/publish.yml`.

Closes [#560](https://github.com/OpenZeppelin/compact-contracts/issues/560).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package publishing to use secure OIDC-based authentication.
  * Added build provenance attestations to published packages.
  * Updated the release workflow configuration for the latest Node.js publishing environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
