### PR TITLE
refactor(token): rename NST supply to PublicSupply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Rename the contract-compilation scripts and Turbo tasks from `compact` / `compact:*` to `compile` / `compile:*`, and the Biome scripts from `fmt-and-lint` / `fmt-and-lint:*` to `lint` / `lint:*`. (#680)
+- Rename the native shielded token supply extensions to `NativeShieldedTokenPublicSupply` / `NativeShieldedTokenFamilyPublicSupply` (and the shared `NativeShieldedTokenPublicSupplyCore`), making explicit that they track supply on-chain and matching the `ConfidentialFungibleTokenPublicSupply` naming. (#TBD)
 
 ## 0.3.0-alpha (2026-06-30)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Rename the contract-compilation scripts and Turbo tasks from `compact` / `compact:*` to `compile` / `compile:*`, and the Biome scripts from `fmt-and-lint` / `fmt-and-lint:*` to `lint` / `lint:*`. (#680)
-- Rename the native shielded token supply extensions to `NativeShieldedTokenPublicSupply` / `NativeShieldedTokenFamilyPublicSupply` (and the shared `NativeShieldedTokenPublicSupplyCore`), making explicit that they track supply on-chain and matching the `ConfidentialFungibleTokenPublicSupply` naming. (#TBD)
+- Rename the native shielded token supply extensions to `NativeShieldedTokenPublicSupply` / `NativeShieldedTokenFamilyPublicSupply` (and the shared `NativeShieldedTokenPublicSupplyCore`), making explicit that they track supply on-chain and matching the `ConfidentialFungibleTokenPublicSupply` naming. (#710)
 
 ## 0.3.0-alpha (2026-06-30)
 

--- a/contracts/src/token/NativeShieldedToken.compact
+++ b/contracts/src/token/NativeShieldedToken.compact
@@ -45,7 +45,7 @@ pragma language_version >= 0.23.0;
  * recipient-public.
  *
  * @notice Supply accounting is opt-in: this module tracks NO supply totals.
- * Compose the optional `NativeShieldedTokenSupply` extension only if you need an
+ * Compose the optional `NativeShieldedTokenPublicSupply` extension only if you need an
  * on-chain `totalSupply()`; see it for the privacy trade-off it introduces (it
  * makes contract-mediated burn amounts public).
  *

--- a/contracts/src/token/NativeShieldedTokenFamily.compact
+++ b/contracts/src/token/NativeShieldedTokenFamily.compact
@@ -53,7 +53,7 @@ pragma language_version >= 0.23.0;
  * output, at the cost of making those mints recipient-public.
  *
  * @notice Supply accounting is opt-in: this module tracks NO supply totals.
- * Compose the optional `NativeShieldedTokenFamilySupply` extension only if you
+ * Compose the optional `NativeShieldedTokenFamilyPublicSupply` extension only if you
  * need an on-chain `totalSupply(domain)`; see it for the privacy trade-off it
  * introduces (it makes contract-mediated burn amounts public).
  *

--- a/contracts/src/token/extensions/NativeShieldedTokenFamilyPublicSupply.compact
+++ b/contracts/src/token/extensions/NativeShieldedTokenFamilyPublicSupply.compact
@@ -1,16 +1,16 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Compact Contracts v0.2.0 (token/extensions/NativeShieldedTokenFamilySupply.compact)
+// OpenZeppelin Compact Contracts v0.2.0 (token/extensions/NativeShieldedTokenFamilyPublicSupply.compact)
 
 pragma language_version >= 0.23.0;
 
 /**
- * @module NativeShieldedTokenFamilySupply
+ * @module NativeShieldedTokenFamilyPublicSupply
  * @description Optional standalone extension that adds per-domain on-chain
  * supply accounting to a `NativeShieldedTokenFamily`. It exposes `_addMinted` /
  * `_addBurned` building blocks plus the `totalMinted` / `totalBurned` /
  * `totalSupply` getters, each keyed by domain. It imports no token module.
  *
- * It is a thin wrapper over `NativeShieldedTokenSupplyCore`, forwarding the
+ * It is a thin wrapper over `NativeShieldedTokenPublicSupplyCore`, forwarding the
  * caller's per-call `domain`, so the accounting logic and guarantees live in
  * the shared core.
  *
@@ -51,25 +51,25 @@ pragma language_version >= 0.23.0;
  *
  * @dev Mint amounts are already public via the protocol's `shieldedMints`
  * effect, so `_addMinted` adds accounting, not disclosure. See
- * `NativeShieldedTokenSupplyCore` for the exact / lower-bound / upper-bound
+ * `NativeShieldedTokenPublicSupplyCore` for the exact / lower-bound / upper-bound
  * guarantees, the per-domain `burned <= minted` invariant, and the mint-side
  * drift caveat.
  *
  * @warning Pair every mint with `_addMinted` and every burn with `_addBurned` on
  * every path, under the matching domain; mis-wiring is a security-critical,
  * undetectable error (e.g. an undercounted mint makes `_addBurned` reject
- * legitimate burns). See `NativeShieldedTokenSupplyCore`.
+ * legitimate burns). See `NativeShieldedTokenPublicSupplyCore`.
  */
-module NativeShieldedTokenFamilySupply {
+module NativeShieldedTokenFamilyPublicSupply {
   import CompactStandardLibrary;
-  import "./NativeShieldedTokenSupplyCore" prefix Core_;
+  import "./NativeShieldedTokenPublicSupplyCore" prefix Core_;
 
   // Circuits use the `Core_` prefix above. The named import/re-export below is
   // only for the core supply ledger keys, so the implementing contract's ledger
   // keys read as `_totalMinted` / `_totalBurned` rather than
-  // `NativeShieldedTokenSupplyCore__totalMinted`. The circuit names are
+  // `NativeShieldedTokenPublicSupplyCore__totalMinted`. The circuit names are
   // intentionally NOT imported unprefixed, to avoid potential clashes.
-  import { _totalMinted, _totalBurned } from "./NativeShieldedTokenSupplyCore";
+  import { _totalMinted, _totalBurned } from "./NativeShieldedTokenPublicSupplyCore";
   export { _totalMinted, _totalBurned };
 
   /**

--- a/contracts/src/token/extensions/NativeShieldedTokenPublicSupply.compact
+++ b/contracts/src/token/extensions/NativeShieldedTokenPublicSupply.compact
@@ -1,16 +1,16 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Compact Contracts v0.2.0 (token/extensions/NativeShieldedTokenSupply.compact)
+// OpenZeppelin Compact Contracts v0.2.0 (token/extensions/NativeShieldedTokenPublicSupply.compact)
 
 pragma language_version >= 0.23.0;
 
 /**
- * @module NativeShieldedTokenSupply
+ * @module NativeShieldedTokenPublicSupply
  * @description Optional standalone extension that adds on-chain supply
  * accounting to a `NativeShieldedToken`. It exposes scalar `_addMinted` /
  * `_addBurned` building blocks plus the `totalMinted` / `totalBurned` /
  * `totalSupply` getters. It imports no token module.
  *
- * It is a thin wrapper over `NativeShieldedTokenSupplyCore`, forwarding a
+ * It is a thin wrapper over `NativeShieldedTokenPublicSupplyCore`, forwarding a
  * single fixed key (the paired contract has exactly one token type), so the
  * accounting logic and guarantees live in the shared core.
  *
@@ -48,24 +48,24 @@ pragma language_version >= 0.23.0;
  *
  * @dev Mint amounts are already public via the protocol's `shieldedMints`
  * effect, so `_addMinted` adds accounting, not disclosure. See
- * `NativeShieldedTokenSupplyCore` for the exact / lower-bound / upper-bound
+ * `NativeShieldedTokenPublicSupplyCore` for the exact / lower-bound / upper-bound
  * guarantees, the `burned <= minted` invariant, and the mint-side drift caveat.
  *
  * @warning Pair every mint with `_addMinted` and every burn with `_addBurned` on
  * every path; mis-wiring is a security-critical, undetectable error (e.g. an
  * undercounted mint makes `_addBurned` reject legitimate burns). See
- * `NativeShieldedTokenSupplyCore`.
+ * `NativeShieldedTokenPublicSupplyCore`.
  */
-module NativeShieldedTokenSupply {
+module NativeShieldedTokenPublicSupply {
   import CompactStandardLibrary;
-  import "./NativeShieldedTokenSupplyCore" prefix Core_;
+  import "./NativeShieldedTokenPublicSupplyCore" prefix Core_;
 
   // Circuits use the `Core_` prefix above. The named import/re-export below is
   // only for the core supply ledger keys, so the implementing contract's ledger
   // keys read as `_totalMinted` / `_totalBurned` rather than
-  // `NativeShieldedTokenSupplyCore__totalMinted`. The circuit names are
+  // `NativeShieldedTokenPublicSupplyCore__totalMinted`. The circuit names are
   // intentionally NOT imported unprefixed, to avoid potential clashes.
-  import { _totalMinted, _totalBurned } from "./NativeShieldedTokenSupplyCore";
+  import { _totalMinted, _totalBurned } from "./NativeShieldedTokenPublicSupplyCore";
   export { _totalMinted, _totalBurned };
 
   /**

--- a/contracts/src/token/extensions/NativeShieldedTokenPublicSupplyCore.compact
+++ b/contracts/src/token/extensions/NativeShieldedTokenPublicSupplyCore.compact
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Compact Contracts v0.2.0 (token/extensions/NativeShieldedTokenSupplyCore.compact)
+// OpenZeppelin Compact Contracts v0.2.0 (token/extensions/NativeShieldedTokenPublicSupplyCore.compact)
 
 pragma language_version >= 0.23.0;
 
 /**
- * @module NativeShieldedTokenSupplyCore
+ * @module NativeShieldedTokenPublicSupplyCore
  * @description Shared, domain-keyed core of the optional supply-accounting
  * extension. It owns the per-domain minted/burned maps and exposes the
  * `_addMinted` / `_addBurned` building blocks plus the `totalMinted` /
@@ -13,12 +13,12 @@ pragma language_version >= 0.23.0;
  * This module is NOT meant to be composed directly. It is the de-duplicated
  * base behind the two user-facing flavors:
  *
- * - `NativeShieldedTokenSupply` — pairs with `NativeShieldedToken`; forwards a
+ * - `NativeShieldedTokenPublicSupply` — pairs with `NativeShieldedToken`; forwards a
  *   single fixed key (the contract has one token type).
- * - `NativeShieldedTokenFamilySupply` — pairs with `NativeShieldedTokenFamily`;
+ * - `NativeShieldedTokenFamilyPublicSupply` — pairs with `NativeShieldedTokenFamily`;
  *   forwards the caller's per-call `domain`.
  *
- * @dev Assertion messages use the generic `NativeShieldedTokenSupply:` prefix
+ * @dev Assertion messages use the generic `NativeShieldedTokenPublicSupply:` prefix
  * so they read sensibly from either flavor. There is no initialization: an
  * absent domain key reads as 0, and the getters do not gate on the paired token
  * module's init flag (a counter reading 0 before init is correct), so init
@@ -51,7 +51,7 @@ pragma language_version >= 0.23.0;
  *   overstates circulating supply.
  * Call the matching accounting block on every mint and burn path, same domain.
  */
-module NativeShieldedTokenSupplyCore {
+module NativeShieldedTokenPublicSupplyCore {
   import CompactStandardLibrary;
   import "../../utils/Utils" prefix Utils_;
 
@@ -79,7 +79,7 @@ module NativeShieldedTokenSupplyCore {
    */
   export circuit _addMinted(domain: Bytes<32>, amount: Uint<64>): [] {
     const current = totalMinted(domain);
-    assert(Utils_UINT128_MAX() - current >= amount, "NativeShieldedTokenSupply: arithmetic overflow");
+    assert(Utils_UINT128_MAX() - current >= amount, "NativeShieldedTokenPublicSupply: arithmetic overflow");
     _totalMinted.insert(disclose(domain), disclose((current + amount) as Uint<128>));
   }
 
@@ -103,8 +103,8 @@ module NativeShieldedTokenSupplyCore {
     // First guards the subtraction below from underflowing on an already-corrupt
     // state (stored burned past minted); the second is the reachable per-call
     // check that this burn does not push the domain past its minted total.
-    assert(minted >= current, "NativeShieldedTokenSupply: burned total exceeds minted");
-    assert(minted - current >= amount, "NativeShieldedTokenSupply: burn exceeds available supply");
+    assert(minted >= current, "NativeShieldedTokenPublicSupply: burned total exceeds minted");
+    assert(minted - current >= amount, "NativeShieldedTokenPublicSupply: burn exceeds available supply");
     _totalBurned.insert(disclose(domain), disclose((current + amount) as Uint<128>));
   }
 

--- a/contracts/src/token/test/extensions/NativeShieldedTokenFamilyPublicSupply.test.ts
+++ b/contracts/src/token/test/extensions/NativeShieldedTokenFamilyPublicSupply.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it } from 'vitest';
-import { NativeShieldedTokenFamilySupplySimulator } from '../simulators/NativeShieldedTokenFamilySupplySimulator.js';
+import { NativeShieldedTokenFamilyPublicSupplySimulator } from '../simulators/NativeShieldedTokenFamilyPublicSupplySimulator.js';
 
 const b32 = (label: string): Uint8Array => {
   const u = new Uint8Array(32);
@@ -13,11 +13,11 @@ const DOMAIN_B = b32('domain-B');
 // The per-domain supply extension imports no token module, so it is unit-tested
 // by driving its accounting blocks and getters directly.
 
-let supply: NativeShieldedTokenFamilySupplySimulator;
+let supply: NativeShieldedTokenFamilyPublicSupplySimulator;
 
-describe('NativeShieldedTokenFamilySupply (extension)', () => {
+describe('NativeShieldedTokenFamilyPublicSupply (extension)', () => {
   beforeEach(async () => {
-    supply = await NativeShieldedTokenFamilySupplySimulator.create();
+    supply = await NativeShieldedTokenFamilyPublicSupplySimulator.create();
   });
 
   describe('initial state', () => {
@@ -65,14 +65,14 @@ describe('NativeShieldedTokenFamilySupply (extension)', () => {
       await supply._addMinted(DOMAIN_A, 1_000n);
       // DOMAIN_B was never minted; burning under it must revert.
       await expect(supply._addBurned(DOMAIN_B, 1n)).rejects.toThrow(
-        'NativeShieldedTokenSupply: burn exceeds available supply',
+        'NativeShieldedTokenPublicSupply: burn exceeds available supply',
       );
     });
 
     it('should revert a burn that exceeds the domain minted total', async () => {
       await supply._addMinted(DOMAIN_A, 1_000n);
       await expect(supply._addBurned(DOMAIN_A, 1_001n)).rejects.toThrow(
-        'NativeShieldedTokenSupply: burn exceeds available supply',
+        'NativeShieldedTokenPublicSupply: burn exceeds available supply',
       );
     });
 
@@ -82,7 +82,7 @@ describe('NativeShieldedTokenFamilySupply (extension)', () => {
       // available-supply check) is what fires.
       await supply.unsafeSetBurned(DOMAIN_A, 1_500n);
       await expect(supply._addBurned(DOMAIN_A, 1n)).rejects.toThrow(
-        'NativeShieldedTokenSupply: burned total exceeds minted',
+        'NativeShieldedTokenPublicSupply: burned total exceeds minted',
       );
     });
   });

--- a/contracts/src/token/test/extensions/NativeShieldedTokenPublicSupply.property.test.ts
+++ b/contracts/src/token/test/extensions/NativeShieldedTokenPublicSupply.property.test.ts
@@ -1,12 +1,12 @@
 import fc from 'fast-check';
 import { describe, expect, it } from 'vitest';
-import { NativeShieldedTokenFamilySupplySimulator } from '../simulators/NativeShieldedTokenFamilySupplySimulator.js';
-import { NativeShieldedTokenSupplySimulator } from '../simulators/NativeShieldedTokenSupplySimulator.js';
+import { NativeShieldedTokenFamilyPublicSupplySimulator } from '../simulators/NativeShieldedTokenFamilyPublicSupplySimulator.js';
+import { NativeShieldedTokenPublicSupplySimulator } from '../simulators/NativeShieldedTokenPublicSupplySimulator.js';
 
 // Property-based invariant fuzzing over random mint/burn op sequences for the
 // supply extension. Both flavors are covered in one file: the scalar
-// `NativeShieldedTokenSupply` and the per-domain `NativeShieldedTokenFamilySupply`.
-// Both delegate to the shared `NativeShieldedTokenSupplyCore`, so the core
+// `NativeShieldedTokenPublicSupply` and the per-domain `NativeShieldedTokenFamilyPublicSupply`.
+// Both delegate to the shared `NativeShieldedTokenPublicSupplyCore`, so the core
 // accounting is exercised transitively through each.
 //
 // Conservation (burned <= minted) is respected by construction: each op burns
@@ -24,13 +24,14 @@ const opArb = fc.record({
   burnPct: fc.integer({ min: 0, max: 100 }),
 });
 
-describe('NativeShieldedTokenSupply(Core/Family) — property: supply invariants under random op sequences', () => {
+describe('NativeShieldedTokenPublicSupply(Core/Family) — property: supply invariants under random op sequences', () => {
   it('should keep totalMinted exact, totalSupply = minted - burned, and burned <= minted (scalar)', async () => {
     await fc.assert(
       fc.asyncProperty(
         fc.array(opArb, { minLength: 1, maxLength: 6 }),
         async (ops) => {
-          const supply = await NativeShieldedTokenSupplySimulator.create();
+          const supply =
+            await NativeShieldedTokenPublicSupplySimulator.create();
           let expectedMinted = 0n;
           let expectedBurned = 0n;
 
@@ -71,7 +72,7 @@ describe('NativeShieldedTokenSupply(Core/Family) — property: supply invariants
         ),
         async (ops) => {
           const supply =
-            await NativeShieldedTokenFamilySupplySimulator.create();
+            await NativeShieldedTokenFamilyPublicSupplySimulator.create();
           const expectedMinted = DOMAINS.map(() => 0n);
           const expectedBurned = DOMAINS.map(() => 0n);
 

--- a/contracts/src/token/test/extensions/NativeShieldedTokenPublicSupply.test.ts
+++ b/contracts/src/token/test/extensions/NativeShieldedTokenPublicSupply.test.ts
@@ -1,14 +1,14 @@
 import { beforeEach, describe, expect, it } from 'vitest';
-import { NativeShieldedTokenSupplySimulator } from '../simulators/NativeShieldedTokenSupplySimulator.js';
+import { NativeShieldedTokenPublicSupplySimulator } from '../simulators/NativeShieldedTokenPublicSupplySimulator.js';
 
 // The supply extension imports no token module, so it is unit-tested by driving
 // its accounting blocks (`_addMinted` / `_addBurned`) and getters directly.
 
-let supply: NativeShieldedTokenSupplySimulator;
+let supply: NativeShieldedTokenPublicSupplySimulator;
 
-describe('NativeShieldedTokenSupply (extension)', () => {
+describe('NativeShieldedTokenPublicSupply (extension)', () => {
   beforeEach(async () => {
-    supply = await NativeShieldedTokenSupplySimulator.create();
+    supply = await NativeShieldedTokenPublicSupplySimulator.create();
   });
 
   describe('initial state', () => {
@@ -37,14 +37,14 @@ describe('NativeShieldedTokenSupply (extension)', () => {
 
     it('should revert an unpaired burn (burned exceeds minted from zero)', async () => {
       await expect(supply._addBurned(1n)).rejects.toThrow(
-        'NativeShieldedTokenSupply: burn exceeds available supply',
+        'NativeShieldedTokenPublicSupply: burn exceeds available supply',
       );
     });
 
     it('should revert a burn that exceeds the minted total', async () => {
       await supply._addMinted(1_000n);
       await expect(supply._addBurned(1_001n)).rejects.toThrow(
-        'NativeShieldedTokenSupply: burn exceeds available supply',
+        'NativeShieldedTokenPublicSupply: burn exceeds available supply',
       );
     });
 
@@ -52,7 +52,7 @@ describe('NativeShieldedTokenSupply (extension)', () => {
       await supply._addMinted(1_000n);
       await supply._addBurned(600n);
       await expect(supply._addBurned(600n)).rejects.toThrow(
-        'NativeShieldedTokenSupply: burn exceeds available supply',
+        'NativeShieldedTokenPublicSupply: burn exceeds available supply',
       );
       // The rejected burn left the total unchanged.
       expect(await supply.totalBurned()).toBe(600n);
@@ -64,7 +64,7 @@ describe('NativeShieldedTokenSupply (extension)', () => {
       // first guard (not the available-supply check) is what fires.
       await supply.unsafeSetBurned(1_500n);
       await expect(supply._addBurned(1n)).rejects.toThrow(
-        'NativeShieldedTokenSupply: burned total exceeds minted',
+        'NativeShieldedTokenPublicSupply: burned total exceeds minted',
       );
     });
   });

--- a/contracts/src/token/test/mocks/MockNativeShieldedTokenFamilyPublicSupply.compact
+++ b/contracts/src/token/test/mocks/MockNativeShieldedTokenFamilyPublicSupply.compact
@@ -9,37 +9,37 @@ pragma language_version >= 0.23.0;
 
 import CompactStandardLibrary;
 
-import "../../extensions/NativeShieldedTokenFamilySupply" prefix NativeShieldedTokenFamilySupply_;
+import "../../extensions/NativeShieldedTokenFamilyPublicSupply" prefix NativeShieldedTokenFamilyPublicSupply_;
 
 export { ZswapCoinPublicKey, ContractAddress, Either, Maybe };
 
 // Surface the core supply ledger state unprefixed so tests can read it via
 // `getPublicState()` and assert the per-domain accounting getters return it verbatim.
-import { _totalMinted, _totalBurned } from "../../extensions/NativeShieldedTokenFamilySupply";
+import { _totalMinted, _totalBurned } from "../../extensions/NativeShieldedTokenFamilyPublicSupply";
 export { _totalMinted, _totalBurned };
 
-// Unit mock for the NativeShieldedTokenFamilySupply extension in isolation. The
+// Unit mock for the NativeShieldedTokenFamilyPublicSupply extension in isolation. The
 // extension imports no token module, so the per-domain accounting blocks and
 // getters are driven directly here. The extension needs no initialization.
 
 export circuit _addMinted(domain: Bytes<32>, amount: Uint<64>): [] {
-  NativeShieldedTokenFamilySupply__addMinted(domain, amount);
+  NativeShieldedTokenFamilyPublicSupply__addMinted(domain, amount);
 }
 
 export circuit _addBurned(domain: Bytes<32>, amount: Uint<128>): [] {
-  NativeShieldedTokenFamilySupply__addBurned(domain, amount);
+  NativeShieldedTokenFamilyPublicSupply__addBurned(domain, amount);
 }
 
 export circuit totalMinted(domain: Bytes<32>): Uint<128> {
-  return NativeShieldedTokenFamilySupply_totalMinted(domain);
+  return NativeShieldedTokenFamilyPublicSupply_totalMinted(domain);
 }
 
 export circuit totalBurned(domain: Bytes<32>): Uint<128> {
-  return NativeShieldedTokenFamilySupply_totalBurned(domain);
+  return NativeShieldedTokenFamilyPublicSupply_totalBurned(domain);
 }
 
 export circuit totalSupply(domain: Bytes<32>): Uint<128> {
-  return NativeShieldedTokenFamilySupply_totalSupply(domain);
+  return NativeShieldedTokenFamilyPublicSupply_totalSupply(domain);
 }
 
 // Test-only: force `_totalBurned(domain)` past `_totalMinted(domain)` to reach

--- a/contracts/src/token/test/mocks/MockNativeShieldedTokenPublicSupply.compact
+++ b/contracts/src/token/test/mocks/MockNativeShieldedTokenPublicSupply.compact
@@ -9,37 +9,37 @@ pragma language_version >= 0.23.0;
 
 import CompactStandardLibrary;
 
-import "../../extensions/NativeShieldedTokenSupply" prefix NativeShieldedTokenSupply_;
+import "../../extensions/NativeShieldedTokenPublicSupply" prefix NativeShieldedTokenPublicSupply_;
 
 export { ZswapCoinPublicKey, ContractAddress, Either, Maybe };
 
 // Surface the core supply ledger state unprefixed so tests can read it via
 // `getPublicState()` and assert the accounting getters return it verbatim.
-import { _totalMinted, _totalBurned } from "../../extensions/NativeShieldedTokenSupply";
+import { _totalMinted, _totalBurned } from "../../extensions/NativeShieldedTokenPublicSupply";
 export { _totalMinted, _totalBurned };
 
-// Unit mock for the NativeShieldedTokenSupply extension in isolation. The
+// Unit mock for the NativeShieldedTokenPublicSupply extension in isolation. The
 // extension imports no token module, so the accounting blocks and getters are
 // driven directly here. The extension needs no initialization.
 
 export circuit _addMinted(amount: Uint<64>): [] {
-  NativeShieldedTokenSupply__addMinted(amount);
+  NativeShieldedTokenPublicSupply__addMinted(amount);
 }
 
 export circuit _addBurned(amount: Uint<128>): [] {
-  NativeShieldedTokenSupply__addBurned(amount);
+  NativeShieldedTokenPublicSupply__addBurned(amount);
 }
 
 export circuit totalMinted(): Uint<128> {
-  return NativeShieldedTokenSupply_totalMinted();
+  return NativeShieldedTokenPublicSupply_totalMinted();
 }
 
 export circuit totalBurned(): Uint<128> {
-  return NativeShieldedTokenSupply_totalBurned();
+  return NativeShieldedTokenPublicSupply_totalBurned();
 }
 
 export circuit totalSupply(): Uint<128> {
-  return NativeShieldedTokenSupply_totalSupply();
+  return NativeShieldedTokenPublicSupply_totalSupply();
 }
 
 // Test-only: force `_totalBurned` past `_totalMinted` to reach the otherwise

--- a/contracts/src/token/test/simulators/NativeShieldedTokenFamilyPublicSupplySimulator.ts
+++ b/contracts/src/token/test/simulators/NativeShieldedTokenFamilyPublicSupplySimulator.ts
@@ -4,57 +4,60 @@ import {
 } from '@openzeppelin/compact-simulator';
 import {
   ledger,
-  Contract as MockNativeShieldedTokenFamilySupply,
-} from '../../../../artifacts/MockNativeShieldedTokenFamilySupply/contract/index.js';
+  Contract as MockNativeShieldedTokenFamilyPublicSupply,
+} from '../../../../artifacts/MockNativeShieldedTokenFamilyPublicSupply/contract/index.js';
 
 /**
  * The family supply extension declares no witnesses, so the private state is
  * empty and the witnesses object is `{}`.
  */
-export type NativeShieldedTokenFamilySupplyPrivateState = Record<string, never>;
-export const NativeShieldedTokenFamilySupplyPrivateState: NativeShieldedTokenFamilySupplyPrivateState =
+export type NativeShieldedTokenFamilyPublicSupplyPrivateState = Record<
+  string,
+  never
+>;
+export const NativeShieldedTokenFamilyPublicSupplyPrivateState: NativeShieldedTokenFamilyPublicSupplyPrivateState =
   {};
-export const NativeShieldedTokenFamilySupplyWitnesses = () => ({});
+export const NativeShieldedTokenFamilyPublicSupplyWitnesses = () => ({});
 
 /** The extension needs no initialization, so the constructor is nullary. */
-type NativeShieldedTokenFamilySupplyArgs = readonly [];
+type NativeShieldedTokenFamilyPublicSupplyArgs = readonly [];
 
-const NativeShieldedTokenFamilySupplySimulatorBase = createSimulator<
-  NativeShieldedTokenFamilySupplyPrivateState,
+const NativeShieldedTokenFamilyPublicSupplySimulatorBase = createSimulator<
+  NativeShieldedTokenFamilyPublicSupplyPrivateState,
   ReturnType<typeof ledger>,
-  ReturnType<typeof NativeShieldedTokenFamilySupplyWitnesses>,
-  MockNativeShieldedTokenFamilySupply<NativeShieldedTokenFamilySupplyPrivateState>,
-  NativeShieldedTokenFamilySupplyArgs
+  ReturnType<typeof NativeShieldedTokenFamilyPublicSupplyWitnesses>,
+  MockNativeShieldedTokenFamilyPublicSupply<NativeShieldedTokenFamilyPublicSupplyPrivateState>,
+  NativeShieldedTokenFamilyPublicSupplyArgs
 >({
   contractFactory: (witnesses) =>
-    new MockNativeShieldedTokenFamilySupply<NativeShieldedTokenFamilySupplyPrivateState>(
+    new MockNativeShieldedTokenFamilyPublicSupply<NativeShieldedTokenFamilyPublicSupplyPrivateState>(
       witnesses,
     ),
-  defaultPrivateState: () => NativeShieldedTokenFamilySupplyPrivateState,
+  defaultPrivateState: () => NativeShieldedTokenFamilyPublicSupplyPrivateState,
   contractArgs: () => [],
   ledgerExtractor: (state) => ledger(state),
-  witnessesFactory: () => NativeShieldedTokenFamilySupplyWitnesses(),
-  artifactName: 'MockNativeShieldedTokenFamilySupply',
+  witnessesFactory: () => NativeShieldedTokenFamilyPublicSupplyWitnesses(),
+  artifactName: 'MockNativeShieldedTokenFamilyPublicSupply',
 });
 
 /**
- * NativeShieldedTokenFamilySupply (extension) Simulator.
+ * NativeShieldedTokenFamilyPublicSupply (extension) Simulator.
  *
  * Drives the per-domain accounting blocks (`_addMinted` / `_addBurned`) and
  * getters directly; the extension imports no token module.
  */
-export class NativeShieldedTokenFamilySupplySimulator extends NativeShieldedTokenFamilySupplySimulatorBase {
+export class NativeShieldedTokenFamilyPublicSupplySimulator extends NativeShieldedTokenFamilyPublicSupplySimulatorBase {
   static async create(
     options: SimulatorOptions<
-      NativeShieldedTokenFamilySupplyPrivateState,
-      ReturnType<typeof NativeShieldedTokenFamilySupplyWitnesses>
+      NativeShieldedTokenFamilyPublicSupplyPrivateState,
+      ReturnType<typeof NativeShieldedTokenFamilyPublicSupplyWitnesses>
     > = {},
-  ): Promise<NativeShieldedTokenFamilySupplySimulator> {
+  ): Promise<NativeShieldedTokenFamilyPublicSupplySimulator> {
     // biome-ignore lint/complexity/noThisInStatic: super.create must keep the subclass `this`
     return super.create(
       [],
       options,
-    ) as Promise<NativeShieldedTokenFamilySupplySimulator>;
+    ) as Promise<NativeShieldedTokenFamilyPublicSupplySimulator>;
   }
 
   /** @description Adds `amount` to the exact minted total for `domain`. */

--- a/contracts/src/token/test/simulators/NativeShieldedTokenPublicSupplySimulator.ts
+++ b/contracts/src/token/test/simulators/NativeShieldedTokenPublicSupplySimulator.ts
@@ -4,57 +4,57 @@ import {
 } from '@openzeppelin/compact-simulator';
 import {
   ledger,
-  Contract as MockNativeShieldedTokenSupply,
-} from '../../../../artifacts/MockNativeShieldedTokenSupply/contract/index.js';
+  Contract as MockNativeShieldedTokenPublicSupply,
+} from '../../../../artifacts/MockNativeShieldedTokenPublicSupply/contract/index.js';
 
 /**
  * The supply extension declares no witnesses, so the private state is empty and
  * the witnesses object is `{}`.
  */
-export type NativeShieldedTokenSupplyPrivateState = Record<string, never>;
-export const NativeShieldedTokenSupplyPrivateState: NativeShieldedTokenSupplyPrivateState =
+export type NativeShieldedTokenPublicSupplyPrivateState = Record<string, never>;
+export const NativeShieldedTokenPublicSupplyPrivateState: NativeShieldedTokenPublicSupplyPrivateState =
   {};
-export const NativeShieldedTokenSupplyWitnesses = () => ({});
+export const NativeShieldedTokenPublicSupplyWitnesses = () => ({});
 
 /** The supply extension needs no initialization, so the constructor is nullary. */
-type NativeShieldedTokenSupplyArgs = readonly [];
+type NativeShieldedTokenPublicSupplyArgs = readonly [];
 
-const NativeShieldedTokenSupplySimulatorBase = createSimulator<
-  NativeShieldedTokenSupplyPrivateState,
+const NativeShieldedTokenPublicSupplySimulatorBase = createSimulator<
+  NativeShieldedTokenPublicSupplyPrivateState,
   ReturnType<typeof ledger>,
-  ReturnType<typeof NativeShieldedTokenSupplyWitnesses>,
-  MockNativeShieldedTokenSupply<NativeShieldedTokenSupplyPrivateState>,
-  NativeShieldedTokenSupplyArgs
+  ReturnType<typeof NativeShieldedTokenPublicSupplyWitnesses>,
+  MockNativeShieldedTokenPublicSupply<NativeShieldedTokenPublicSupplyPrivateState>,
+  NativeShieldedTokenPublicSupplyArgs
 >({
   contractFactory: (witnesses) =>
-    new MockNativeShieldedTokenSupply<NativeShieldedTokenSupplyPrivateState>(
+    new MockNativeShieldedTokenPublicSupply<NativeShieldedTokenPublicSupplyPrivateState>(
       witnesses,
     ),
-  defaultPrivateState: () => NativeShieldedTokenSupplyPrivateState,
+  defaultPrivateState: () => NativeShieldedTokenPublicSupplyPrivateState,
   contractArgs: () => [],
   ledgerExtractor: (state) => ledger(state),
-  witnessesFactory: () => NativeShieldedTokenSupplyWitnesses(),
-  artifactName: 'MockNativeShieldedTokenSupply',
+  witnessesFactory: () => NativeShieldedTokenPublicSupplyWitnesses(),
+  artifactName: 'MockNativeShieldedTokenPublicSupply',
 });
 
 /**
- * NativeShieldedTokenSupply (extension) Simulator.
+ * NativeShieldedTokenPublicSupply (extension) Simulator.
  *
  * Drives the scalar accounting blocks (`_addMinted` / `_addBurned`) and getters
  * directly; the extension imports no token module.
  */
-export class NativeShieldedTokenSupplySimulator extends NativeShieldedTokenSupplySimulatorBase {
+export class NativeShieldedTokenPublicSupplySimulator extends NativeShieldedTokenPublicSupplySimulatorBase {
   static async create(
     options: SimulatorOptions<
-      NativeShieldedTokenSupplyPrivateState,
-      ReturnType<typeof NativeShieldedTokenSupplyWitnesses>
+      NativeShieldedTokenPublicSupplyPrivateState,
+      ReturnType<typeof NativeShieldedTokenPublicSupplyWitnesses>
     > = {},
-  ): Promise<NativeShieldedTokenSupplySimulator> {
+  ): Promise<NativeShieldedTokenPublicSupplySimulator> {
     // biome-ignore lint/complexity/noThisInStatic: super.create must keep the subclass `this`
     return super.create(
       [],
       options,
-    ) as Promise<NativeShieldedTokenSupplySimulator>;
+    ) as Promise<NativeShieldedTokenPublicSupplySimulator>;
   }
 
   /** @description Adds `amount` to the exact minted total. */


### PR DESCRIPTION
## Types of changes

What types of changes does your code introduce to OpenZeppelin Midnight Contracts?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

Closes #711

Insert `Public` before `Supply` in the native shielded token supply
extension names, so the name makes the on-chain (publicly visible) supply
accounting explicit and matches the existing `ConfidentialFungibleTokenPublicSupply`
extension already on `main`.

| Before | After |
| --- | --- |
| `NativeShieldedTokenSupply` | `NativeShieldedTokenPublicSupply` |
| `NativeShieldedTokenFamilySupply` | `NativeShieldedTokenFamilyPublicSupply` |
| `NativeShieldedTokenSupplyCore` | `NativeShieldedTokenPublicSupplyCore` |

Scope:

- Renames the three extension files plus their paired mocks, simulators, and
  tests via `git mv` (rename history preserved).
- Updates the assertion-message prefix in the core and the doc references in
  the consuming `NativeShieldedToken` / `NativeShieldedTokenFamily` contracts.
- Pure rename, no behavioural change. Breaking only in that the public import
  paths change, which is appropriate for the current `0.3.0-alpha`.

## PR Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md#your-first-code-contribution)
- [x] I have added tests that prove my fix is effective or that my feature works. <!-- Existing extension tests renamed alongside the modules; no new tests needed for a rename. -->
- [x] I have added documentation for new methods or changes to existing method behavior. <!-- Doc references in the consuming contracts and a CHANGELOG entry updated. -->
- [ ] CI Workflows Are Passing <!-- Pending CI. -->

#### Further comments

Verified locally: all four affected contracts compile (`compact compile --skip-zk`,
artifacts generated) and `biome check` passes on the renamed TS files (the longer
type name triggered one formatter rewrap, which is included). `tsc` / `vitest` were
not run in this worktree (no `node_modules`); CI covers them.
