### PR TITLE
refactor(test-utils): remove createEitherTestUser

### DIFF
--- a/contracts/src/access/test/ZOwnablePK.test.ts
+++ b/contracts/src/access/test/ZOwnablePK.test.ts
@@ -152,7 +152,9 @@ describe('ZOwnablePK', () => {
     });
 
     it('should allow pure computeOwnerId', async () => {
-      const eitherOwner = utils.createEitherTestUser('OWNER');
+      const eitherOwner = utils.eitherUserFromCoinPublicKey(
+        utils.toHexPadded('OWNER'),
+      );
 
       const ownerId = await ownable._computeOwnerId(
         eitherOwner,
@@ -435,17 +437,23 @@ describe('ZOwnablePK', () => {
       const testCases = [
         ...Array.from({ length: 10 }, (_, i) => ({
           label: `User${i}`,
-          eitherOwner: utils.createEitherTestUser(`User${i}`),
+          eitherOwner: utils.eitherUserFromCoinPublicKey(
+            utils.toHexPadded(`User${i}`),
+          ),
           nonce: new Uint8Array(32).fill(i),
         })),
         {
           label: 'All-zero nonce',
-          eitherOwner: utils.createEitherTestUser('ZeroUser'),
+          eitherOwner: utils.eitherUserFromCoinPublicKey(
+            utils.toHexPadded('ZeroUser'),
+          ),
           nonce: new Uint8Array(32).fill(0),
         },
         {
           label: 'Max nonce',
-          eitherOwner: utils.createEitherTestUser('MaxUser'),
+          eitherOwner: utils.eitherUserFromCoinPublicKey(
+            utils.toHexPadded('MaxUser'),
+          ),
           nonce: new Uint8Array(32).fill(255),
         },
       ];

--- a/contracts/src/multisig/test/ForwarderPrivate.test.ts
+++ b/contracts/src/multisig/test/ForwarderPrivate.test.ts
@@ -32,7 +32,9 @@ import { MockForwarderPrivateSimulator } from './simulators/MockForwarderPrivate
 // stays a synthetic key: it only exercises the commitment gate, which rejects it
 // before any send.
 const PARENT_BYTES = shieldedTestKey().left.bytes;
-const WRONG_BYTES = utils.createEitherTestUser('WRONG').left.bytes;
+const WRONG_BYTES = utils.eitherUserFromCoinPublicKey(
+  utils.toHexPadded('WRONG'),
+).left.bytes;
 const OP_SECRET = new Uint8Array(32).fill(0xaa);
 const WRONG_OP_SECRET = new Uint8Array(32).fill(0xbb);
 const ZERO = new Uint8Array(32);
@@ -445,7 +447,9 @@ describe('ForwarderPrivate module', () => {
   describe.skipIf(isLiveBackend())(
     'drain — implementing contract routes the change onward (dry only)',
     () => {
-      const CHANGE_DEST = utils.createEitherTestUser('CHANGE_DEST');
+      const CHANGE_DEST = utils.eitherUserFromCoinPublicKey(
+        utils.toHexPadded('CHANGE_DEST'),
+      );
 
       it('should let the caller send the change to a different recipient using the drain result', async () => {
         const { mock, coin } = await freshMock(PARENT_BYTES);
@@ -511,7 +515,9 @@ describe('ForwarderPrivate module', () => {
           {
             is_left: true,
             left: key(PARENT_BYTES),
-            right: utils.createEitherTestUser('CHANGE_DEST').right,
+            right: utils.eitherUserFromCoinPublicKey(
+              utils.toHexPadded('CHANGE_DEST'),
+            ).right,
           },
         );
         expect(routed.change.is_some).toBe(false);

--- a/contracts/src/multisig/test/ShieldedTreasuryStateless.test.ts
+++ b/contracts/src/multisig/test/ShieldedTreasuryStateless.test.ts
@@ -203,7 +203,9 @@ describe('ShieldedTreasuryStateless', () => {
   describe.skipIf(isLiveBackend())(
     '_send — implementing contract routes the change onward (dry only)',
     () => {
-      const CHANGE_DEST = utils.createEitherTestUser('CHANGE_DEST');
+      const CHANGE_DEST = utils.eitherUserFromCoinPublicKey(
+        utils.toHexPadded('CHANGE_DEST'),
+      );
 
       it('should let the caller send the change to a different recipient using the send result', async () => {
         const snap = zswapSnapshot(treasury);

--- a/contracts/src/token/test/NativeShieldedToken.test.ts
+++ b/contracts/src/token/test/NativeShieldedToken.test.ts
@@ -16,9 +16,13 @@ const b32 = (label: string): Uint8Array => {
 };
 
 // Users / recipients
-const RECIPIENT = utils.createEitherTestUser('RECIPIENT');
+const RECIPIENT = utils.eitherUserFromCoinPublicKey(
+  utils.toHexPadded('RECIPIENT'),
+);
 const RECIPIENT_CONTRACT = utils.createEitherTestContractAddress('RECIPIENT_C');
-const REFUND_TO = utils.createEitherTestUser('REFUND_TO');
+const REFUND_TO = utils.eitherUserFromCoinPublicKey(
+  utils.toHexPadded('REFUND_TO'),
+);
 const { ZERO_KEY, ZERO_ADDRESS } = utils;
 
 // Metadata
@@ -40,8 +44,9 @@ let token: NativeShieldedTokenSimulator;
 // Resolved once in `beforeAll` after the first `create()`: on live the harness
 // then publishes MIDNIGHT_DEPLOYER_COIN_PK, so this is the deployer wallet's own
 // coin public key (an encryption key the node can resolve as a mint recipient /
-// refund target); on dry it is the synthetic `createEitherTestUser('RECIPIENT')`,
-// identical to the un-gated tests' `RECIPIENT`.
+// refund target); on dry it is the synthetic
+// `eitherUserFromCoinPublicKey(toHexPadded('RECIPIENT'))`, identical to the
+// un-gated tests' `RECIPIENT`.
 let Z_RECIPIENT: ReturnType<typeof shieldedTestKey>;
 
 // A backend-aware mint nonce, delegated to the shared coin builder: on live every

--- a/contracts/src/token/test/NativeShieldedTokenCore.test.ts
+++ b/contracts/src/token/test/NativeShieldedTokenCore.test.ts
@@ -14,8 +14,12 @@ const b32 = (label: string): Uint8Array => {
   return u;
 };
 
-const RECIPIENT = utils.createEitherTestUser('RECIPIENT');
-const REFUND_TO = utils.createEitherTestUser('REFUND_TO');
+const RECIPIENT = utils.eitherUserFromCoinPublicKey(
+  utils.toHexPadded('RECIPIENT'),
+);
+const REFUND_TO = utils.eitherUserFromCoinPublicKey(
+  utils.toHexPadded('REFUND_TO'),
+);
 const { ZERO_KEY, ZERO_ADDRESS } = utils;
 
 const NAME = 'Core Token';
@@ -35,8 +39,9 @@ let token: NativeShieldedTokenCoreSimulator;
 // Resolved once in `beforeAll` after the first `create()`: on live the harness
 // then publishes MIDNIGHT_DEPLOYER_COIN_PK, so this is the deployer wallet's own
 // coin public key (an encryption key the node can resolve as a mint recipient /
-// refund target); on dry it is the synthetic `createEitherTestUser('RECIPIENT')`,
-// identical to the un-gated tests' `RECIPIENT`.
+// refund target); on dry it is the synthetic
+// `eitherUserFromCoinPublicKey(toHexPadded('RECIPIENT'))`, identical to the
+// un-gated tests' `RECIPIENT`.
 let Z_RECIPIENT: ReturnType<typeof shieldedTestKey>;
 
 // A backend-aware mint nonce, delegated to the shared coin builder: on live every

--- a/contracts/src/token/test/NativeShieldedTokenFamily.test.ts
+++ b/contracts/src/token/test/NativeShieldedTokenFamily.test.ts
@@ -14,8 +14,12 @@ const b32 = (label: string): Uint8Array => {
   return u;
 };
 
-const RECIPIENT = utils.createEitherTestUser('RECIPIENT');
-const REFUND_TO = utils.createEitherTestUser('REFUND_TO');
+const RECIPIENT = utils.eitherUserFromCoinPublicKey(
+  utils.toHexPadded('RECIPIENT'),
+);
+const REFUND_TO = utils.eitherUserFromCoinPublicKey(
+  utils.toHexPadded('REFUND_TO'),
+);
 const { ZERO_KEY, ZERO_ADDRESS } = utils;
 
 const NAME = 'Family Token';
@@ -35,8 +39,9 @@ let token: NativeShieldedTokenFamilySimulator;
 // Resolved once in `beforeAll` after the first `create()`: on live the harness
 // then publishes MIDNIGHT_DEPLOYER_COIN_PK, so this is the deployer wallet's own
 // coin public key (an encryption key the node can resolve as a mint recipient /
-// refund target); on dry it is the synthetic `createEitherTestUser('RECIPIENT')`,
-// identical to the un-gated tests' `RECIPIENT`.
+// refund target); on dry it is the synthetic
+// `eitherUserFromCoinPublicKey(toHexPadded('RECIPIENT'))`, identical to the
+// un-gated tests' `RECIPIENT`.
 let Z_RECIPIENT: ReturnType<typeof shieldedTestKey>;
 
 // A backend-aware mint nonce, delegated to the shared coin builder: on live every

--- a/contracts/src/utils/test/utils.test.ts
+++ b/contracts/src/utils/test/utils.test.ts
@@ -7,8 +7,12 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import * as contractUtils from '#test-utils/fixtures/address.js';
 import { UtilsSimulator } from './simulators/UtilsSimulator.js';
 
-const Z_SOME_KEY = contractUtils.createEitherTestUser('SOME_KEY');
-const Z_OTHER_KEY = contractUtils.createEitherTestUser('OTHER_KEY');
+const Z_SOME_KEY = contractUtils.eitherUserFromCoinPublicKey(
+  contractUtils.toHexPadded('SOME_KEY'),
+);
+const Z_OTHER_KEY = contractUtils.eitherUserFromCoinPublicKey(
+  contractUtils.toHexPadded('OTHER_KEY'),
+);
 const SOME_CONTRACT =
   contractUtils.createEitherTestContractAddress('SOME_CONTRACT');
 const OTHER_CONTRACT =

--- a/contracts/test-utils/fixtures/address.ts
+++ b/contracts/test-utils/fixtures/address.ts
@@ -53,25 +53,11 @@ export const encodeToAddress = (str: string): EncodedContractAddress => {
 };
 
 /**
- * @description Generates an Either object for ZswapCoinPublicKey for testing.
- *              For use when an Either argument is expected.
- * @param str String to hexify and encode.
- * @returns Defined Either object for ZswapCoinPublicKey.
- */
-export const createEitherTestUser = (
-  str: string,
-): Either<ZswapCoinPublicKey, ContractAddress> => ({
-  is_left: true,
-  left: encodeToPK(str),
-  right: encodeToAddress(''),
-});
-
-/**
  * @description Builds an `Either<ZswapCoinPublicKey, ContractAddress>` bound to a
  * real coin public key (a 64-char hex string, e.g. a live wallet's
  * `getCoinPublicKey()`) instead of a hashed test string. The live backend uses
  * this so shielded sends target a recipient whose encryption key the node can
- * resolve (a fabricated key from `createEitherTestUser` has none).
+ * resolve (a fabricated key from a hashed test label has none).
  * @param coinPublicKey 64-char hex coin public key.
  * @returns Defined Either object for the given ZswapCoinPublicKey.
  */
@@ -103,7 +89,7 @@ const baseGeneratePubKeyPair = (
   ZswapCoinPublicKey | Either<ZswapCoinPublicKey, ContractAddress>,
 ] => {
   const pk = toHexPadded(str);
-  const zpk = asEither ? createEitherTestUser(str) : encodeToPK(str);
+  const zpk = asEither ? eitherUserFromCoinPublicKey(pk) : encodeToPK(str);
   return [pk, zpk];
 };
 

--- a/contracts/test-utils/fixtures/shieldedKey.ts
+++ b/contracts/test-utils/fixtures/shieldedKey.ts
@@ -4,10 +4,7 @@
 // `Either<ZswapCoinPublicKey, ContractAddress>`; its `.left` is the coin public
 // key (`EncodedCoinPublicKey`) that callers needing a bare key read directly.
 import type { EncodedRecipient } from '@midnight-ntwrk/compact-runtime';
-import {
-  createEitherTestUser,
-  eitherUserFromCoinPublicKey,
-} from './address.js';
+import { eitherUserFromCoinPublicKey, toHexPadded } from './address.js';
 
 /**
  * Backend-aware shielded coin-public-key fixture, so one spec runs unchanged on
@@ -34,8 +31,9 @@ const coinPkEnvVar = (alias: string): string =>
  * backends. On live it resolves to the named wallet's own coin public key
  * (published by the harness as `MIDNIGHT_<ALIAS>_COIN_PK`), so `.as(alias)`
  * submits from that wallet and the circuit's `ownPublicKey()` matches it; on dry
- * it is the deterministic synthetic key `createEitherTestUser(alias)`, exactly
- * what the dry backend resolves `.as(alias)` to. Callers needing a bare
+ * it is the deterministic synthetic key
+ * `eitherUserFromCoinPublicKey(toHexPadded(alias))`, exactly what the dry
+ * backend resolves `.as(alias)` to. Callers needing a bare
  * `EncodedCoinPublicKey` (not an `Either`) read `.left`.
  *
  * The `deployer` default suits a send recipient / drain parent: on live that key
@@ -49,5 +47,7 @@ const coinPkEnvVar = (alias: string): string =>
  */
 export const shieldedTestKey = (alias = 'deployer'): EncodedRecipient => {
   const pk = process.env[coinPkEnvVar(alias)];
-  return pk ? eitherUserFromCoinPublicKey(pk) : createEitherTestUser(alias);
+  return pk
+    ? eitherUserFromCoinPublicKey(pk)
+    : eitherUserFromCoinPublicKey(toHexPadded(alias));
 };

--- a/contracts/test-utils/fixtures/test/address.test.ts
+++ b/contracts/test-utils/fixtures/test/address.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from 'vitest';
 import {
   createEitherTestContractAddress,
   createEitherTestUnshieldedContract,
-  createEitherTestUser,
   createEitherTestUserAddress,
   eitherUserFromCoinPublicKey,
   encodeToAddress,
@@ -109,16 +108,6 @@ describe('address fixtures', () => {
       expect(eitherUserFromCoinPublicKey(pk)).toStrictEqual({
         is_left: true,
         left: { bytes: new Uint8Array(32).fill(0xab) },
-        right: { bytes: zeros() },
-      });
-    });
-  });
-
-  describe('createEitherTestUser', () => {
-    it('should build a left Either bound to the hashed public key', () => {
-      expect(createEitherTestUser('A')).toStrictEqual({
-        is_left: true,
-        left: { bytes: lastByte(A) },
         right: { bytes: zeros() },
       });
     });

--- a/contracts/test-utils/fixtures/test/shieldedKey.test.ts
+++ b/contracts/test-utils/fixtures/test/shieldedKey.test.ts
@@ -1,8 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import {
-  createEitherTestUser,
-  eitherUserFromCoinPublicKey,
-} from '../address.js';
+import { eitherUserFromCoinPublicKey, toHexPadded } from '../address.js';
 import { shieldedTestKey } from '../shieldedKey.js';
 
 /**
@@ -24,7 +21,9 @@ describe('shieldedTestKey', () => {
   describe('deployer (default)', () => {
     it('should build a synthetic deployer key when none is published', () => {
       vi.stubEnv('MIDNIGHT_DEPLOYER_COIN_PK', undefined);
-      expect(shieldedTestKey()).toStrictEqual(createEitherTestUser('deployer'));
+      expect(shieldedTestKey()).toStrictEqual(
+        eitherUserFromCoinPublicKey(toHexPadded('deployer')),
+      );
     });
 
     it('should bind to the published deployer coin public key', () => {
@@ -37,7 +36,7 @@ describe('shieldedTestKey', () => {
     it("should build a synthetic key from the alias when the signer's key is unpublished", () => {
       vi.stubEnv('MIDNIGHT_SIGNER1_COIN_PK', undefined);
       expect(shieldedTestKey('SIGNER1')).toStrictEqual(
-        createEitherTestUser('SIGNER1'),
+        eitherUserFromCoinPublicKey(toHexPadded('SIGNER1')),
       );
     });
 


### PR DESCRIPTION
## Types of changes

What types of changes does your code introduce to OpenZeppelin Midnight Contracts?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

<!-- test-utils refactor; none of the four categories fit exactly. -->

Split out of #673 per review ([comment](https://github.com/OpenZeppelin/compact-contracts/pull/673#discussion_r3582558391)): removes the duplicate `createEitherTestUser` test helper in favor of `eitherUserFromCoinPublicKey`, so there is one clear way to build an `Either<ZswapCoinPublicKey, ContractAddress>` fixture.

The two were byte-identical — `createEitherTestUser(str)` produced `encodeCoinPublicKey(toHexPadded(str))`, exactly what `eitherUserFromCoinPublicKey(toHexPadded(str))` produces — so every call site is rewritten to the latter and **test values do not change**.

**No longer stacked.** #673 introduced `eitherUserFromCoinPublicKey` and has since merged, so this branch is a single commit containing only the helper consolidation.

Rebased onto current `main`, which since collapsed the three shielded-key fixtures into one `shieldedTestKey` (#694). Its dry arm now builds the synthetic key inline, so the fixture keeps exactly the same keys on both backends.

Scope note: the `archive` package keeps its own separate `createEitherTestUser` (a local copy in `src/archive/test/utils/address.ts`) — out of scope for this review comment. `createEitherTestUserAddress` is a different helper and is untouched.

## PR Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md#your-first-code-contribution)
- [x] I have added tests that prove my fix is effective or that my feature works. Existing suites cover the swap; `eitherUserFromCoinPublicKey` already has its own fixture test.
- [x] I have added documentation for new methods or changes to existing method behavior.
- [ ] CI Workflows Are Passing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test fixtures to use realistic, padded coin public keys for owner, recipient, refund, signer, and change addresses.
  * Improved coverage consistency across ownership, multisig, treasury, token, and utility scenarios.
  * Removed obsolete test coverage for the retired synthetic address helper.
* **Chores**
  * Standardized shielded key fixture generation while preserving live environment-key behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
