### PR TITLE
build(deps): consolidate open Dependabot updates

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -18,12 +18,12 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
           egress-policy: audit
 
       - name: Check out code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 2 # Recommended by turbo team
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,12 +24,12 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
           egress-policy: audit
 
       - name: Check out code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 2 # Recommended by turbo team
 
@@ -39,13 +39,13 @@ jobs:
           skip-compact: "true"
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           languages: ${{ matrix.language }}
           # We can add custom queries later when needed
           # queries: security-extended
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
           egress-policy: audit
 
@@ -44,7 +44,7 @@ jobs:
           permission-contents: write
 
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           # No git writes here (release is cut via gh/app token), so don't persist creds.
           persist-credentials: false

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
           egress-policy: audit
 
@@ -43,7 +43,7 @@ jobs:
           permission-pull-requests: write
 
       - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           token: ${{ steps.gh-app-token.outputs.token }}
           # Commit/PR go through the app token via API, not git creds on disk.
@@ -168,7 +168,7 @@ jobs:
 
       # Uses GitHub API to create signed commits (requires creating blobs per file)
       - name: Commit version bump
-        uses: iarekylew00t/verified-bot-commit@5b4e8852dc472093935b8debcb81459bb79f7986 # v2.3.2
+        uses: iarekylew00t/verified-bot-commit@33985d44b7719dcaf0b854a0f4b0caad9bdc5b86 # v2.3.3
         with:
           message: "chore(release): bump version to ${{ env.NEW_VERSION }}"
           token: ${{ steps.gh-app-token.outputs.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,12 +16,12 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
           egress-policy: audit
 
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           # No git writes here (publish goes through the npm token), so don't persist creds.
           persist-credentials: false

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -30,12 +30,12 @@ jobs:
       # actions: read
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
           egress-policy: audit
 
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
@@ -56,6 +56,6 @@ jobs:
           retention-days: 5
 
       - name: Upload SARIF to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           sarif_file: results.sarif

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,12 +26,12 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
           egress-policy: audit
 
       - name: Check out code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 2 # Recommended by turbo team
 

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.0/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -51,11 +51,11 @@
   "devDependencies": {
     "@openzeppelin/compact-simulator": "^0.2.0",
     "@tsconfig/node24": "^24.0.4",
-    "@types/node": "25.9.3",
-    "@vitest/coverage-v8": "^4.1.9",
+    "@types/node": "26.1.0",
+    "@vitest/coverage-v8": "^4.1.10",
     "fast-check": "^4.8.0",
     "ts-node": "^10.9.2",
     "typescript": "^6.0.3",
-    "vitest": "^4.1.9"
+    "vitest": "^4.1.10"
   }
 }

--- a/contracts/src/access/test/AccessControl.test.ts
+++ b/contracts/src/access/test/AccessControl.test.ts
@@ -391,19 +391,20 @@ describe('AccessControl', () => {
       await accessControl._unsafeGrantRole(OPERATOR_ROLE_1, OP1_CONTRACT);
     });
 
-    describe.each(
-      operatorTypes,
-    )('when the operator is a %s', (_operatorType, _operator) => {
-      it('admin should revoke role', async () => {
-        // Set admin SK
-        await accessControl.privateState.injectSecretKey(ADMIN.secretKey);
+    describe.each(operatorTypes)(
+      'when the operator is a %s',
+      (_operatorType, _operator) => {
+        it('admin should revoke role', async () => {
+          // Set admin SK
+          await accessControl.privateState.injectSecretKey(ADMIN.secretKey);
 
-        await accessControl.revokeRole(OPERATOR_ROLE_1, _operator);
-        expect(await accessControl.hasRole(OPERATOR_ROLE_1, _operator)).toBe(
-          false,
-        );
-      });
-    });
+          await accessControl.revokeRole(OPERATOR_ROLE_1, _operator);
+          expect(await accessControl.hasRole(OPERATOR_ROLE_1, _operator)).toBe(
+            false,
+          );
+        });
+      },
+    );
 
     it('should fail if unauthorized revokes role', async () => {
       await accessControl.privateState.injectSecretKey(UNAUTHORIZED.secretKey);
@@ -754,19 +755,20 @@ describe('AccessControl', () => {
   });
 
   describe('_revokeRole', () => {
-    describe.each(
-      operatorTypes,
-    )('when the operator is a %s', (_, _operator) => {
-      it('should revoke role', async () => {
-        await accessControl._unsafeGrantRole(OPERATOR_ROLE_1, _operator);
-        expect(
-          await accessControl._revokeRole(OPERATOR_ROLE_1, _operator),
-        ).toBe(true);
-        expect(await accessControl.hasRole(OPERATOR_ROLE_1, _operator)).toBe(
-          false,
-        );
-      });
-    });
+    describe.each(operatorTypes)(
+      'when the operator is a %s',
+      (_, _operator) => {
+        it('should revoke role', async () => {
+          await accessControl._unsafeGrantRole(OPERATOR_ROLE_1, _operator);
+          expect(
+            await accessControl._revokeRole(OPERATOR_ROLE_1, _operator),
+          ).toBe(true);
+          expect(await accessControl.hasRole(OPERATOR_ROLE_1, _operator)).toBe(
+            false,
+          );
+        });
+      },
+    );
 
     it('should return false if account does not have role', async () => {
       expect(await accessControl._revokeRole(OPERATOR_ROLE_1, OP1.either)).toBe(

--- a/contracts/src/access/test/Ownable.test.ts
+++ b/contracts/src/access/test/Ownable.test.ts
@@ -90,15 +90,16 @@ describe('Ownable', () => {
       ).rejects.toThrow('Ownable: unsafe ownership transfer');
     });
 
-    it.each(
-      zeroTypes,
-    )('should fail to initialize when owner is zero (%s)', async (_, _zero) => {
-      await expect(
-        OwnableSimulator.create(_zero, isInit, {
-          privateState: { secretKey: OWNER.secretKey },
-        }),
-      ).rejects.toThrow('Ownable: invalid initial owner');
-    });
+    it.each(zeroTypes)(
+      'should fail to initialize when owner is zero (%s)',
+      async (_, _zero) => {
+        await expect(
+          OwnableSimulator.create(_zero, isInit, {
+            privateState: { secretKey: OWNER.secretKey },
+          }),
+        ).rejects.toThrow('Ownable: invalid initial owner');
+      },
+    );
 
     type FailingCircuits = [method: keyof OwnableSimulator, args: unknown[]];
     const circuitsToFail: FailingCircuits[] = [
@@ -110,18 +111,19 @@ describe('Ownable', () => {
       ['_transferOwnership', [OWNER.either]],
       ['_unsafeUncheckedTransferOwnership', [OWNER.either]],
     ];
-    it.each(
-      circuitsToFail,
-    )('should fail when calling circuit "%s"', async (circuitName, args) => {
-      ownable = await OwnableSimulator.create(OWNER.either, isBadInit, {
-        privateState: { secretKey: OWNER.secretKey },
-      });
-      await expect(
-        (ownable[circuitName] as (...args: unknown[]) => Promise<unknown>)(
-          ...args,
-        ),
-      ).rejects.toThrow('Ownable: contract not initialized');
-    });
+    it.each(circuitsToFail)(
+      'should fail when calling circuit "%s"',
+      async (circuitName, args) => {
+        ownable = await OwnableSimulator.create(OWNER.either, isBadInit, {
+          privateState: { secretKey: OWNER.secretKey },
+        });
+        await expect(
+          (ownable[circuitName] as (...args: unknown[]) => Promise<unknown>)(
+            ...args,
+          ),
+        ).rejects.toThrow('Ownable: contract not initialized');
+      },
+    );
 
     it('should canonicalize initial owner', async () => {
       const nonCanonical = {

--- a/contracts/src/access/test/ShieldedAccessControl.test.ts
+++ b/contracts/src/access/test/ShieldedAccessControl.test.ts
@@ -122,17 +122,18 @@ describe('ShieldedAccessControl', () => {
       ['_setRoleAdmin', [ROLE_ADMIN, ROLE_ADMIN]],
     ];
 
-    it.each(
-      circuitsRequiringInit,
-    )('%s should fail', async (circuitName, args) => {
-      await expect(
-        (
-          contract[circuitName as keyof ShieldedAccessControlSimulator] as (
-            ...a: unknown[]
-          ) => Promise<unknown>
-        )(...args),
-      ).rejects.toThrow('ShieldedAccessControl: contract not initialized');
-    });
+    it.each(circuitsRequiringInit)(
+      '%s should fail',
+      async (circuitName, args) => {
+        await expect(
+          (
+            contract[circuitName as keyof ShieldedAccessControlSimulator] as (
+              ...a: unknown[]
+            ) => Promise<unknown>
+          )(...args),
+        ).rejects.toThrow('ShieldedAccessControl: contract not initialized');
+      },
+    );
 
     it('_grantRole should independently check initialization', async () => {
       await expect(
@@ -154,15 +155,16 @@ describe('ShieldedAccessControl', () => {
       ['computeAccountId', [ADMIN_SK, INSTANCE_SALT]],
     ];
 
-    it.each(
-      circuitsNotRequiringInit,
-    )('%s should succeed', async (circuitName, args) => {
-      await (
-        contract[circuitName as keyof ShieldedAccessControlSimulator] as (
-          ...a: unknown[]
-        ) => Promise<unknown>
-      )(...args);
-    });
+    it.each(circuitsNotRequiringInit)(
+      '%s should succeed',
+      async (circuitName, args) => {
+        await (
+          contract[circuitName as keyof ShieldedAccessControlSimulator] as (
+            ...a: unknown[]
+          ) => Promise<unknown>
+        )(...args);
+      },
+    );
 
     it('should fail with zero instanceSalt', async () => {
       await expect(

--- a/contracts/src/access/test/ZOwnablePK.test.ts
+++ b/contracts/src/access/test/ZOwnablePK.test.ts
@@ -382,36 +382,34 @@ describe('ZOwnablePK', () => {
           counter: MAX_U64,
         },
       ];
-      it.each(
-        testCases,
-      )('should match commitment for $label with counter $counter', async ({
-        ownerPK,
-        counter,
-      }) => {
-        const id = createIdHash(ownerPK, secretNonce);
+      it.each(testCases)(
+        'should match commitment for $label with counter $counter',
+        async ({ ownerPK, counter }) => {
+          const id = createIdHash(ownerPK, secretNonce);
 
-        // Check buildCommitmentFromId
-        const hashFromContract = await ownable._computeOwnerCommitment(
-          id,
-          counter,
-        );
-        const hashFromHelper1 = buildCommitmentFromId(
-          id,
-          INSTANCE_SALT,
-          counter,
-        );
-        expect(hashFromContract).toEqual(hashFromHelper1);
+          // Check buildCommitmentFromId
+          const hashFromContract = await ownable._computeOwnerCommitment(
+            id,
+            counter,
+          );
+          const hashFromHelper1 = buildCommitmentFromId(
+            id,
+            INSTANCE_SALT,
+            counter,
+          );
+          expect(hashFromContract).toEqual(hashFromHelper1);
 
-        // Check buildCommitment
-        const hashFromHelper2 = buildCommitment(
-          ownerPK,
-          secretNonce,
-          INSTANCE_SALT,
-          counter,
-          DOMAIN,
-        );
-        expect(hashFromHelper1).toEqual(hashFromHelper2);
-      });
+          // Check buildCommitment
+          const hashFromHelper2 = buildCommitment(
+            ownerPK,
+            secretNonce,
+            INSTANCE_SALT,
+            counter,
+            DOMAIN,
+          );
+          expect(hashFromHelper1).toEqual(hashFromHelper2);
+        },
+      );
     });
 
     describe('_computeOwnerId', () => {
@@ -433,16 +431,14 @@ describe('ZOwnablePK', () => {
         },
       ];
 
-      it.each(
-        testCases,
-      )('should match local and contract owner id for $label', async ({
-        eitherOwner,
-        nonce,
-      }) => {
-        const ownerId = await ownable._computeOwnerId(eitherOwner, nonce);
-        const expId = createIdHash(eitherOwner.left, nonce);
-        expect(ownerId).toEqual(expId);
-      });
+      it.each(testCases)(
+        'should match local and contract owner id for $label',
+        async ({ eitherOwner, nonce }) => {
+          const ownerId = await ownable._computeOwnerId(eitherOwner, nonce);
+          const expId = createIdHash(eitherOwner.left, nonce);
+          expect(ownerId).toEqual(expId);
+        },
+      );
 
       it('should fail to compute ContractAddress id', async () => {
         const eitherContract =

--- a/contracts/src/multisig/test/Signer.test.ts
+++ b/contracts/src/multisig/test/Signer.test.ts
@@ -28,17 +28,18 @@ describe('Signer', () => {
       ['getThreshold', []],
     ];
 
-    it.each(
-      circuitsRequiringInit,
-    )('%s should fail', async (circuitName, args) => {
-      await expect(
-        (
-          contract[circuitName as keyof SignerSimulator] as (
-            ...a: unknown[]
-          ) => Promise<unknown>
-        )(...args),
-      ).rejects.toThrow('Signer: contract not initialized');
-    });
+    it.each(circuitsRequiringInit)(
+      '%s should fail',
+      async (circuitName, args) => {
+        await expect(
+          (
+            contract[circuitName as keyof SignerSimulator] as (
+              ...a: unknown[]
+            ) => Promise<unknown>
+          )(...args),
+        ).rejects.toThrow('Signer: contract not initialized');
+      },
+    );
 
     it('isSigner should succeed (no init guard)', async () => {
       expect(await contract.isSigner(SIGNER)).toEqual(false);

--- a/contracts/src/token/test/FungibleToken.test.ts
+++ b/contracts/src/token/test/FungibleToken.test.ts
@@ -354,66 +354,70 @@ describe('FungibleToken', () => {
     });
 
     describe('_unsafeTransfer', () => {
-      describe.each(
-        recipientTypes,
-      )('when the recipient is a %s', (_, recipient) => {
-        beforeEach(async () => {
-          await token._mint(OWNER.either, AMOUNT);
-          expect(await token.balanceOf(OWNER.either)).toEqual(AMOUNT);
-          expect(await token.balanceOf(recipient)).toEqual(0n);
-        });
+      describe.each(recipientTypes)(
+        'when the recipient is a %s',
+        (_, recipient) => {
+          beforeEach(async () => {
+            await token._mint(OWNER.either, AMOUNT);
+            expect(await token.balanceOf(OWNER.either)).toEqual(AMOUNT);
+            expect(await token.balanceOf(recipient)).toEqual(0n);
+          });
 
-        afterEach(async () => {
-          expect(await token.totalSupply()).toEqual(AMOUNT);
-        });
+          afterEach(async () => {
+            expect(await token.totalSupply()).toEqual(AMOUNT);
+          });
 
-        it('should transfer partial', async () => {
-          await token.privateState.injectSecretKey(OWNER.secretKey);
+          it('should transfer partial', async () => {
+            await token.privateState.injectSecretKey(OWNER.secretKey);
 
-          const partialAmt = AMOUNT - 1n;
-          const txSuccess = await token._unsafeTransfer(recipient, partialAmt);
+            const partialAmt = AMOUNT - 1n;
+            const txSuccess = await token._unsafeTransfer(
+              recipient,
+              partialAmt,
+            );
 
-          expect(txSuccess).toBe(true);
-          expect(await token.balanceOf(OWNER.either)).toEqual(1n);
-          expect(await token.balanceOf(recipient)).toEqual(partialAmt);
-        });
+            expect(txSuccess).toBe(true);
+            expect(await token.balanceOf(OWNER.either)).toEqual(1n);
+            expect(await token.balanceOf(recipient)).toEqual(partialAmt);
+          });
 
-        it('should transfer full', async () => {
-          await token.privateState.injectSecretKey(OWNER.secretKey);
+          it('should transfer full', async () => {
+            await token.privateState.injectSecretKey(OWNER.secretKey);
 
-          const txSuccess = await token._unsafeTransfer(recipient, AMOUNT);
+            const txSuccess = await token._unsafeTransfer(recipient, AMOUNT);
 
-          expect(txSuccess).toBe(true);
-          expect(await token.balanceOf(OWNER.either)).toEqual(0n);
-          expect(await token.balanceOf(recipient)).toEqual(AMOUNT);
-        });
+            expect(txSuccess).toBe(true);
+            expect(await token.balanceOf(OWNER.either)).toEqual(0n);
+            expect(await token.balanceOf(recipient)).toEqual(AMOUNT);
+          });
 
-        it('should fail with insufficient balance', async () => {
-          await token.privateState.injectSecretKey(OWNER.secretKey);
+          it('should fail with insufficient balance', async () => {
+            await token.privateState.injectSecretKey(OWNER.secretKey);
 
-          await expect(
-            token._unsafeTransfer(recipient, AMOUNT + 1n),
-          ).rejects.toThrow('FungibleToken: insufficient balance');
-        });
+            await expect(
+              token._unsafeTransfer(recipient, AMOUNT + 1n),
+            ).rejects.toThrow('FungibleToken: insufficient balance');
+          });
 
-        it('should allow transfer of 0 tokens', async () => {
-          await token.privateState.injectSecretKey(OWNER.secretKey);
+          it('should allow transfer of 0 tokens', async () => {
+            await token.privateState.injectSecretKey(OWNER.secretKey);
 
-          const txSuccess = await token._unsafeTransfer(recipient, 0n);
+            const txSuccess = await token._unsafeTransfer(recipient, 0n);
 
-          expect(txSuccess).toBe(true);
-          expect(await token.balanceOf(OWNER.either)).toEqual(AMOUNT);
-          expect(await token.balanceOf(recipient)).toEqual(0n);
-        });
+            expect(txSuccess).toBe(true);
+            expect(await token.balanceOf(OWNER.either)).toEqual(AMOUNT);
+            expect(await token.balanceOf(recipient)).toEqual(0n);
+          });
 
-        it('should handle transfer with empty _balances', async () => {
-          await token.privateState.injectSecretKey(SPENDER.secretKey);
+          it('should handle transfer with empty _balances', async () => {
+            await token.privateState.injectSecretKey(SPENDER.secretKey);
 
-          await expect(token._unsafeTransfer(recipient, 1n)).rejects.toThrow(
-            'FungibleToken: insufficient balance',
-          );
-        });
-      });
+            await expect(token._unsafeTransfer(recipient, 1n)).rejects.toThrow(
+              'FungibleToken: insufficient balance',
+            );
+          });
+        },
+      );
 
       it('should fail with transfer to zero (accountId)', async () => {
         await token._mint(OWNER.either, AMOUNT);
@@ -637,89 +641,90 @@ describe('FungibleToken', () => {
         expect(await token.totalSupply()).toEqual(AMOUNT);
       });
 
-      describe.each(
-        recipientTypes,
-      )('when the recipient is a %s', (_, recipient) => {
-        it('should transferFrom spender (partial)', async () => {
-          await token.privateState.injectSecretKey(SPENDER.secretKey);
+      describe.each(recipientTypes)(
+        'when the recipient is a %s',
+        (_, recipient) => {
+          it('should transferFrom spender (partial)', async () => {
+            await token.privateState.injectSecretKey(SPENDER.secretKey);
 
-          const partialAmt = AMOUNT - 1n;
-          const txSuccess = await token._unsafeTransferFrom(
-            OWNER.either,
-            recipient,
-            partialAmt,
-          );
-          expect(txSuccess).toBe(true);
+            const partialAmt = AMOUNT - 1n;
+            const txSuccess = await token._unsafeTransferFrom(
+              OWNER.either,
+              recipient,
+              partialAmt,
+            );
+            expect(txSuccess).toBe(true);
 
-          expect(await token.balanceOf(OWNER.either)).toEqual(1n);
-          expect(await token.balanceOf(recipient)).toEqual(partialAmt);
-          expect(await token.allowance(OWNER.either, SPENDER.either)).toEqual(
-            1n,
-          );
-        });
+            expect(await token.balanceOf(OWNER.either)).toEqual(1n);
+            expect(await token.balanceOf(recipient)).toEqual(partialAmt);
+            expect(await token.allowance(OWNER.either, SPENDER.either)).toEqual(
+              1n,
+            );
+          });
 
-        it('should transferFrom spender (full)', async () => {
-          await token.privateState.injectSecretKey(SPENDER.secretKey);
+          it('should transferFrom spender (full)', async () => {
+            await token.privateState.injectSecretKey(SPENDER.secretKey);
 
-          const txSuccess = await token._unsafeTransferFrom(
-            OWNER.either,
-            recipient,
-            AMOUNT,
-          );
-          expect(txSuccess).toBe(true);
+            const txSuccess = await token._unsafeTransferFrom(
+              OWNER.either,
+              recipient,
+              AMOUNT,
+            );
+            expect(txSuccess).toBe(true);
 
-          expect(await token.balanceOf(OWNER.either)).toEqual(0n);
-          expect(await token.balanceOf(recipient)).toEqual(AMOUNT);
-          expect(await token.allowance(OWNER.either, SPENDER.either)).toEqual(
-            0n,
-          );
-        });
+            expect(await token.balanceOf(OWNER.either)).toEqual(0n);
+            expect(await token.balanceOf(recipient)).toEqual(AMOUNT);
+            expect(await token.allowance(OWNER.either, SPENDER.either)).toEqual(
+              0n,
+            );
+          });
 
-        it('should transferFrom and not consume infinite allowance', async () => {
-          await token.privateState.injectSecretKey(OWNER.secretKey);
-          await token.approve(SPENDER.either, MAX_UINT128);
+          it('should transferFrom and not consume infinite allowance', async () => {
+            await token.privateState.injectSecretKey(OWNER.secretKey);
+            await token.approve(SPENDER.either, MAX_UINT128);
 
-          await token.privateState.injectSecretKey(SPENDER.secretKey);
-          const txSuccess = await token._unsafeTransferFrom(
-            OWNER.either,
-            recipient,
-            AMOUNT,
-          );
-          expect(txSuccess).toBe(true);
+            await token.privateState.injectSecretKey(SPENDER.secretKey);
+            const txSuccess = await token._unsafeTransferFrom(
+              OWNER.either,
+              recipient,
+              AMOUNT,
+            );
+            expect(txSuccess).toBe(true);
 
-          expect(await token.balanceOf(OWNER.either)).toEqual(0n);
-          expect(await token.balanceOf(recipient)).toEqual(AMOUNT);
-          expect(await token.allowance(OWNER.either, SPENDER.either)).toEqual(
-            MAX_UINT128,
-          );
-        });
+            expect(await token.balanceOf(OWNER.either)).toEqual(0n);
+            expect(await token.balanceOf(recipient)).toEqual(AMOUNT);
+            expect(await token.allowance(OWNER.either, SPENDER.either)).toEqual(
+              MAX_UINT128,
+            );
+          });
 
-        it('should fail when transfer amount exceeds allowance', async () => {
-          await token.privateState.injectSecretKey(SPENDER.secretKey);
+          it('should fail when transfer amount exceeds allowance', async () => {
+            await token.privateState.injectSecretKey(SPENDER.secretKey);
 
-          await expect(
-            token._unsafeTransferFrom(OWNER.either, recipient, AMOUNT + 1n),
-          ).rejects.toThrow('FungibleToken: insufficient allowance');
-        });
+            await expect(
+              token._unsafeTransferFrom(OWNER.either, recipient, AMOUNT + 1n),
+            ).rejects.toThrow('FungibleToken: insufficient allowance');
+          });
 
-        it('should fail when transfer amount exceeds balance', async () => {
-          await token.privateState.injectSecretKey(OWNER.secretKey);
-          await token.approve(SPENDER.either, AMOUNT + 1n);
+          it('should fail when transfer amount exceeds balance', async () => {
+            await token.privateState.injectSecretKey(OWNER.secretKey);
+            await token.approve(SPENDER.either, AMOUNT + 1n);
 
-          await token.privateState.injectSecretKey(SPENDER.secretKey);
-          await expect(
-            token._unsafeTransferFrom(OWNER.either, recipient, AMOUNT + 1n),
-          ).rejects.toThrow('FungibleToken: insufficient balance');
-        });
+            await token.privateState.injectSecretKey(SPENDER.secretKey);
+            await expect(
+              token._unsafeTransferFrom(OWNER.either, recipient, AMOUNT + 1n),
+            ).rejects.toThrow('FungibleToken: insufficient balance');
+          });
 
-        it('should fail when spender does not have allowance', async () => {
-          await token.privateState.injectSecretKey(UNAUTHORIZED.secretKey);
+          it('should fail when spender does not have allowance', async () => {
+            await token.privateState.injectSecretKey(UNAUTHORIZED.secretKey);
 
-          await expect(
-            token._unsafeTransferFrom(OWNER.either, recipient, AMOUNT),
-          ).rejects.toThrow('FungibleToken: insufficient allowance');
-        });
-      });
+            await expect(
+              token._unsafeTransferFrom(OWNER.either, recipient, AMOUNT),
+            ).rejects.toThrow('FungibleToken: insufficient allowance');
+          });
+        },
+      );
 
       it('should fail to transfer to the zero address (accountId)', async () => {
         await token.privateState.injectSecretKey(SPENDER.secretKey);
@@ -771,44 +776,49 @@ describe('FungibleToken', () => {
         expect(await token.totalSupply()).toEqual(AMOUNT);
       });
 
-      describe.each(
-        recipientTypes,
-      )('when the recipient is a %s', (_, recipient) => {
-        it('should update balances (partial)', async () => {
-          const partialAmt = AMOUNT - 1n;
-          await token._unsafeUncheckedTransfer(
-            OWNER.either,
-            recipient,
-            partialAmt,
-          );
-
-          expect(await token.balanceOf(OWNER.either)).toEqual(1n);
-          expect(await token.balanceOf(recipient)).toEqual(partialAmt);
-        });
-
-        it('should update balances (full)', async () => {
-          await token._unsafeUncheckedTransfer(OWNER.either, recipient, AMOUNT);
-
-          expect(await token.balanceOf(OWNER.either)).toEqual(0n);
-          expect(await token.balanceOf(recipient)).toEqual(AMOUNT);
-        });
-
-        it('should fail when transfer amount exceeds balance', async () => {
-          await expect(
-            token._unsafeUncheckedTransfer(
+      describe.each(recipientTypes)(
+        'when the recipient is a %s',
+        (_, recipient) => {
+          it('should update balances (partial)', async () => {
+            const partialAmt = AMOUNT - 1n;
+            await token._unsafeUncheckedTransfer(
               OWNER.either,
               recipient,
-              AMOUNT + 1n,
-            ),
-          ).rejects.toThrow('FungibleToken: insufficient balance');
-        });
+              partialAmt,
+            );
 
-        it('should fail when transfer from zero', async () => {
-          await expect(
-            token._unsafeUncheckedTransfer(ZERO_CONTRACT, recipient, AMOUNT),
-          ).rejects.toThrow('FungibleToken: invalid sender');
-        });
-      });
+            expect(await token.balanceOf(OWNER.either)).toEqual(1n);
+            expect(await token.balanceOf(recipient)).toEqual(partialAmt);
+          });
+
+          it('should update balances (full)', async () => {
+            await token._unsafeUncheckedTransfer(
+              OWNER.either,
+              recipient,
+              AMOUNT,
+            );
+
+            expect(await token.balanceOf(OWNER.either)).toEqual(0n);
+            expect(await token.balanceOf(recipient)).toEqual(AMOUNT);
+          });
+
+          it('should fail when transfer amount exceeds balance', async () => {
+            await expect(
+              token._unsafeUncheckedTransfer(
+                OWNER.either,
+                recipient,
+                AMOUNT + 1n,
+              ),
+            ).rejects.toThrow('FungibleToken: insufficient balance');
+          });
+
+          it('should fail when transfer from zero', async () => {
+            await expect(
+              token._unsafeUncheckedTransfer(ZERO_CONTRACT, recipient, AMOUNT),
+            ).rejects.toThrow('FungibleToken: invalid sender');
+          });
+        },
+      );
 
       it('should fail when transfer to zero (accountId)', async () => {
         await expect(
@@ -917,31 +927,32 @@ describe('FungibleToken', () => {
     });
 
     describe('_unsafeMint', () => {
-      describe.each(
-        recipientTypes,
-      )('when the recipient is a %s', (_, recipient) => {
-        it('should mint and update supply', async () => {
-          expect(await token.totalSupply()).toEqual(0n);
+      describe.each(recipientTypes)(
+        'when the recipient is a %s',
+        (_, recipient) => {
+          it('should mint and update supply', async () => {
+            expect(await token.totalSupply()).toEqual(0n);
 
-          await token._unsafeMint(recipient, AMOUNT);
-          expect(await token.totalSupply()).toEqual(AMOUNT);
-          expect(await token.balanceOf(recipient)).toEqual(AMOUNT);
-        });
+            await token._unsafeMint(recipient, AMOUNT);
+            expect(await token.totalSupply()).toEqual(AMOUNT);
+            expect(await token.balanceOf(recipient)).toEqual(AMOUNT);
+          });
 
-        it('should catch mint overflow', async () => {
-          await token._unsafeMint(recipient, MAX_UINT128);
+          it('should catch mint overflow', async () => {
+            await token._unsafeMint(recipient, MAX_UINT128);
 
-          await expect(token._unsafeMint(recipient, 1n)).rejects.toThrow(
-            'FungibleToken: arithmetic overflow',
-          );
-        });
+            await expect(token._unsafeMint(recipient, 1n)).rejects.toThrow(
+              'FungibleToken: arithmetic overflow',
+            );
+          });
 
-        it('should allow mint of 0 tokens', async () => {
-          await token._unsafeMint(recipient, 0n);
-          expect(await token.totalSupply()).toEqual(0n);
-          expect(await token.balanceOf(recipient)).toEqual(0n);
-        });
-      });
+          it('should allow mint of 0 tokens', async () => {
+            await token._unsafeMint(recipient, 0n);
+            expect(await token.totalSupply()).toEqual(0n);
+            expect(await token.balanceOf(recipient)).toEqual(0n);
+          });
+        },
+      );
 
       it('should not mint to zero (accountId)', async () => {
         await expect(token._unsafeMint(ZERO_ACCOUNT, AMOUNT)).rejects.toThrow(

--- a/contracts/src/token/test/MultiToken.test.ts
+++ b/contracts/src/token/test/MultiToken.test.ts
@@ -668,134 +668,139 @@ describe('MultiToken', () => {
           await token.privateState.injectSecretKey(caller.secretKey);
         });
 
-        describe.each(
-          recipientTypes,
-        )('when the recipient is a %s', (_, recipient) => {
-          it('should transfer whole', async () => {
-            await token._unsafeTransferFrom(
-              OWNER.either,
-              recipient,
-              TOKEN_ID,
-              AMOUNT,
-            );
-
-            expect(await token.balanceOf(OWNER.either, TOKEN_ID)).toEqual(0n);
-            expect(await token.balanceOf(recipient, TOKEN_ID)).toEqual(AMOUNT);
-          });
-
-          it('should transfer partial', async () => {
-            const partialAmt = AMOUNT - 1n;
-            await token._unsafeTransferFrom(
-              OWNER.either,
-              recipient,
-              TOKEN_ID,
-              partialAmt,
-            );
-
-            expect(await token.balanceOf(OWNER.either, TOKEN_ID)).toEqual(
-              AMOUNT - partialAmt,
-            );
-            expect(await token.balanceOf(recipient, TOKEN_ID)).toEqual(
-              partialAmt,
-            );
-          });
-
-          it('should allow transfer of 0 tokens', async () => {
-            await token._unsafeTransferFrom(
-              OWNER.either,
-              recipient,
-              TOKEN_ID,
-              0n,
-            );
-
-            expect(await token.balanceOf(OWNER.either, TOKEN_ID)).toEqual(
-              AMOUNT,
-            );
-            expect(await token.balanceOf(recipient, TOKEN_ID)).toEqual(0n);
-          });
-
-          it('should handle self-transfer', async () => {
-            await token._unsafeTransferFrom(
-              OWNER.either,
-              OWNER.either,
-              TOKEN_ID,
-              AMOUNT,
-            );
-            expect(await token.balanceOf(OWNER.either, TOKEN_ID)).toEqual(
-              AMOUNT,
-            );
-          });
-
-          it('should handle MAX_UINT128 transfer amount', async () => {
-            await token._mint(OWNER.either, TOKEN_ID, MAX_UINT128 - AMOUNT);
-
-            await token._unsafeTransferFrom(
-              OWNER.either,
-              recipient,
-              TOKEN_ID,
-              MAX_UINT128,
-            );
-            expect(await token.balanceOf(recipient, TOKEN_ID)).toEqual(
-              MAX_UINT128,
-            );
-          });
-
-          it('should handle rapid state changes', async () => {
-            await token.privateState.injectSecretKey(OWNER.secretKey);
-            await token.setApprovalForAll(SPENDER.either, true);
-
-            await token._unsafeTransferFrom(
-              OWNER.either,
-              recipient,
-              TOKEN_ID,
-              AMOUNT,
-            );
-            expect(await token.balanceOf(recipient, TOKEN_ID)).toEqual(AMOUNT);
-
-            await token.setApprovalForAll(SPENDER.either, false);
-            expect(
-              await token.isApprovedForAll(OWNER.either, SPENDER.either),
-            ).toBe(false);
-
-            await token.setApprovalForAll(SPENDER.either, true);
-            expect(
-              await token.isApprovedForAll(OWNER.either, SPENDER.either),
-            ).toBe(true);
-          });
-
-          it('should fail with insufficient balance', async () => {
-            await expect(
-              token._unsafeTransferFrom(
+        describe.each(recipientTypes)(
+          'when the recipient is a %s',
+          (_, recipient) => {
+            it('should transfer whole', async () => {
+              await token._unsafeTransferFrom(
                 OWNER.either,
                 recipient,
                 TOKEN_ID,
-                AMOUNT + 1n,
-              ),
-            ).rejects.toThrow('MultiToken: insufficient balance');
-          });
+                AMOUNT,
+              );
 
-          it('should fail with nonexistent id', async () => {
-            await expect(
-              token._unsafeTransferFrom(
+              expect(await token.balanceOf(OWNER.either, TOKEN_ID)).toEqual(0n);
+              expect(await token.balanceOf(recipient, TOKEN_ID)).toEqual(
+                AMOUNT,
+              );
+            });
+
+            it('should transfer partial', async () => {
+              const partialAmt = AMOUNT - 1n;
+              await token._unsafeTransferFrom(
                 OWNER.either,
                 recipient,
-                NONEXISTENT_ID,
-                AMOUNT,
-              ),
-            ).rejects.toThrow('MultiToken: insufficient balance');
-          });
+                TOKEN_ID,
+                partialAmt,
+              );
 
-          it('should fail with transfer from zero', async () => {
-            await expect(
-              token._unsafeTransferFrom(
-                ZERO_ACCOUNT,
+              expect(await token.balanceOf(OWNER.either, TOKEN_ID)).toEqual(
+                AMOUNT - partialAmt,
+              );
+              expect(await token.balanceOf(recipient, TOKEN_ID)).toEqual(
+                partialAmt,
+              );
+            });
+
+            it('should allow transfer of 0 tokens', async () => {
+              await token._unsafeTransferFrom(
+                OWNER.either,
+                recipient,
+                TOKEN_ID,
+                0n,
+              );
+
+              expect(await token.balanceOf(OWNER.either, TOKEN_ID)).toEqual(
+                AMOUNT,
+              );
+              expect(await token.balanceOf(recipient, TOKEN_ID)).toEqual(0n);
+            });
+
+            it('should handle self-transfer', async () => {
+              await token._unsafeTransferFrom(
+                OWNER.either,
+                OWNER.either,
+                TOKEN_ID,
+                AMOUNT,
+              );
+              expect(await token.balanceOf(OWNER.either, TOKEN_ID)).toEqual(
+                AMOUNT,
+              );
+            });
+
+            it('should handle MAX_UINT128 transfer amount', async () => {
+              await token._mint(OWNER.either, TOKEN_ID, MAX_UINT128 - AMOUNT);
+
+              await token._unsafeTransferFrom(
+                OWNER.either,
+                recipient,
+                TOKEN_ID,
+                MAX_UINT128,
+              );
+              expect(await token.balanceOf(recipient, TOKEN_ID)).toEqual(
+                MAX_UINT128,
+              );
+            });
+
+            it('should handle rapid state changes', async () => {
+              await token.privateState.injectSecretKey(OWNER.secretKey);
+              await token.setApprovalForAll(SPENDER.either, true);
+
+              await token._unsafeTransferFrom(
+                OWNER.either,
                 recipient,
                 TOKEN_ID,
                 AMOUNT,
-              ),
-            ).rejects.toThrow('MultiToken: unauthorized operator');
-          });
-        });
+              );
+              expect(await token.balanceOf(recipient, TOKEN_ID)).toEqual(
+                AMOUNT,
+              );
+
+              await token.setApprovalForAll(SPENDER.either, false);
+              expect(
+                await token.isApprovedForAll(OWNER.either, SPENDER.either),
+              ).toBe(false);
+
+              await token.setApprovalForAll(SPENDER.either, true);
+              expect(
+                await token.isApprovedForAll(OWNER.either, SPENDER.either),
+              ).toBe(true);
+            });
+
+            it('should fail with insufficient balance', async () => {
+              await expect(
+                token._unsafeTransferFrom(
+                  OWNER.either,
+                  recipient,
+                  TOKEN_ID,
+                  AMOUNT + 1n,
+                ),
+              ).rejects.toThrow('MultiToken: insufficient balance');
+            });
+
+            it('should fail with nonexistent id', async () => {
+              await expect(
+                token._unsafeTransferFrom(
+                  OWNER.either,
+                  recipient,
+                  NONEXISTENT_ID,
+                  AMOUNT,
+                ),
+              ).rejects.toThrow('MultiToken: insufficient balance');
+            });
+
+            it('should fail with transfer from zero', async () => {
+              await expect(
+                token._unsafeTransferFrom(
+                  ZERO_ACCOUNT,
+                  recipient,
+                  TOKEN_ID,
+                  AMOUNT,
+                ),
+              ).rejects.toThrow('MultiToken: unauthorized operator');
+            });
+          },
+        );
 
         it('should fail with transfer to zero (id)', async () => {
           await expect(
@@ -921,75 +926,81 @@ describe('MultiToken', () => {
           await token.privateState.injectSecretKey(UNAUTHORIZED.secretKey);
         });
 
-        describe.each(
-          recipientTypes,
-        )('when recipient is %s', (_, recipient) => {
-          it('should fail when transfer whole', async () => {
-            await expect(
-              token._unsafeTransferFrom(
-                OWNER.either,
-                recipient,
-                TOKEN_ID,
-                AMOUNT,
-              ),
-            ).rejects.toThrow('MultiToken: unauthorized operator');
-          });
+        describe.each(recipientTypes)(
+          'when recipient is %s',
+          (_, recipient) => {
+            it('should fail when transfer whole', async () => {
+              await expect(
+                token._unsafeTransferFrom(
+                  OWNER.either,
+                  recipient,
+                  TOKEN_ID,
+                  AMOUNT,
+                ),
+              ).rejects.toThrow('MultiToken: unauthorized operator');
+            });
 
-          it('should fail when transfer partial', async () => {
-            const partialAmt = AMOUNT - 1n;
-            await expect(
-              token._unsafeTransferFrom(
-                OWNER.either,
-                recipient,
-                TOKEN_ID,
-                partialAmt,
-              ),
-            ).rejects.toThrow('MultiToken: unauthorized operator');
-          });
+            it('should fail when transfer partial', async () => {
+              const partialAmt = AMOUNT - 1n;
+              await expect(
+                token._unsafeTransferFrom(
+                  OWNER.either,
+                  recipient,
+                  TOKEN_ID,
+                  partialAmt,
+                ),
+              ).rejects.toThrow('MultiToken: unauthorized operator');
+            });
 
-          it('should fail when transfer zero', async () => {
-            await expect(
-              token._unsafeTransferFrom(OWNER.either, recipient, TOKEN_ID, 0n),
-            ).rejects.toThrow('MultiToken: unauthorized operator');
-          });
+            it('should fail when transfer zero', async () => {
+              await expect(
+                token._unsafeTransferFrom(
+                  OWNER.either,
+                  recipient,
+                  TOKEN_ID,
+                  0n,
+                ),
+              ).rejects.toThrow('MultiToken: unauthorized operator');
+            });
 
-          it('should fail with insufficient balance', async () => {
-            await expect(
-              token._unsafeTransferFrom(
-                OWNER.either,
-                recipient,
-                TOKEN_ID,
-                AMOUNT + 1n,
-              ),
-            ).rejects.toThrow('MultiToken: unauthorized operator');
-          });
+            it('should fail with insufficient balance', async () => {
+              await expect(
+                token._unsafeTransferFrom(
+                  OWNER.either,
+                  recipient,
+                  TOKEN_ID,
+                  AMOUNT + 1n,
+                ),
+              ).rejects.toThrow('MultiToken: unauthorized operator');
+            });
 
-          it('should fail with nonexistent id', async () => {
-            await expect(
-              token._unsafeTransferFrom(
-                OWNER.either,
-                recipient,
-                NONEXISTENT_ID,
-                AMOUNT,
-              ),
-            ).rejects.toThrow('MultiToken: unauthorized operator');
-          });
+            it('should fail with nonexistent id', async () => {
+              await expect(
+                token._unsafeTransferFrom(
+                  OWNER.either,
+                  recipient,
+                  NONEXISTENT_ID,
+                  AMOUNT,
+                ),
+              ).rejects.toThrow('MultiToken: unauthorized operator');
+            });
 
-          it('should fail with transfer from zero', async () => {
-            // With witness-based identity, the caller is H(sk) which is
-            // always non-zero. Transferring from ZERO_ACCOUNT means
-            // canonFrom != caller → isApprovedForAll(zeroAccount, caller) → false
-            // → "unauthorized operator"
-            await expect(
-              token._unsafeTransferFrom(
-                ZERO_ACCOUNT,
-                recipient,
-                TOKEN_ID,
-                AMOUNT,
-              ),
-            ).rejects.toThrow('MultiToken: unauthorized operator');
-          });
-        });
+            it('should fail with transfer from zero', async () => {
+              // With witness-based identity, the caller is H(sk) which is
+              // always non-zero. Transferring from ZERO_ACCOUNT means
+              // canonFrom != caller → isApprovedForAll(zeroAccount, caller) → false
+              // → "unauthorized operator"
+              await expect(
+                token._unsafeTransferFrom(
+                  ZERO_ACCOUNT,
+                  recipient,
+                  TOKEN_ID,
+                  AMOUNT,
+                ),
+              ).rejects.toThrow('MultiToken: unauthorized operator');
+            });
+          },
+        );
       });
     });
 
@@ -1120,79 +1131,82 @@ describe('MultiToken', () => {
         expect(await token.balanceOf(RECIPIENT.either, TOKEN_ID)).toEqual(0n);
       });
 
-      describe.each(
-        recipientTypes,
-      )('when the recipient is a %s', (_, recipient) => {
-        it('should transfer whole', async () => {
-          await token._unsafeTransfer(
-            OWNER.either,
-            recipient,
-            TOKEN_ID,
-            AMOUNT,
-          );
-
-          expect(await token.balanceOf(OWNER.either, TOKEN_ID)).toEqual(0n);
-          expect(await token.balanceOf(recipient, TOKEN_ID)).toEqual(AMOUNT);
-        });
-
-        it('should transfer partial', async () => {
-          const partialAmt = AMOUNT - 1n;
-          await token._unsafeTransfer(
-            OWNER.either,
-            recipient,
-            TOKEN_ID,
-            partialAmt,
-          );
-
-          expect(await token.balanceOf(OWNER.either, TOKEN_ID)).toEqual(
-            AMOUNT - partialAmt,
-          );
-          expect(await token.balanceOf(recipient, TOKEN_ID)).toEqual(
-            partialAmt,
-          );
-        });
-
-        it('should allow transfer of 0 tokens', async () => {
-          await token._unsafeTransfer(OWNER.either, recipient, TOKEN_ID, 0n);
-
-          expect(await token.balanceOf(OWNER.either, TOKEN_ID)).toEqual(AMOUNT);
-          expect(await token.balanceOf(recipient, TOKEN_ID)).toEqual(0n);
-        });
-
-        it('should fail with insufficient balance', async () => {
-          await expect(
-            token._unsafeTransfer(
+      describe.each(recipientTypes)(
+        'when the recipient is a %s',
+        (_, recipient) => {
+          it('should transfer whole', async () => {
+            await token._unsafeTransfer(
               OWNER.either,
               recipient,
               TOKEN_ID,
-              AMOUNT + 1n,
-            ),
-          ).rejects.toThrow('MultiToken: insufficient balance');
-        });
+              AMOUNT,
+            );
 
-        it('should fail with nonexistent id', async () => {
-          await expect(
-            token._unsafeTransfer(
+            expect(await token.balanceOf(OWNER.either, TOKEN_ID)).toEqual(0n);
+            expect(await token.balanceOf(recipient, TOKEN_ID)).toEqual(AMOUNT);
+          });
+
+          it('should transfer partial', async () => {
+            const partialAmt = AMOUNT - 1n;
+            await token._unsafeTransfer(
               OWNER.either,
               recipient,
-              NONEXISTENT_ID,
+              TOKEN_ID,
+              partialAmt,
+            );
+
+            expect(await token.balanceOf(OWNER.either, TOKEN_ID)).toEqual(
+              AMOUNT - partialAmt,
+            );
+            expect(await token.balanceOf(recipient, TOKEN_ID)).toEqual(
+              partialAmt,
+            );
+          });
+
+          it('should allow transfer of 0 tokens', async () => {
+            await token._unsafeTransfer(OWNER.either, recipient, TOKEN_ID, 0n);
+
+            expect(await token.balanceOf(OWNER.either, TOKEN_ID)).toEqual(
               AMOUNT,
-            ),
-          ).rejects.toThrow('MultiToken: insufficient balance');
-        });
+            );
+            expect(await token.balanceOf(recipient, TOKEN_ID)).toEqual(0n);
+          });
 
-        it('should fail when transfer from 0 (id)', async () => {
-          await expect(
-            token._unsafeTransfer(ZERO_ACCOUNT, recipient, TOKEN_ID, AMOUNT),
-          ).rejects.toThrow('MultiToken: invalid sender');
-        });
+          it('should fail with insufficient balance', async () => {
+            await expect(
+              token._unsafeTransfer(
+                OWNER.either,
+                recipient,
+                TOKEN_ID,
+                AMOUNT + 1n,
+              ),
+            ).rejects.toThrow('MultiToken: insufficient balance');
+          });
 
-        it('should fail when transfer from 0 (contract address)', async () => {
-          await expect(
-            token._unsafeTransfer(ZERO_CONTRACT, recipient, TOKEN_ID, AMOUNT),
-          ).rejects.toThrow('MultiToken: invalid sender');
-        });
-      });
+          it('should fail with nonexistent id', async () => {
+            await expect(
+              token._unsafeTransfer(
+                OWNER.either,
+                recipient,
+                NONEXISTENT_ID,
+                AMOUNT,
+              ),
+            ).rejects.toThrow('MultiToken: insufficient balance');
+          });
+
+          it('should fail when transfer from 0 (id)', async () => {
+            await expect(
+              token._unsafeTransfer(ZERO_ACCOUNT, recipient, TOKEN_ID, AMOUNT),
+            ).rejects.toThrow('MultiToken: invalid sender');
+          });
+
+          it('should fail when transfer from 0 (contract address)', async () => {
+            await expect(
+              token._unsafeTransfer(ZERO_CONTRACT, recipient, TOKEN_ID, AMOUNT),
+            ).rejects.toThrow('MultiToken: invalid sender');
+          });
+        },
+      );
 
       it('should handle non-canonical fromAddress (id)', async () => {
         const nonCanonical = nonCanonicalLeft(OWNER.accountId);
@@ -1363,31 +1377,32 @@ describe('MultiToken', () => {
     });
 
     describe('_unsafeMint', () => {
-      describe.each(
-        recipientTypes,
-      )('when the recipient is a %s', (_, recipient) => {
-        it('should update balance when minting', async () => {
-          await token._unsafeMint(recipient, TOKEN_ID, AMOUNT);
+      describe.each(recipientTypes)(
+        'when the recipient is a %s',
+        (_, recipient) => {
+          it('should update balance when minting', async () => {
+            await token._unsafeMint(recipient, TOKEN_ID, AMOUNT);
 
-          expect(await token.balanceOf(recipient, TOKEN_ID)).toEqual(AMOUNT);
-        });
+            expect(await token.balanceOf(recipient, TOKEN_ID)).toEqual(AMOUNT);
+          });
 
-        it('should update balance with multiple mints', async () => {
-          for (let i = 0; i < 3; i++) {
-            await token._unsafeMint(recipient, TOKEN_ID, 1n);
-          }
+          it('should update balance with multiple mints', async () => {
+            for (let i = 0; i < 3; i++) {
+              await token._unsafeMint(recipient, TOKEN_ID, 1n);
+            }
 
-          expect(await token.balanceOf(recipient, TOKEN_ID)).toEqual(3n);
-        });
+            expect(await token.balanceOf(recipient, TOKEN_ID)).toEqual(3n);
+          });
 
-        it('should fail when overflowing uint128', async () => {
-          await token._unsafeMint(recipient, TOKEN_ID, MAX_UINT128);
+          it('should fail when overflowing uint128', async () => {
+            await token._unsafeMint(recipient, TOKEN_ID, MAX_UINT128);
 
-          await expect(
-            token._unsafeMint(recipient, TOKEN_ID, 1n),
-          ).rejects.toThrow('MultiToken: arithmetic overflow');
-        });
-      });
+            await expect(
+              token._unsafeMint(recipient, TOKEN_ID, 1n),
+            ).rejects.toThrow('MultiToken: arithmetic overflow');
+          });
+        },
+      );
 
       it('should fail when minting to zero address (id)', async () => {
         await expect(

--- a/contracts/src/token/test/NativeShieldedToken.test.ts
+++ b/contracts/src/token/test/NativeShieldedToken.test.ts
@@ -92,13 +92,14 @@ describe('NativeShieldedToken (Fungible profile)', () => {
       ],
     ];
 
-    it.each(
-      circuitsToFail,
-    )('should revert %s before initialize', async (method, args) => {
-      await expect(
-        (token[method] as (...a: unknown[]) => Promise<unknown>)(...args),
-      ).rejects.toThrow('NativeShieldedToken: contract not initialized');
-    });
+    it.each(circuitsToFail)(
+      'should revert %s before initialize',
+      async (method, args) => {
+        await expect(
+          (token[method] as (...a: unknown[]) => Promise<unknown>)(...args),
+        ).rejects.toThrow('NativeShieldedToken: contract not initialized');
+      },
+    );
   });
 
   describe('_mint', () => {

--- a/contracts/src/token/test/NativeShieldedTokenCore.test.ts
+++ b/contracts/src/token/test/NativeShieldedTokenCore.test.ts
@@ -135,13 +135,14 @@ describe('NativeShieldedTokenCore (bare base)', () => {
       ],
     ];
 
-    it.each(
-      circuitsToFail,
-    )('should revert %s before initialize', async (method, args) => {
-      await expect(
-        (token[method] as (...a: unknown[]) => Promise<unknown>)(...args),
-      ).rejects.toThrow('NativeShieldedToken: contract not initialized');
-    });
+    it.each(circuitsToFail)(
+      'should revert %s before initialize',
+      async (method, args) => {
+        await expect(
+          (token[method] as (...a: unknown[]) => Promise<unknown>)(...args),
+        ).rejects.toThrow('NativeShieldedToken: contract not initialized');
+      },
+    );
   });
 
   describe('_mint (per domain)', () => {

--- a/contracts/src/token/test/NativeShieldedTokenFamily.test.ts
+++ b/contracts/src/token/test/NativeShieldedTokenFamily.test.ts
@@ -78,13 +78,14 @@ describe('NativeShieldedTokenFamily (Family profile)', () => {
       ],
     ];
 
-    it.each(
-      circuitsToFail,
-    )('should revert %s before initialize', async (method, args) => {
-      await expect(
-        (token[method] as (...a: unknown[]) => Promise<unknown>)(...args),
-      ).rejects.toThrow('NativeShieldedToken: contract not initialized');
-    });
+    it.each(circuitsToFail)(
+      'should revert %s before initialize',
+      async (method, args) => {
+        await expect(
+          (token[method] as (...a: unknown[]) => Promise<unknown>)(...args),
+        ).rejects.toThrow('NativeShieldedToken: contract not initialized');
+      },
+    );
   });
 
   describe('_mint (per domain)', () => {

--- a/package.json
+++ b/package.json
@@ -36,13 +36,13 @@
     "@midnight-ntwrk/compact-runtime": "0.16.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.5.0",
+    "@biomejs/biome": "^2.5.2",
     "@midnight-ntwrk/ledger-v8": "8.1.0",
     "@midnight-ntwrk/zswap": "^4.0.0",
-    "@types/node": "25.9.3",
+    "@types/node": "26.1.0",
     "ts-node": "^10.9.2",
-    "turbo": "^2.9.18",
+    "turbo": "^2.10.0",
     "typescript": "^6.0.3",
-    "vitest": "^4.1.9"
+    "vitest": "^4.1.10"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -47,18 +47,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@biomejs/biome@npm:^2.5.0":
-  version: 2.5.0
-  resolution: "@biomejs/biome@npm:2.5.0"
+"@biomejs/biome@npm:^2.5.2":
+  version: 2.5.4
+  resolution: "@biomejs/biome@npm:2.5.4"
   dependencies:
-    "@biomejs/cli-darwin-arm64": "npm:2.5.0"
-    "@biomejs/cli-darwin-x64": "npm:2.5.0"
-    "@biomejs/cli-linux-arm64": "npm:2.5.0"
-    "@biomejs/cli-linux-arm64-musl": "npm:2.5.0"
-    "@biomejs/cli-linux-x64": "npm:2.5.0"
-    "@biomejs/cli-linux-x64-musl": "npm:2.5.0"
-    "@biomejs/cli-win32-arm64": "npm:2.5.0"
-    "@biomejs/cli-win32-x64": "npm:2.5.0"
+    "@biomejs/cli-darwin-arm64": "npm:2.5.4"
+    "@biomejs/cli-darwin-x64": "npm:2.5.4"
+    "@biomejs/cli-linux-arm64": "npm:2.5.4"
+    "@biomejs/cli-linux-arm64-musl": "npm:2.5.4"
+    "@biomejs/cli-linux-x64": "npm:2.5.4"
+    "@biomejs/cli-linux-x64-musl": "npm:2.5.4"
+    "@biomejs/cli-win32-arm64": "npm:2.5.4"
+    "@biomejs/cli-win32-x64": "npm:2.5.4"
   dependenciesMeta:
     "@biomejs/cli-darwin-arm64":
       optional: true
@@ -78,62 +78,62 @@ __metadata:
       optional: true
   bin:
     biome: bin/biome
-  checksum: 10/8bd40ccb0f0465b78df98f5f433aeb5a2ea455b6563194737ba7354b57568ff3793817d15c1912a15f7d79b9068103f007bb53c08aa048406510714d99646022
+  checksum: 10/df9f4c2537d98b93606cefa8591612b8c5287646c5fd01540433ac395a7c2c7eab4941c43b0564485e1b0373e0e2945faac431cb6216c14c409c9adf1928db54
   languageName: node
   linkType: hard
 
-"@biomejs/cli-darwin-arm64@npm:2.5.0":
-  version: 2.5.0
-  resolution: "@biomejs/cli-darwin-arm64@npm:2.5.0"
+"@biomejs/cli-darwin-arm64@npm:2.5.4":
+  version: 2.5.4
+  resolution: "@biomejs/cli-darwin-arm64@npm:2.5.4"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@biomejs/cli-darwin-x64@npm:2.5.0":
-  version: 2.5.0
-  resolution: "@biomejs/cli-darwin-x64@npm:2.5.0"
+"@biomejs/cli-darwin-x64@npm:2.5.4":
+  version: 2.5.4
+  resolution: "@biomejs/cli-darwin-x64@npm:2.5.4"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@biomejs/cli-linux-arm64-musl@npm:2.5.0":
-  version: 2.5.0
-  resolution: "@biomejs/cli-linux-arm64-musl@npm:2.5.0"
+"@biomejs/cli-linux-arm64-musl@npm:2.5.4":
+  version: 2.5.4
+  resolution: "@biomejs/cli-linux-arm64-musl@npm:2.5.4"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"@biomejs/cli-linux-arm64@npm:2.5.0":
-  version: 2.5.0
-  resolution: "@biomejs/cli-linux-arm64@npm:2.5.0"
+"@biomejs/cli-linux-arm64@npm:2.5.4":
+  version: 2.5.4
+  resolution: "@biomejs/cli-linux-arm64@npm:2.5.4"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@biomejs/cli-linux-x64-musl@npm:2.5.0":
-  version: 2.5.0
-  resolution: "@biomejs/cli-linux-x64-musl@npm:2.5.0"
+"@biomejs/cli-linux-x64-musl@npm:2.5.4":
+  version: 2.5.4
+  resolution: "@biomejs/cli-linux-x64-musl@npm:2.5.4"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"@biomejs/cli-linux-x64@npm:2.5.0":
-  version: 2.5.0
-  resolution: "@biomejs/cli-linux-x64@npm:2.5.0"
+"@biomejs/cli-linux-x64@npm:2.5.4":
+  version: 2.5.4
+  resolution: "@biomejs/cli-linux-x64@npm:2.5.4"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@biomejs/cli-win32-arm64@npm:2.5.0":
-  version: 2.5.0
-  resolution: "@biomejs/cli-win32-arm64@npm:2.5.0"
+"@biomejs/cli-win32-arm64@npm:2.5.4":
+  version: 2.5.4
+  resolution: "@biomejs/cli-win32-arm64@npm:2.5.4"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@biomejs/cli-win32-x64@npm:2.5.0":
-  version: 2.5.0
-  resolution: "@biomejs/cli-win32-x64@npm:2.5.0"
+"@biomejs/cli-win32-x64@npm:2.5.4":
+  version: 2.5.4
+  resolution: "@biomejs/cli-win32-x64@npm:2.5.4"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -331,12 +331,12 @@ __metadata:
     "@openzeppelin/compact-cli": "npm:^0.0.2"
     "@openzeppelin/compact-simulator": "npm:^0.2.0"
     "@tsconfig/node24": "npm:^24.0.4"
-    "@types/node": "npm:25.9.3"
-    "@vitest/coverage-v8": "npm:^4.1.9"
+    "@types/node": "npm:26.1.0"
+    "@vitest/coverage-v8": "npm:^4.1.10"
     fast-check: "npm:^4.8.0"
     ts-node: "npm:^10.9.2"
     typescript: "npm:^6.0.3"
-    vitest: "npm:^4.1.9"
+    vitest: "npm:^4.1.10"
   languageName: unknown
   linkType: soft
 
@@ -530,44 +530,44 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@turbo/darwin-64@npm:2.9.18":
-  version: 2.9.18
-  resolution: "@turbo/darwin-64@npm:2.9.18"
+"@turbo/darwin-64@npm:2.10.5":
+  version: 2.10.5
+  resolution: "@turbo/darwin-64@npm:2.10.5"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@turbo/darwin-arm64@npm:2.9.18":
-  version: 2.9.18
-  resolution: "@turbo/darwin-arm64@npm:2.9.18"
+"@turbo/darwin-arm64@npm:2.10.5":
+  version: 2.10.5
+  resolution: "@turbo/darwin-arm64@npm:2.10.5"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@turbo/linux-64@npm:2.9.18":
-  version: 2.9.18
-  resolution: "@turbo/linux-64@npm:2.9.18"
+"@turbo/linux-64@npm:2.10.5":
+  version: 2.10.5
+  resolution: "@turbo/linux-64@npm:2.10.5"
   conditions: os=linux & cpu=x64
   languageName: node
   linkType: hard
 
-"@turbo/linux-arm64@npm:2.9.18":
-  version: 2.9.18
-  resolution: "@turbo/linux-arm64@npm:2.9.18"
+"@turbo/linux-arm64@npm:2.10.5":
+  version: 2.10.5
+  resolution: "@turbo/linux-arm64@npm:2.10.5"
   conditions: os=linux & cpu=arm64
   languageName: node
   linkType: hard
 
-"@turbo/windows-64@npm:2.9.18":
-  version: 2.9.18
-  resolution: "@turbo/windows-64@npm:2.9.18"
+"@turbo/windows-64@npm:2.10.5":
+  version: 2.10.5
+  resolution: "@turbo/windows-64@npm:2.10.5"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
-"@turbo/windows-arm64@npm:2.9.18":
-  version: 2.9.18
-  resolution: "@turbo/windows-arm64@npm:2.9.18"
+"@turbo/windows-arm64@npm:2.10.5":
+  version: 2.10.5
+  resolution: "@turbo/windows-arm64@npm:2.10.5"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
@@ -604,12 +604,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:25.9.3":
-  version: 25.9.3
-  resolution: "@types/node@npm:25.9.3"
+"@types/node@npm:26.1.0":
+  version: 26.1.0
+  resolution: "@types/node@npm:26.1.0"
   dependencies:
-    undici-types: "npm:>=7.24.0 <7.24.7"
-  checksum: 10/40c5f5c91450689b255dbf8cbd6cf0bb05e1013a353830b15eb9b5c9cda6448510be572d1ecadc38c8a4ac472e61381de9ae28df82094abece59f4c1eccffbc5
+    undici-types: "npm:~8.3.0"
+  checksum: 10/fee720e8ddf8aa66a22bc5cf3209347f8dcc07cbf7475f966761684f04fb34b819739a311edbf87271d6c7f9f50b1f015d3ff9e36d67d04264aafe18ac9a3796
   languageName: node
   linkType: hard
 
@@ -620,12 +620,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vitest/coverage-v8@npm:^4.1.9":
-  version: 4.1.9
-  resolution: "@vitest/coverage-v8@npm:4.1.9"
+"@vitest/coverage-v8@npm:^4.1.10":
+  version: 4.1.10
+  resolution: "@vitest/coverage-v8@npm:4.1.10"
   dependencies:
     "@bcoe/v8-coverage": "npm:^1.0.2"
-    "@vitest/utils": "npm:4.1.9"
+    "@vitest/utils": "npm:4.1.10"
     ast-v8-to-istanbul: "npm:^1.0.0"
     istanbul-lib-coverage: "npm:^3.2.2"
     istanbul-lib-report: "npm:^3.0.1"
@@ -635,34 +635,34 @@ __metadata:
     std-env: "npm:^4.0.0-rc.1"
     tinyrainbow: "npm:^3.1.0"
   peerDependencies:
-    "@vitest/browser": 4.1.9
-    vitest: 4.1.9
+    "@vitest/browser": 4.1.10
+    vitest: 4.1.10
   peerDependenciesMeta:
     "@vitest/browser":
       optional: true
-  checksum: 10/1f236e17336973868aa6e7662b863b1c519d07840107daab3465429652741fc1f8a8988d1b7b28b8cfa883c7280f7479927a85e56c7874a0ddc5cc8ceda25cd6
+  checksum: 10/e593f5205a65d10f200e68a99e720d7a9f5e9be65d8160e4f0b6b5f1a7a87f0453c03e79fd1c022dbd7fb26a22657ca4d9410ae27b36da90d41d7ca04f681ab1
   languageName: node
   linkType: hard
 
-"@vitest/expect@npm:4.1.9":
-  version: 4.1.9
-  resolution: "@vitest/expect@npm:4.1.9"
+"@vitest/expect@npm:4.1.10":
+  version: 4.1.10
+  resolution: "@vitest/expect@npm:4.1.10"
   dependencies:
     "@standard-schema/spec": "npm:^1.1.0"
     "@types/chai": "npm:^5.2.2"
-    "@vitest/spy": "npm:4.1.9"
-    "@vitest/utils": "npm:4.1.9"
+    "@vitest/spy": "npm:4.1.10"
+    "@vitest/utils": "npm:4.1.10"
     chai: "npm:^6.2.2"
     tinyrainbow: "npm:^3.1.0"
-  checksum: 10/aba1a06cd28199f9c861d97797b014c0584fa6f6197e78345da0db5f74914d47f18958bb848658e889ca44452aa61e07ae851c16ea7b2175afd50d649dd4ed8c
+  checksum: 10/487fcad404a68968a54ae5fb9d099f12170cd793420a04b34a5606516317090c50a8303ab687c70166ee181864e3e138941d4a96d0405434dcd37696b3105350
   languageName: node
   linkType: hard
 
-"@vitest/mocker@npm:4.1.9":
-  version: 4.1.9
-  resolution: "@vitest/mocker@npm:4.1.9"
+"@vitest/mocker@npm:4.1.10":
+  version: 4.1.10
+  resolution: "@vitest/mocker@npm:4.1.10"
   dependencies:
-    "@vitest/spy": "npm:4.1.9"
+    "@vitest/spy": "npm:4.1.10"
     estree-walker: "npm:^3.0.3"
     magic-string: "npm:^0.30.21"
   peerDependencies:
@@ -673,56 +673,56 @@ __metadata:
       optional: true
     vite:
       optional: true
-  checksum: 10/3e35ff3e2ecbdfbcae598e9c5c83978dd5f0cf3b16df37cf947c80faabce797ab275ca2075c3bb8ca85f595f3070267f93cb6798bbe415f1af2698f51833974c
+  checksum: 10/ae9645d1bcdad3ab7de7182feb4f1c9148a5ff97cef19581eec9257112aace94889eee9a1ad12e40ce59453ac05f52453b5fdb49ff76a31af8ccdbaaa4471ef3
   languageName: node
   linkType: hard
 
-"@vitest/pretty-format@npm:4.1.9":
-  version: 4.1.9
-  resolution: "@vitest/pretty-format@npm:4.1.9"
+"@vitest/pretty-format@npm:4.1.10":
+  version: 4.1.10
+  resolution: "@vitest/pretty-format@npm:4.1.10"
   dependencies:
     tinyrainbow: "npm:^3.1.0"
-  checksum: 10/52512b300c000594c54bebbbfe31fab39e416a35d3686e2c46bc8e48ef8476d32306605f7736139608c3962943e0d22790dc15a3e6b1ffa436143d31f743a7c8
+  checksum: 10/e4f6907143ab0e40dda29d70b17027586c92921d622091321f10512e660b3995dcee7aa56e17b750b72560f295e25f96035372348415f18ebfd39b66a55b4704
   languageName: node
   linkType: hard
 
-"@vitest/runner@npm:4.1.9":
-  version: 4.1.9
-  resolution: "@vitest/runner@npm:4.1.9"
+"@vitest/runner@npm:4.1.10":
+  version: 4.1.10
+  resolution: "@vitest/runner@npm:4.1.10"
   dependencies:
-    "@vitest/utils": "npm:4.1.9"
+    "@vitest/utils": "npm:4.1.10"
     pathe: "npm:^2.0.3"
-  checksum: 10/52e4e16e627faa62676f17683e570f505d58d2ce0ef421a3ae60e70c0ec5606d4af090fa6c7d5717d6e949f4401d6357b1f69cf06e52a5455a0ad9c9040268c0
+  checksum: 10/2c962cb13af0880990036808a35679b7ac6657c8f542490234c2faa6ffd2ab080ac6bf21b487c64d84aa635cfb37b49eb679098c2003a100dfc6c4d5e87bf055
   languageName: node
   linkType: hard
 
-"@vitest/snapshot@npm:4.1.9":
-  version: 4.1.9
-  resolution: "@vitest/snapshot@npm:4.1.9"
+"@vitest/snapshot@npm:4.1.10":
+  version: 4.1.10
+  resolution: "@vitest/snapshot@npm:4.1.10"
   dependencies:
-    "@vitest/pretty-format": "npm:4.1.9"
-    "@vitest/utils": "npm:4.1.9"
+    "@vitest/pretty-format": "npm:4.1.10"
+    "@vitest/utils": "npm:4.1.10"
     magic-string: "npm:^0.30.21"
     pathe: "npm:^2.0.3"
-  checksum: 10/c83349b1ad08d48284c1d3393168a7b7faffd24ace1ef337751a568dad322d83b0f9bc29378a4a60379cf2a13a268092b1d802936d6adb1ca28859f02dad8b87
+  checksum: 10/7940d83ffd2fbebf9a04ea31e196b7e8bf981093ec739950959fe8dd29caa33c80823780fb4b1063d9459c44a0a8d8b2748c00dfb6941becd7404e6d687eea01
   languageName: node
   linkType: hard
 
-"@vitest/spy@npm:4.1.9":
-  version: 4.1.9
-  resolution: "@vitest/spy@npm:4.1.9"
-  checksum: 10/8b8e42cc8e4b20d29bd8b312f34b9dbf2e20d4b4cdc24e3bcf6fd4d3b1f49e8924636d2730cca3946fbb45de893dfb531c77b832eb853c2624fdc2b800444e75
+"@vitest/spy@npm:4.1.10":
+  version: 4.1.10
+  resolution: "@vitest/spy@npm:4.1.10"
+  checksum: 10/7c1b79a95474338e0659f0f2e43be4df1ef7939ff5b37b044954e0287582947803bd417508f44a7f244809672309d9b3dd67660b704ec3fe7f323cc958ae47a3
   languageName: node
   linkType: hard
 
-"@vitest/utils@npm:4.1.9":
-  version: 4.1.9
-  resolution: "@vitest/utils@npm:4.1.9"
+"@vitest/utils@npm:4.1.10":
+  version: 4.1.10
+  resolution: "@vitest/utils@npm:4.1.10"
   dependencies:
-    "@vitest/pretty-format": "npm:4.1.9"
+    "@vitest/pretty-format": "npm:4.1.10"
     convert-source-map: "npm:^2.0.0"
     tinyrainbow: "npm:^3.1.0"
-  checksum: 10/78f5969fc09b1a95fda9dadd37e84a3a6ead35f66af15ad3b792eef35f80407047803e7afd53df86a8d794f59bf25ffbdc4146099140a3d5f9b51ea061bf2308
+  checksum: 10/95484aad55c7b00bbcd4963e27cbb86fe207620a6093973d68da9d0a06bad37c388d84c9ab43d5f35d88e46c8f376a5592d9c54c025c958361160f4802bb25ee
   languageName: node
   linkType: hard
 
@@ -1621,15 +1621,15 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "openzeppelin-compact@workspace:."
   dependencies:
-    "@biomejs/biome": "npm:^2.5.0"
+    "@biomejs/biome": "npm:^2.5.2"
     "@midnight-ntwrk/compact-runtime": "npm:0.16.0"
     "@midnight-ntwrk/ledger-v8": "npm:8.1.0"
     "@midnight-ntwrk/zswap": "npm:^4.0.0"
-    "@types/node": "npm:25.9.3"
+    "@types/node": "npm:26.1.0"
     ts-node: "npm:^10.9.2"
-    turbo: "npm:^2.9.18"
+    turbo: "npm:^2.10.0"
     typescript: "npm:^6.0.3"
-    vitest: "npm:^4.1.9"
+    vitest: "npm:^4.1.10"
   languageName: unknown
   linkType: soft
 
@@ -2096,16 +2096,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"turbo@npm:^2.9.18":
-  version: 2.9.18
-  resolution: "turbo@npm:2.9.18"
+"turbo@npm:^2.10.0":
+  version: 2.10.5
+  resolution: "turbo@npm:2.10.5"
   dependencies:
-    "@turbo/darwin-64": "npm:2.9.18"
-    "@turbo/darwin-arm64": "npm:2.9.18"
-    "@turbo/linux-64": "npm:2.9.18"
-    "@turbo/linux-arm64": "npm:2.9.18"
-    "@turbo/windows-64": "npm:2.9.18"
-    "@turbo/windows-arm64": "npm:2.9.18"
+    "@turbo/darwin-64": "npm:2.10.5"
+    "@turbo/darwin-arm64": "npm:2.10.5"
+    "@turbo/linux-64": "npm:2.10.5"
+    "@turbo/linux-arm64": "npm:2.10.5"
+    "@turbo/windows-64": "npm:2.10.5"
+    "@turbo/windows-arm64": "npm:2.10.5"
   dependenciesMeta:
     "@turbo/darwin-64":
       optional: true
@@ -2121,7 +2121,7 @@ __metadata:
       optional: true
   bin:
     turbo: bin/turbo
-  checksum: 10/2053d8a0608e9f49e310b6f144b1eb014987f4be9a1eed0293903be7d8e79a0cc32127d8bc930ff34bf956a8a2acb6869ecbf8a119ac30fc4c553ba645814769
+  checksum: 10/90480b731ce0394e77db1358b84c09dc074a5518d1816cd26dc2fda54a61e1cdbeee55caf7e2375c0fc5d62728b0f50a598fdee1e4b9a6d2c6f546fb7e1820d7
   languageName: node
   linkType: hard
 
@@ -2145,10 +2145,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici-types@npm:>=7.24.0 <7.24.7":
-  version: 7.24.6
-  resolution: "undici-types@npm:7.24.6"
-  checksum: 10/defc9538b952e3c15b8526596c591f7c1f0c7605ad27a2b7feddbea7ef2e3003f3eda2cdb051a3cb1a2185e3893100fd9cb925c799db99d48131ea63b5233d10
+"undici-types@npm:~8.3.0":
+  version: 8.3.0
+  resolution: "undici-types@npm:8.3.0"
+  checksum: 10/6681d2837ac75a75ac1cc46090aa2b8ddc7c6b8ecc295a6cdb06838752a730da3d8afeecf05e5ab7903160eafad3a8b6ffa1927e5ded260590f4d4fef18646d5
   languageName: node
   linkType: hard
 
@@ -2234,17 +2234,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vitest@npm:^4.1.9":
-  version: 4.1.9
-  resolution: "vitest@npm:4.1.9"
+"vitest@npm:^4.1.10":
+  version: 4.1.10
+  resolution: "vitest@npm:4.1.10"
   dependencies:
-    "@vitest/expect": "npm:4.1.9"
-    "@vitest/mocker": "npm:4.1.9"
-    "@vitest/pretty-format": "npm:4.1.9"
-    "@vitest/runner": "npm:4.1.9"
-    "@vitest/snapshot": "npm:4.1.9"
-    "@vitest/spy": "npm:4.1.9"
-    "@vitest/utils": "npm:4.1.9"
+    "@vitest/expect": "npm:4.1.10"
+    "@vitest/mocker": "npm:4.1.10"
+    "@vitest/pretty-format": "npm:4.1.10"
+    "@vitest/runner": "npm:4.1.10"
+    "@vitest/snapshot": "npm:4.1.10"
+    "@vitest/spy": "npm:4.1.10"
+    "@vitest/utils": "npm:4.1.10"
     es-module-lexer: "npm:^2.0.0"
     expect-type: "npm:^1.3.0"
     magic-string: "npm:^0.30.21"
@@ -2262,12 +2262,12 @@ __metadata:
     "@edge-runtime/vm": "*"
     "@opentelemetry/api": ^1.9.0
     "@types/node": ^20.0.0 || ^22.0.0 || >=24.0.0
-    "@vitest/browser-playwright": 4.1.9
-    "@vitest/browser-preview": 4.1.9
-    "@vitest/browser-webdriverio": 4.1.9
-    "@vitest/coverage-istanbul": 4.1.9
-    "@vitest/coverage-v8": 4.1.9
-    "@vitest/ui": 4.1.9
+    "@vitest/browser-playwright": 4.1.10
+    "@vitest/browser-preview": 4.1.10
+    "@vitest/browser-webdriverio": 4.1.10
+    "@vitest/coverage-istanbul": 4.1.10
+    "@vitest/coverage-v8": 4.1.10
+    "@vitest/ui": 4.1.10
     happy-dom: "*"
     jsdom: "*"
     vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -2298,7 +2298,7 @@ __metadata:
       optional: false
   bin:
     vitest: ./vitest.mjs
-  checksum: 10/64f9d1a0aae92c493c39822ecae8ec5b5a336fc27166f776d08c01ae79ef1ec5485a1826ef1451bb05df2edaae109894125c2ecceadaa56c17be2690f66f9758
+  checksum: 10/020843460fe696c23be2a363634dde4daf54625f1c443c24066ba3f87c478b0ccfdd5124343ba30eb092f54902ffea09f4bed0af4a16a9ee805e494ee2dce34e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Types of changes

_Maintenance: dependency updates. None of the categories below strictly apply — this is a grouped Dependabot bump._

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

Consolidates the 10 open Dependabot PRs into a single PR so they can be reviewed and merged together, then closes the individual ones. There is no grouping configured in `dependabot.yml`, and the `github-actions` ecosystem was sitting at its 5-open-PR cap, so this batches everything by hand.

### GitHub Actions

| Action | From | To |
| --- | --- | --- |
| `actions/checkout` | v6.0.3 | **v7.0.0** (major) |
| `step-security/harden-runner` | v2.19.4 | v2.20.0 |
| `github/codeql-action/{init,analyze,upload-sarif}` | v4.36.2 | v4.36.3 |
| `iarekylew00t/verified-bot-commit` | v2.3.2 | v2.3.3 |

Supersedes #622, #662, #663, #664, #649.

> `codeql-action/upload-sarif` (in `scorecard.yml`) had no open Dependabot PR — it shares the same release SHA as `init`/`analyze`, and CodeQL requires all sub-actions on one version. Bumped it here so the three stay consistent (otherwise `init`/`analyze` at v4.36.3 + `upload-sarif` at v4.36.2 would break scanning).

### npm (dev dependencies)

| Package | Range before | Range after | Lockfile resolves |
| --- | --- | --- | --- |
| `vitest` | ^4.1.9 | ^4.1.10 | 4.1.10 |
| `@vitest/coverage-v8` | ^4.1.9 | ^4.1.10 | 4.1.10 |
| `turbo` | ^2.9.18 | ^2.10.0 | 2.10.5 |
| `@types/node` | 25.9.3 | 26.1.0 | 26.1.0 (major) |
| `@biomejs/biome` | ^2.5.0 | ^2.5.2 | 2.5.4 |

Supersedes #660, #659, #627, #651, #652.

> `turbo` and `biome` resolve to the newest in-range patch (2.10.5, 2.5.4) rather than the exact versions the individual PRs pinned (2.10.0, 2.5.2) — that is what a fresh `yarn install` against these ranges produces. The lockfile was regenerated once for a single coherent result rather than cherry-picking conflicting per-PR lockfiles.

### Biome reformat

Biome 2.5.4 changed how `it.each(...)` call chains wrap. `biome format` reformatted 10 existing test files. Formatting-only, no logic changes. This is a required consequence of the biome bump, isolated so it is easy to skim.

`biome migrate` also bumped `biome.json`'s `$schema` URL (2.5.0 → 2.5.4) so editor validation tracks the installed version. No rule/config changes; clears the `Run biome migrate` notice from `biome ci`.

## PR Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md#your-first-code-contribution)
- [ ] I have added tests — N/A (no behavior change)
- [ ] I have added documentation — N/A
- [x] CI Workflows Are Passing

#### Further comments

Verified locally before pushing:
- `yarn fmt-and-lint:ci` (biome 2.5.4) — clean, exit 0.
- `yarn types` (tsc under `@types/node` 26 + full compile of 66 contracts, turbo 2.10.5) — 8/8 tasks, exit 0.
- Lockfile drift is limited to the bumped packages and their platform/sub-packages; no unrelated transitive churn.
