### PR TITLE
fix: run biome on full tree, not only --changed

### DIFF
--- a/contracts/src/token/test/NativeShieldedToken.test.ts
+++ b/contracts/src/token/test/NativeShieldedToken.test.ts
@@ -1,8 +1,8 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import * as utils from '#test-utils/address.js';
 import {
-  type NativeShieldedTokenSimulator as Sim,
   NativeShieldedTokenSimulator,
+  type NativeShieldedTokenSimulator as Sim,
 } from './simulators/NativeShieldedTokenSimulator.js';
 
 // Helpers
@@ -75,21 +75,30 @@ describe('NativeShieldedToken (Fungible profile)', () => {
       ['decimals', []],
       ['tokenColor', []],
       ['_mint', [RECIPIENT, AMOUNT, b32('n')]],
-      ['_burn', [{ nonce: b32('cn'), color: b32('c'), value: AMOUNT }, AMOUNT, REFUND_TO]],
+      [
+        '_burn',
+        [
+          { nonce: b32('cn'), color: b32('c'), value: AMOUNT },
+          AMOUNT,
+          REFUND_TO,
+        ],
+      ],
       [
         '_burnFromSelf',
-        [{ nonce: b32('cn'), color: b32('c'), value: AMOUNT, mt_index: 0n }, AMOUNT],
+        [
+          { nonce: b32('cn'), color: b32('c'), value: AMOUNT, mt_index: 0n },
+          AMOUNT,
+        ],
       ],
     ];
 
-    it.each(circuitsToFail)(
-      'should revert %s before initialize',
-      async (method, args) => {
-        await expect(
-          (token[method] as (...a: unknown[]) => Promise<unknown>)(...args),
-        ).rejects.toThrow('NativeShieldedToken: contract not initialized');
-      },
-    );
+    it.each(
+      circuitsToFail,
+    )('should revert %s before initialize', async (method, args) => {
+      await expect(
+        (token[method] as (...a: unknown[]) => Promise<unknown>)(...args),
+      ).rejects.toThrow('NativeShieldedToken: contract not initialized');
+    });
   });
 
   describe('_mint', () => {

--- a/contracts/src/token/test/NativeShieldedTokenFamily.test.ts
+++ b/contracts/src/token/test/NativeShieldedTokenFamily.test.ts
@@ -1,8 +1,8 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import * as utils from '#test-utils/address.js';
 import {
-  type NativeShieldedTokenFamilySimulator as Sim,
   NativeShieldedTokenFamilySimulator,
+  type NativeShieldedTokenFamilySimulator as Sim,
 } from './simulators/NativeShieldedTokenFamilySimulator.js';
 
 const b32 = (label: string): Uint8Array => {
@@ -59,21 +59,32 @@ describe('NativeShieldedTokenFamily (Family profile)', () => {
       ['decimals', []],
       ['tokenColor', [DOMAIN_A]],
       ['_mint', [DOMAIN_A, RECIPIENT, AMOUNT, b32('n')]],
-      ['_burn', [DOMAIN_A, { nonce: b32('cn'), color: b32('c'), value: AMOUNT }, AMOUNT, REFUND_TO]],
+      [
+        '_burn',
+        [
+          DOMAIN_A,
+          { nonce: b32('cn'), color: b32('c'), value: AMOUNT },
+          AMOUNT,
+          REFUND_TO,
+        ],
+      ],
       [
         '_burnFromSelf',
-        [DOMAIN_A, { nonce: b32('cn'), color: b32('c'), value: AMOUNT, mt_index: 0n }, AMOUNT],
+        [
+          DOMAIN_A,
+          { nonce: b32('cn'), color: b32('c'), value: AMOUNT, mt_index: 0n },
+          AMOUNT,
+        ],
       ],
     ];
 
-    it.each(circuitsToFail)(
-      'should revert %s before initialize',
-      async (method, args) => {
-        await expect(
-          (token[method] as (...a: unknown[]) => Promise<unknown>)(...args),
-        ).rejects.toThrow('NativeShieldedToken: contract not initialized');
-      },
-    );
+    it.each(
+      circuitsToFail,
+    )('should revert %s before initialize', async (method, args) => {
+      await expect(
+        (token[method] as (...a: unknown[]) => Promise<unknown>)(...args),
+      ).rejects.toThrow('NativeShieldedToken: contract not initialized');
+    });
   });
 
   describe('_mint (per domain)', () => {
@@ -113,7 +124,12 @@ describe('NativeShieldedTokenFamily (Family profile)', () => {
     it('should reject burning a domain-A coin under domain B (wrong color)', async () => {
       const colorA = await token.tokenColor(DOMAIN_A);
       await expect(
-        token._burn(DOMAIN_B, { nonce: b32('c'), color: colorA, value: AMOUNT }, AMOUNT, REFUND_TO),
+        token._burn(
+          DOMAIN_B,
+          { nonce: b32('c'), color: colorA, value: AMOUNT },
+          AMOUNT,
+          REFUND_TO,
+        ),
       ).rejects.toThrow('NativeShieldedToken: wrong token');
     });
   });
@@ -144,8 +160,16 @@ describe('NativeShieldedTokenFamily (Family profile)', () => {
     });
 
     it('should return none on a full burn and some(refund) on a partial burn', async () => {
-      expect((await token._burn(DOMAIN_A, coinOf(AMOUNT), AMOUNT, REFUND_TO)).is_some).toBe(false);
-      const partial = await token._burn(DOMAIN_A, coinOf(AMOUNT), 600n, REFUND_TO);
+      expect(
+        (await token._burn(DOMAIN_A, coinOf(AMOUNT), AMOUNT, REFUND_TO))
+          .is_some,
+      ).toBe(false);
+      const partial = await token._burn(
+        DOMAIN_A,
+        coinOf(AMOUNT),
+        600n,
+        REFUND_TO,
+      );
       expect(partial.is_some).toBe(true);
       expect(partial.value.value).toBe(AMOUNT - 600n);
     });
@@ -166,8 +190,12 @@ describe('NativeShieldedTokenFamily (Family profile)', () => {
     });
 
     it('should return change on a partial burn and none on a full burn', async () => {
-      expect((await token._burnFromSelf(DOMAIN_A, qCoinOf(AMOUNT), 600n)).is_some).toBe(true);
-      expect((await token._burnFromSelf(DOMAIN_A, qCoinOf(AMOUNT), AMOUNT)).is_some).toBe(false);
+      expect(
+        (await token._burnFromSelf(DOMAIN_A, qCoinOf(AMOUNT), 600n)).is_some,
+      ).toBe(true);
+      expect(
+        (await token._burnFromSelf(DOMAIN_A, qCoinOf(AMOUNT), AMOUNT)).is_some,
+      ).toBe(false);
     });
 
     it('should reject a wrong-color coin', async () => {

--- a/contracts/src/token/test/simulators/NativeShieldedTokenDerivedNonceSimulator.ts
+++ b/contracts/src/token/test/simulators/NativeShieldedTokenDerivedNonceSimulator.ts
@@ -3,8 +3,8 @@ import {
   type SimulatorOptions,
 } from '@openzeppelin/compact-simulator';
 import {
-  Contract as MockNativeShieldedTokenDerivedNonce,
   ledger,
+  Contract as MockNativeShieldedTokenDerivedNonce,
 } from '../../../../artifacts/MockNativeShieldedTokenDerivedNonce/contract/index.js';
 
 /**
@@ -64,6 +64,7 @@ export class NativeShieldedTokenDerivedNonceSimulator extends NativeShieldedToke
 
   /** @description Current value of the derived-nonce counter. */
   public async nonceCounter(): Promise<bigint> {
-    return (await this.getPublicState()).NativeShieldedTokenDerivedNonce__counter;
+    return (await this.getPublicState())
+      .NativeShieldedTokenDerivedNonce__counter;
   }
 }

--- a/contracts/src/token/test/simulators/NativeShieldedTokenFamilySimulator.ts
+++ b/contracts/src/token/test/simulators/NativeShieldedTokenFamilySimulator.ts
@@ -5,12 +5,12 @@ import {
 import {
   type ContractAddress,
   type Either,
+  ledger,
   type Maybe,
+  Contract as MockNativeShieldedTokenFamily,
   type QualifiedShieldedCoinInfo,
   type ShieldedCoinInfo,
   type ZswapCoinPublicKey,
-  Contract as MockNativeShieldedTokenFamily,
-  ledger,
 } from '../../../../artifacts/MockNativeShieldedTokenFamily/contract/index.js';
 
 /**
@@ -46,7 +46,12 @@ const NativeShieldedTokenFamilySimulatorBase = createSimulator<
       witnesses,
     ),
   defaultPrivateState: () => NativeShieldedTokenFamilyPrivateState,
-  contractArgs: (name, symbol, decimals, init) => [name, symbol, decimals, init],
+  contractArgs: (name, symbol, decimals, init) => [
+    name,
+    symbol,
+    decimals,
+    init,
+  ],
   ledgerExtractor: (state) => ledger(state),
   witnessesFactory: () => NativeShieldedTokenFamilyWitnesses(),
   artifactName: 'MockNativeShieldedTokenFamily',

--- a/contracts/src/token/test/simulators/NativeShieldedTokenSimulator.ts
+++ b/contracts/src/token/test/simulators/NativeShieldedTokenSimulator.ts
@@ -5,12 +5,12 @@ import {
 import {
   type ContractAddress,
   type Either,
+  ledger,
   type Maybe,
+  Contract as MockNativeShieldedToken,
   type QualifiedShieldedCoinInfo,
   type ShieldedCoinInfo,
   type ZswapCoinPublicKey,
-  Contract as MockNativeShieldedToken,
-  ledger,
 } from '../../../../artifacts/MockNativeShieldedToken/contract/index.js';
 
 /**

--- a/contracts/test/integration/fixtures/composedTokens.ts
+++ b/contracts/test/integration/fixtures/composedTokens.ts
@@ -1,7 +1,7 @@
 import { createSimulator } from '@openzeppelin/compact-simulator';
 import {
-  ledger,
   Contract as ComposedTokens,
+  ledger,
 } from '../../../artifacts/ComposedTokens/contract/index.js';
 
 type EmptyPrivateState = Record<string, never>;
@@ -27,7 +27,7 @@ const ComposedTokensSimulatorBase = createSimulator<
   contractFactory: (witnesses) =>
     new ComposedTokens<EmptyPrivateState>(witnesses),
   defaultPrivateState: () => ({}),
-  contractArgs: (ftName, ftSymbol, ftDecimals, nftName, nftSymbol, initFT, initNFT) => [
+  contractArgs: (
     ftName,
     ftSymbol,
     ftDecimals,
@@ -35,7 +35,7 @@ const ComposedTokensSimulatorBase = createSimulator<
     nftSymbol,
     initFT,
     initNFT,
-  ],
+  ) => [ftName, ftSymbol, ftDecimals, nftName, nftSymbol, initFT, initNFT],
   ledgerExtractor: (state) => ledger(state),
   witnessesFactory: () => ({}),
 });

--- a/contracts/test/integration/specs/initStateIsolation.spec.ts
+++ b/contracts/test/integration/specs/initStateIsolation.spec.ts
@@ -40,7 +40,9 @@ describe('Initializable state isolation (#556)', () => {
       c.initA();
 
       // BUG: B can never be initialized — the shared slot is already set.
-      expect(() => c.initB()).toThrow('Initializable: contract already initialized');
+      expect(() => c.initB()).toThrow(
+        'Initializable: contract already initialized',
+      );
     });
   });
 
@@ -60,7 +62,9 @@ describe('Initializable state isolation (#556)', () => {
       const c = new ComposedTokensSimulator(false, true);
 
       expect(() => c.nftName()).not.toThrow();
-      expect(() => c.ftName()).toThrow('FungibleToken: contract not initialized');
+      expect(() => c.ftName()).toThrow(
+        'FungibleToken: contract not initialized',
+      );
     });
 
     it('should initialize each module independently', () => {

--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
     "compact:utils": "turbo run compact:utils --filter=@openzeppelin/compact-contracts --log-prefix=none",
     "build": "turbo run build --log-prefix=none",
     "test": "turbo run test --filter=@openzeppelin/compact-contracts --log-prefix=none",
-    "fmt-and-lint": "biome check . --changed",
-    "fmt-and-lint:fix": "biome check . --changed --write",
-    "fmt-and-lint:ci": "biome ci . --changed --no-errors-on-unmatched",
+    "fmt-and-lint": "biome check .",
+    "fmt-and-lint:fix": "biome check . --write",
+    "fmt-and-lint:ci": "biome ci . --no-errors-on-unmatched",
     "types": "turbo run types",
     "clean": "turbo run clean"
   },


### PR DESCRIPTION
## Summary

`fmt-and-lint` used Biome's `--changed` flag, which can process zero files and exit clean while formatting problems land in the tree. Run Biome on the full project instead.

## Linked issue

Fixes #571

## Test plan

- [x] `package.json` scripts no longer pass `--changed`
- [ ] Locally: `yarn fmt-and-lint` processes files (not "Checked 0 files")

## AI assistance

Prepared with AI assistance; I reviewed and tested the change.

## Risk

CI may be slightly slower and can fail on pre-existing format debt once the full tree is checked.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated formatting and linting workflows to check the full codebase.
  * Improved continuous integration handling when no matching files are found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->