### PR TITLE
Fixed: Use named imports across Compact contracts 

### DIFF
--- a/contracts/src/access/AccessControl.compact
+++ b/contracts/src/access/AccessControl.compact
@@ -26,7 +26,7 @@ pragma language_version >= 0.23.0;
  *
  * ```compact
  * import CompactStandardLibrary;
- * import "./node_modules/@openzeppelin-compact/accessControl/src/AccessControl" prefix AccessControl_;
+ * import { assertOnlyRole } from "./node_modules/@openzeppelin-compact/accessControl/src/AccessControl" prefix AccessControl_;
  *
  * export sealed ledger MY_ROLE: Bytes<32>;
  *
@@ -122,7 +122,7 @@ pragma language_version >= 0.23.0;
  */
 module AccessControl {
   import CompactStandardLibrary;
-  import "../utils/Utils" prefix Utils_;
+  import { canonicalize, computeAccountId } from "../utils/Utils" prefix Utils_;
 
   /**
    * @description Mapping from a role identifier -> account -> its permissions.

--- a/contracts/src/access/Ownable.compact
+++ b/contracts/src/access/Ownable.compact
@@ -85,7 +85,7 @@ pragma language_version >= 0.23.0;
  */
 module Ownable {
   import CompactStandardLibrary;
-  import "../utils/Utils" prefix Utils_;
+  import { canonicalize, computeAccountId, isTargetZero } from "../utils/Utils" prefix Utils_;
 
   /**
    * @description Initialization flag, tracked per-module to avoid the compiler's

--- a/contracts/src/access/ShieldedAccessControl.compact
+++ b/contracts/src/access/ShieldedAccessControl.compact
@@ -60,7 +60,14 @@ pragma language_version >= 0.23.0;
  *
  * ```compact
  * import CompactStandardLibrary;
- * import "./node_modules/@openzeppelin/compact-contracts/src/access/ShieldedAccessControl" prefix ShieldedAccessControl_;
+ * import {
+ *   AccountIdentifier,
+ *   RoleIdentifier,
+ *   DEFAULT_ADMIN_ROLE,
+ *   initialize,
+ *   _grantRole,
+ *   assertOnlyRole
+ * } from "./node_modules/@openzeppelin/compact-contracts/src/access/ShieldedAccessControl" prefix ShieldedAccessControl_;
  *
  * export sealed ledger MY_ROLE: Bytes<32>;
  *
@@ -167,7 +174,6 @@ pragma language_version >= 0.23.0;
  */
 module ShieldedAccessControl {
   import CompactStandardLibrary;
-  import "../utils/Utils" prefix Utils_;
 
   export enum UpdateType {
     Grant,

--- a/contracts/src/access/test/mocks/MockAccessControl.compact
+++ b/contracts/src/access/test/mocks/MockAccessControl.compact
@@ -9,7 +9,7 @@ pragma language_version >= 0.23.0;
 
 import CompactStandardLibrary;
 
-import "../../AccessControl" prefix AccessControl_;
+import { DEFAULT_ADMIN_ROLE, _checkRole, _grantRole, _revokeRole, _setRoleAdmin, _unsafeGrantRole, assertOnlyRole, getRoleAdmin, grantRole, hasRole, renounceRole, revokeRole } from "../../AccessControl" prefix AccessControl_;
 
 export { ContractAddress, Either, Maybe };
 

--- a/contracts/src/access/test/mocks/MockOwnable.compact
+++ b/contracts/src/access/test/mocks/MockOwnable.compact
@@ -9,7 +9,7 @@ pragma language_version >= 0.23.0;
 
 import CompactStandardLibrary;
 
-import "../../Ownable" prefix Ownable_;
+import { _transferOwnership, _unsafeTransferOwnership, _unsafeUncheckedTransferOwnership, assertOnlyOwner, initialize, owner, renounceOwnership, transferOwnership } from "../../Ownable" prefix Ownable_;
 
 export { ContractAddress, Either, Maybe };
 

--- a/contracts/src/access/test/mocks/MockShieldedAccessControl.compact
+++ b/contracts/src/access/test/mocks/MockShieldedAccessControl.compact
@@ -9,7 +9,7 @@ pragma language_version >= 0.23.0;
 
 import CompactStandardLibrary;
 
-import "../../ShieldedAccessControl" prefix ShieldedAccessControl_;
+import { AccountIdentifier, DEFAULT_ADMIN_ROLE, RoleCommitment, RoleIdentifier, RoleNullifier, _adminRoles, _grantRole, _operatorRoles, _revokeRole, _roleCommitmentNullifiers, _setRoleAdmin, assertOnlyRole, canProveRole, computeAccountId, computeNullifier, computeRoleCommitment, getRoleAdmin, grantRole, initialize, renounceRole, revokeRole } from "../../ShieldedAccessControl" prefix ShieldedAccessControl_;
 
 export { MerkleTreePath,
          ShieldedAccessControl__operatorRoles,

--- a/contracts/src/access/test/mocks/MockZOwnablePK.compact
+++ b/contracts/src/access/test/mocks/MockZOwnablePK.compact
@@ -8,7 +8,7 @@
 pragma language_version >= 0.23.0;
 
 import CompactStandardLibrary;
-import "../../ZOwnablePK" prefix ZOwnablePK_;
+import { _computeOwnerCommitment, _computeOwnerId, _counter, _ownerCommitment, _transferOwnership, assertOnlyOwner, initialize, owner, renounceOwnership, transferOwnership } from "../../ZOwnablePK" prefix ZOwnablePK_;
 
 export { ZswapCoinPublicKey, ContractAddress, Either, Maybe };
 export { ZOwnablePK__ownerCommitment, ZOwnablePK__counter };

--- a/contracts/src/archive/ShieldedToken.compact
+++ b/contracts/src/archive/ShieldedToken.compact
@@ -33,7 +33,7 @@ pragma language_version >= 0.23.0;
  */
 module ShieldedToken { // DO NOT USE IN PRODUCTION!
   import CompactStandardLibrary;
-  import "../utils/Utils" prefix Utils_;
+  import { isKeyOrAddressZero } from "../utils/Utils" prefix Utils_;
 
   // Public state
   export ledger _counter: Counter;

--- a/contracts/src/archive/test/mocks/MockShieldedToken.compact
+++ b/contracts/src/archive/test/mocks/MockShieldedToken.compact
@@ -8,7 +8,7 @@
 pragma language_version >= 0.23.0;
 
 import CompactStandardLibrary;
-import "../../ShieldedToken" prefix ShieldedToken_;
+import { _counter, _domain, _nonce, burn, decimals, initializer, mint, name, symbol, totalSupply } from "../../ShieldedToken" prefix ShieldedToken_;
 
 export {
   ZswapCoinPublicKey,

--- a/contracts/src/crypto/test/mocks/MockEcdhMask.compact
+++ b/contracts/src/crypto/test/mocks/MockEcdhMask.compact
@@ -8,7 +8,7 @@
 pragma language_version >= 0.23.0;
 
 import CompactStandardLibrary;
-import "../../EcdhMask" prefix EcdhMask_;
+import { Ciphertext, decrypt, encrypt, kdf } from "../../EcdhMask" prefix EcdhMask_;
 
 export { EcdhMask_Ciphertext }
 

--- a/contracts/src/crypto/test/mocks/MockElGamal.compact
+++ b/contracts/src/crypto/test/mocks/MockElGamal.compact
@@ -9,7 +9,7 @@ pragma language_version >= 0.23.0;
 
 import CompactStandardLibrary;
 
-import "../../ElGamal" prefix ElGamal_;
+import { Ciphertext, add, addEncrypted, assertDecryptsTo, assertDecryptsToPoint, assertKeyPair, derivePk, encrypt, encryptPoint, encryptZero, expandRandomness, negate, rerandomize, scalarMul, secretToScalar, sub, subEncrypted } from "../../ElGamal" prefix ElGamal_;
 
 export { ElGamal_Ciphertext }
 

--- a/contracts/src/multisig/ForwarderPrivate.compact
+++ b/contracts/src/multisig/ForwarderPrivate.compact
@@ -29,7 +29,7 @@ pragma language_version >= 0.23.0;
  */
 module ForwarderPrivate {
   import CompactStandardLibrary;
-  import "../utils/Utils" prefix Utils_;
+  import { isKeyZero } from "../utils/Utils" prefix Utils_;
 
   // ─── State ──────────────────────────────────────────────────────
 

--- a/contracts/src/multisig/ForwarderShielded.compact
+++ b/contracts/src/multisig/ForwarderShielded.compact
@@ -44,7 +44,7 @@ pragma language_version >= 0.23.0;
  */
 module ForwarderShielded {
   import CompactStandardLibrary;
-  import "../utils/Utils" prefix Utils_;
+  import { isKeyZero } from "../utils/Utils" prefix Utils_;
 
   // ─── State ──────────────────────────────────────────────────────
 

--- a/contracts/src/multisig/presets/ShieldedMultiSig.compact
+++ b/contracts/src/multisig/presets/ShieldedMultiSig.compact
@@ -27,9 +27,9 @@ pragma language_version >= 0.23.0;
 
 import CompactStandardLibrary;
 
-import "../ProposalManager" prefix Proposal_;
-import "../ShieldedTreasury" prefix Treasury_;
-import "../Signer"<Either<ZswapCoinPublicKey, ContractAddress>> prefix Signer_;
+import { Proposal, ProposalStatus, Recipient, RecipientKind, _createProposal, _markExecuted, assertProposalActive, getProposal, getProposalStatus, toShieldedRecipient } from "../ProposalManager" prefix Proposal_;
+import { _deposit, _send, getReceivedTotal, getSentTotal, getTokenBalance } from "../ShieldedTreasury" prefix Treasury_;
+import { assertSigner, assertThresholdMet, getSignerCount, getThreshold, initialize, isSigner } from "../Signer"<Either<ZswapCoinPublicKey, ContractAddress>> prefix Signer_;
 
 // ─── State ───────────────────────────────────────────────────────────────
 

--- a/contracts/src/multisig/presets/ShieldedMultiSigV2.compact
+++ b/contracts/src/multisig/presets/ShieldedMultiSigV2.compact
@@ -22,9 +22,9 @@ pragma language_version >= 0.23.0;
 
 import CompactStandardLibrary;
 
-import "../ProposalManager" prefix Proposal_;
-import "../ShieldedTreasuryStateless" prefix Treasury_;
-import "../Signer"<Bytes<32>> prefix Signer_;
+import { Recipient, toShieldedRecipient } from "../ProposalManager" prefix Proposal_;
+import { _send } from "../ShieldedTreasuryStateless" prefix Treasury_;
+import { assertSigner, assertThresholdMet, getSignerCount, getThreshold, initialize, isSigner } from "../Signer"<Bytes<32>> prefix Signer_;
 
 // ─── Types ──────────────────────────────────────────────────────
 

--- a/contracts/src/multisig/presets/ShieldedMultiSigV3.compact
+++ b/contracts/src/multisig/presets/ShieldedMultiSigV3.compact
@@ -40,8 +40,8 @@ pragma language_version >= 0.23.0;
 
 import CompactStandardLibrary;
 
-import "../Signer"<Bytes<32>> prefix Signer_;
-import "../../utils/Utils" prefix Utils_;
+import { assertSigner, assertThresholdMet, getSignerCount, getThreshold, initialize, isSigner } from "../Signer"<Bytes<32>> prefix Signer_;
+import { canonicalize } from "../../utils/Utils" prefix Utils_;
 // For testing
 export { ZswapCoinPublicKey };
 

--- a/contracts/src/multisig/presets/forwarder/ForwarderPrivate.compact
+++ b/contracts/src/multisig/presets/forwarder/ForwarderPrivate.compact
@@ -22,7 +22,7 @@ pragma language_version >= 0.23.0;
  */
 
 import CompactStandardLibrary;
-import "../../ForwarderPrivate" prefix ForwarderPrivate_;
+import { _calculateParentCommitment, _deposit, _drain, _parentCommitment, initialize } from "../../ForwarderPrivate" prefix ForwarderPrivate_;
 
 export { ShieldedCoinInfo, QualifiedShieldedCoinInfo, ShieldedSendResult, ZswapCoinPublicKey };
 

--- a/contracts/src/multisig/presets/forwarder/ForwarderShielded.compact
+++ b/contracts/src/multisig/presets/forwarder/ForwarderShielded.compact
@@ -22,7 +22,7 @@ pragma language_version >= 0.23.0;
  */
 
 import CompactStandardLibrary;
-import "../../ForwarderShielded" prefix Forwarder_;
+import { _deposit, _parent, initialize } from "../../ForwarderShielded" prefix Forwarder_;
 
 export { ZswapCoinPublicKey, ContractAddress, ShieldedCoinInfo, Either };
 

--- a/contracts/src/multisig/presets/forwarder/ForwarderUnshielded.compact
+++ b/contracts/src/multisig/presets/forwarder/ForwarderUnshielded.compact
@@ -24,7 +24,7 @@ pragma language_version >= 0.23.0;
  */
 
 import CompactStandardLibrary;
-import "../../ForwarderUnshielded" prefix Forwarder_;
+import { _deposit, _parent, initialize } from "../../ForwarderUnshielded" prefix Forwarder_;
 
 export { ContractAddress, UserAddress, Either };
 

--- a/contracts/src/multisig/test/mocks/MockForwarderPrivate.compact
+++ b/contracts/src/multisig/test/mocks/MockForwarderPrivate.compact
@@ -8,7 +8,7 @@
 pragma language_version >= 0.23.0;
 
 import CompactStandardLibrary;
-import "../../ForwarderPrivate" prefix ForwarderPrivate_;
+import { _calculateParentCommitment, _deposit, _drain, _parentCommitment, initialize } from "../../ForwarderPrivate" prefix ForwarderPrivate_;
 
 export { ShieldedCoinInfo, QualifiedShieldedCoinInfo, ShieldedSendResult, ZswapCoinPublicKey };
 

--- a/contracts/src/multisig/test/mocks/MockForwarderShielded.compact
+++ b/contracts/src/multisig/test/mocks/MockForwarderShielded.compact
@@ -8,7 +8,7 @@
 pragma language_version >= 0.23.0;
 
 import CompactStandardLibrary;
-import "../../ForwarderShielded" prefix Forwarder_;
+import { _deposit, _parent, initialize } from "../../ForwarderShielded" prefix Forwarder_;
 
 export { ZswapCoinPublicKey, ContractAddress, ShieldedCoinInfo, Either };
 

--- a/contracts/src/multisig/test/mocks/MockForwarderUnshielded.compact
+++ b/contracts/src/multisig/test/mocks/MockForwarderUnshielded.compact
@@ -8,7 +8,7 @@
 pragma language_version >= 0.23.0;
 
 import CompactStandardLibrary;
-import "../../ForwarderUnshielded" prefix Forwarder_;
+import { _deposit, _parent, initialize } from "../../ForwarderUnshielded" prefix Forwarder_;
 
 export { ContractAddress, UserAddress, Either };
 

--- a/contracts/src/multisig/test/mocks/MockProposalManager.compact
+++ b/contracts/src/multisig/test/mocks/MockProposalManager.compact
@@ -9,7 +9,7 @@ pragma language_version >= 0.23.0;
 
 import CompactStandardLibrary;
 
-import "../../ProposalManager" prefix Proposal_;
+import { Proposal, ProposalStatus, Recipient, _cancelProposal, _createProposal, _markExecuted, assertProposalActive, assertProposalExists, contractRecipient, getProposal, getProposalAmount, getProposalColor, getProposalRecipient, getProposalStatus, shieldedUserRecipient, toShieldedRecipient, toUnshieldedRecipient, unshieldedUserRecipient } from "../../ProposalManager" prefix Proposal_;
 
 export circuit shieldedUserRecipient(key: ZswapCoinPublicKey): Proposal_Recipient {
   return Proposal_shieldedUserRecipient(key);

--- a/contracts/src/multisig/test/mocks/MockShieldedTreasury.compact
+++ b/contracts/src/multisig/test/mocks/MockShieldedTreasury.compact
@@ -9,7 +9,7 @@ pragma language_version >= 0.23.0;
 
 import CompactStandardLibrary;
 
-import "../../ShieldedTreasury" prefix Treasury_;
+import { _deposit, _send, getReceivedMinusSent, getReceivedTotal, getSentTotal, getTokenBalance } from "../../ShieldedTreasury" prefix Treasury_;
 
 export circuit _deposit(coin: ShieldedCoinInfo): [] {
   return Treasury__deposit(coin);

--- a/contracts/src/multisig/test/mocks/MockShieldedTreasuryStateless.compact
+++ b/contracts/src/multisig/test/mocks/MockShieldedTreasuryStateless.compact
@@ -8,7 +8,7 @@
 pragma language_version >= 0.23.0;
 
 import CompactStandardLibrary;
-import "../../ShieldedTreasuryStateless" prefix Treasury_;
+import { _deposit, _send } from "../../ShieldedTreasuryStateless" prefix Treasury_;
 
 export circuit _deposit(coin: ShieldedCoinInfo): [] {
   Treasury__deposit(coin);

--- a/contracts/src/multisig/test/mocks/MockSigner.compact
+++ b/contracts/src/multisig/test/mocks/MockSigner.compact
@@ -9,7 +9,7 @@ pragma language_version >= 0.23.0;
 
 import CompactStandardLibrary;
 
-import "../../Signer"<Bytes<32>> prefix Signer_;
+import { _addSigner, _changeThreshold, _removeSigner, _setThreshold, assertSigner, assertThresholdMet, getSignerCount, getThreshold, initialize, isSigner } from "../../Signer"<Bytes<32>> prefix Signer_;
 import "../../Signer"<Bytes<32>>;
 
 export { ZswapCoinPublicKey, ContractAddress, Either, Maybe };

--- a/contracts/src/multisig/test/mocks/MockUnshieldedTreasury.compact
+++ b/contracts/src/multisig/test/mocks/MockUnshieldedTreasury.compact
@@ -9,7 +9,7 @@ pragma language_version >= 0.23.0;
 
 import CompactStandardLibrary;
 
-import "../../UnshieldedTreasury" prefix Treasury_;
+import { _deposit, _send, getTokenBalance } from "../../UnshieldedTreasury" prefix Treasury_;
 
 export circuit _deposit(color: Bytes<32>, amount: Uint<128>): [] {
   return Treasury__deposit(color, amount);

--- a/contracts/src/security/test/mocks/MockAllowlist.compact
+++ b/contracts/src/security/test/mocks/MockAllowlist.compact
@@ -8,7 +8,7 @@
 pragma language_version >= 0.23.0;
 
 import CompactStandardLibrary;
-import "../../Allowlist" prefix Allowlist_;
+import { _allow, _allowed, _disallow, assertAllowed, isAllowed } from "../../Allowlist" prefix Allowlist_;
 
 export { Allowlist__allowed };
 

--- a/contracts/src/security/test/mocks/MockBlocklist.compact
+++ b/contracts/src/security/test/mocks/MockBlocklist.compact
@@ -8,7 +8,7 @@
 pragma language_version >= 0.23.0;
 
 import CompactStandardLibrary;
-import "../../Blocklist" prefix Blocklist_;
+import { _block, _blocked, _unblock, assertNotBlocked, isBlocked } from "../../Blocklist" prefix Blocklist_;
 
 export { Blocklist__blocked };
 

--- a/contracts/src/security/test/mocks/MockInitializable.compact
+++ b/contracts/src/security/test/mocks/MockInitializable.compact
@@ -8,7 +8,7 @@
 pragma language_version >= 0.23.0;
 
 import CompactStandardLibrary;
-import "../../Initializable" prefix Initializable_;
+import { _isInitialized, assertInitialized, assertNotInitialized, initialize } from "../../Initializable" prefix Initializable_;
 
 export { Initializable__isInitialized };
 

--- a/contracts/src/security/test/mocks/MockPausable.compact
+++ b/contracts/src/security/test/mocks/MockPausable.compact
@@ -8,7 +8,7 @@
 pragma language_version >= 0.23.0;
 
 import CompactStandardLibrary;
-import "../../Pausable" prefix Pausable_;
+import { _isPaused, _pause, _unpause, assertNotPaused, assertPaused, isPaused } from "../../Pausable" prefix Pausable_;
 
 export { Pausable__isPaused };
 

--- a/contracts/src/token/ConfidentialFungibleToken.compact
+++ b/contracts/src/token/ConfidentialFungibleToken.compact
@@ -221,8 +221,8 @@ pragma language_version >= 0.23.0;
  */
 module ConfidentialFungibleToken {
   import CompactStandardLibrary;
-  import "../crypto/ElGamal" prefix ElGamal_;
-  import "../crypto/EcdhMask" prefix EcdhMask_;
+  import { Ciphertext, add, addEncrypted, assertDecryptsTo, derivePk, encrypt, encryptZero, expandRandomness, subEncrypted } from "../crypto/ElGamal" prefix ElGamal_;
+  import { Ciphertext, encrypt } from "../crypto/EcdhMask" prefix EcdhMask_;
 
   // ---------------------------------------------------------------------------
   // Types

--- a/contracts/src/token/FungibleToken.compact
+++ b/contracts/src/token/FungibleToken.compact
@@ -64,7 +64,7 @@ pragma language_version >= 0.23.0;
  */
 module FungibleToken {
   import CompactStandardLibrary;
-  import "../utils/Utils" prefix Utils_;
+  import { canonicalize, computeAccountId, isTargetZero, zeroAccount } from "../utils/Utils" prefix Utils_;
 
   /**
    * @description Initialization flag, tracked per-module to avoid the compiler's

--- a/contracts/src/token/MultiToken.compact
+++ b/contracts/src/token/MultiToken.compact
@@ -124,7 +124,7 @@ pragma language_version >= 0.23.0;
  */
 module MultiToken {
   import CompactStandardLibrary;
-  import "../utils/Utils" prefix Utils_;
+  import { canonicalize, computeAccountId, isTargetZero, zeroAccount } from "../utils/Utils" prefix Utils_;
 
   /**
    * @description Initialization flag, tracked per-module to avoid the compiler's

--- a/contracts/src/token/NativeShieldedToken.compact
+++ b/contracts/src/token/NativeShieldedToken.compact
@@ -65,7 +65,7 @@ pragma language_version >= 0.23.0;
  */
 module NativeShieldedToken {
   import CompactStandardLibrary;
-  import "./NativeShieldedTokenCore" prefix Core_;
+  import { _burn, _burnFromSelf, _mint, decimals, initialize, isInitialized, name, symbol, tokenColor } from "./NativeShieldedTokenCore" prefix Core_;
 
   // Circuits use the `Core_` prefix above. The named import/re-export below is
   // only for the core state variables, so the implementing contract's ledger

--- a/contracts/src/token/NativeShieldedTokenCore.compact
+++ b/contracts/src/token/NativeShieldedTokenCore.compact
@@ -61,7 +61,7 @@ pragma language_version >= 0.23.0;
  */
 module NativeShieldedTokenCore {
   import CompactStandardLibrary;
-  import "../utils/Utils" prefix Utils_;
+  import { isKeyOrAddressZero } from "../utils/Utils" prefix Utils_;
 
   /**
    * @description Initialization flag, tracked per-module to avoid the compiler's

--- a/contracts/src/token/NativeShieldedTokenFamily.compact
+++ b/contracts/src/token/NativeShieldedTokenFamily.compact
@@ -64,7 +64,7 @@ pragma language_version >= 0.23.0;
  */
 module NativeShieldedTokenFamily {
   import CompactStandardLibrary;
-  import "./NativeShieldedTokenCore" prefix Core_;
+  import { _burn, _burnFromSelf, _mint, decimals, initialize, isInitialized, name, symbol, tokenColor } from "./NativeShieldedTokenCore" prefix Core_;
 
   // Circuits use the `Core_` prefix above. The named import/re-export below is
   // only for the core state variables, so the implementing contract's ledger

--- a/contracts/src/token/NonFungibleToken.compact
+++ b/contracts/src/token/NonFungibleToken.compact
@@ -83,7 +83,7 @@ pragma language_version >= 0.23.0;
 
 module NonFungibleToken {
   import CompactStandardLibrary;
-  import "../utils/Utils" prefix Utils_;
+  import { canonicalize, computeAccountId, emptyString, isTargetZero, zeroAccount } from "../utils/Utils" prefix Utils_;
 
   /// Public state
   export sealed ledger _name: Opaque<"string">;

--- a/contracts/src/token/extensions/NativeShieldedTokenFamilyPublicSupply.compact
+++ b/contracts/src/token/extensions/NativeShieldedTokenFamilyPublicSupply.compact
@@ -62,7 +62,7 @@ pragma language_version >= 0.23.0;
  */
 module NativeShieldedTokenFamilyPublicSupply {
   import CompactStandardLibrary;
-  import "./NativeShieldedTokenPublicSupplyCore" prefix Core_;
+  import { _addBurned, _addMinted, totalBurned, totalMinted, totalSupply } from "./NativeShieldedTokenPublicSupplyCore" prefix Core_;
 
   // Circuits use the `Core_` prefix above. The named import/re-export below is
   // only for the core supply ledger keys, so the implementing contract's ledger

--- a/contracts/src/token/extensions/NativeShieldedTokenPublicSupply.compact
+++ b/contracts/src/token/extensions/NativeShieldedTokenPublicSupply.compact
@@ -58,7 +58,7 @@ pragma language_version >= 0.23.0;
  */
 module NativeShieldedTokenPublicSupply {
   import CompactStandardLibrary;
-  import "./NativeShieldedTokenPublicSupplyCore" prefix Core_;
+  import { _addBurned, _addMinted, totalBurned, totalMinted, totalSupply } from "./NativeShieldedTokenPublicSupplyCore" prefix Core_;
 
   // Circuits use the `Core_` prefix above. The named import/re-export below is
   // only for the core supply ledger keys, so the implementing contract's ledger

--- a/contracts/src/token/extensions/NativeShieldedTokenPublicSupplyCore.compact
+++ b/contracts/src/token/extensions/NativeShieldedTokenPublicSupplyCore.compact
@@ -53,7 +53,7 @@ pragma language_version >= 0.23.0;
  */
 module NativeShieldedTokenPublicSupplyCore {
   import CompactStandardLibrary;
-  import "../../utils/Utils" prefix Utils_;
+  import { UINT128_MAX } from "../../utils/Utils" prefix Utils_;
 
   /**
    * @description Exact amount minted per domain. See "Accounting guarantees".

--- a/contracts/src/token/test/mocks/MockConfidentialFungibleToken.compact
+++ b/contracts/src/token/test/mocks/MockConfidentialFungibleToken.compact
@@ -12,8 +12,8 @@
 // this mock.
 pragma language_version >= 0.23.0;
 import CompactStandardLibrary;
-import "../../ConfidentialFungibleToken" prefix CFT_;
-import "../../../crypto/ElGamal" prefix ElGamal_;
+import { EscrowEntry, _balances, _burn, _burnFrom, _decimals, _encryptionKeys, _escrow, _memos, _mint, _move, _name, _pending, _symbol, allowance, approve, balanceOf, clearMemos, computeAccountId, initialize, isRegistered, pendingOf, register, sweep, transfer, transferFrom } from "../../ConfidentialFungibleToken" prefix CFT_;
+import { Ciphertext } from "../../../crypto/ElGamal" prefix ElGamal_;
 
 export { CFT_EscrowEntry, ElGamal_Ciphertext };
 

--- a/contracts/src/token/test/mocks/MockConfidentialFungibleTokenPublicSupply.compact
+++ b/contracts/src/token/test/mocks/MockConfidentialFungibleTokenPublicSupply.compact
@@ -9,7 +9,7 @@ pragma language_version >= 0.23.0;
 
 import CompactStandardLibrary;
 
-import "../../extensions/ConfidentialFungibleTokenPublicSupply" prefix ConfidentialFungibleTokenPublicSupply_;
+import { _addSupply, _subSupply, totalSupply } from "../../extensions/ConfidentialFungibleTokenPublicSupply" prefix ConfidentialFungibleTokenPublicSupply_;
 
 // Surface the supply ledger cell unprefixed so tests can read it via
 // `getPublicState()` and assert the getter returns it verbatim.

--- a/contracts/src/token/test/mocks/MockFungibleToken.compact
+++ b/contracts/src/token/test/mocks/MockFungibleToken.compact
@@ -9,7 +9,7 @@ pragma language_version >= 0.23.0;
 
 import CompactStandardLibrary;
 
-import "../../FungibleToken" prefix FungibleToken_;
+import { _approve, _burn, _mint, _spendAllowance, _transfer, _unsafeMint, _unsafeTransfer, _unsafeTransferFrom, _unsafeUncheckedTransfer, allowance, approve, balanceOf, decimals, initialize, name, symbol, totalSupply, transfer, transferFrom } from "../../FungibleToken" prefix FungibleToken_;
 
 export { ContractAddress, Either, Maybe };
 

--- a/contracts/src/token/test/mocks/MockMultiToken.compact
+++ b/contracts/src/token/test/mocks/MockMultiToken.compact
@@ -8,7 +8,7 @@
 pragma language_version >= 0.23.0;
 
 import CompactStandardLibrary;
-import "../../MultiToken" prefix MultiToken_;
+import { _balances, _burn, _mint, _operatorApprovals, _setApprovalForAll, _setURI, _transfer, _unsafeMint, _unsafeTransfer, _unsafeTransferFrom, _uri, balanceOf, initialize, isApprovedForAll, setApprovalForAll, transferFrom, uri } from "../../MultiToken" prefix MultiToken_;
 
 export { ContractAddress, Either, Maybe };
 export { MultiToken__balances, MultiToken__operatorApprovals, MultiToken__uri };

--- a/contracts/src/token/test/mocks/MockNativeShieldedToken.compact
+++ b/contracts/src/token/test/mocks/MockNativeShieldedToken.compact
@@ -9,7 +9,7 @@ pragma language_version >= 0.23.0;
 
 import CompactStandardLibrary;
 
-import "../../NativeShieldedToken" prefix NativeShieldedToken_;
+import { _burn, _burnFromSelf, _mint, decimals, initialize, isInitialized, name, symbol, tokenColor } from "../../NativeShieldedToken" prefix NativeShieldedToken_;
 
 export { ZswapCoinPublicKey, ContractAddress, Either, Maybe };
 export { ShieldedCoinInfo, QualifiedShieldedCoinInfo };

--- a/contracts/src/token/test/mocks/MockNativeShieldedTokenCore.compact
+++ b/contracts/src/token/test/mocks/MockNativeShieldedTokenCore.compact
@@ -9,7 +9,7 @@ pragma language_version >= 0.23.0;
 
 import CompactStandardLibrary;
 
-import "../../NativeShieldedTokenCore" prefix NativeShieldedTokenCore_;
+import { _burn, _burnFromSelf, _mint, assertInitialized, assertNotInitialized, decimals, initialize, isInitialized, name, symbol, tokenColor } from "../../NativeShieldedTokenCore" prefix NativeShieldedTokenCore_;
 
 export { ZswapCoinPublicKey, ContractAddress, Either, Maybe };
 export { ShieldedCoinInfo, QualifiedShieldedCoinInfo };

--- a/contracts/src/token/test/mocks/MockNativeShieldedTokenDerivedNonce.compact
+++ b/contracts/src/token/test/mocks/MockNativeShieldedTokenDerivedNonce.compact
@@ -9,7 +9,7 @@ pragma language_version >= 0.23.0;
 
 import CompactStandardLibrary;
 
-import "../../extensions/NativeShieldedTokenDerivedNonce" prefix NativeShieldedTokenDerivedNonce_;
+import { _counter, _deriveNonce } from "../../extensions/NativeShieldedTokenDerivedNonce" prefix NativeShieldedTokenDerivedNonce_;
 
 // Unit mock for the NativeShieldedTokenDerivedNonce extension in isolation. It
 // imports no token module and needs no initialization (counter-only). The

--- a/contracts/src/token/test/mocks/MockNativeShieldedTokenFamily.compact
+++ b/contracts/src/token/test/mocks/MockNativeShieldedTokenFamily.compact
@@ -9,7 +9,7 @@ pragma language_version >= 0.23.0;
 
 import CompactStandardLibrary;
 
-import "../../NativeShieldedTokenFamily" prefix NativeShieldedTokenFamily_;
+import { _burn, _burnFromSelf, _mint, decimals, initialize, isInitialized, name, symbol, tokenColor } from "../../NativeShieldedTokenFamily" prefix NativeShieldedTokenFamily_;
 
 export { ZswapCoinPublicKey, ContractAddress, Either, Maybe };
 export { ShieldedCoinInfo, QualifiedShieldedCoinInfo };

--- a/contracts/src/token/test/mocks/MockNativeShieldedTokenFamilyPublicSupply.compact
+++ b/contracts/src/token/test/mocks/MockNativeShieldedTokenFamilyPublicSupply.compact
@@ -9,7 +9,7 @@ pragma language_version >= 0.23.0;
 
 import CompactStandardLibrary;
 
-import "../../extensions/NativeShieldedTokenFamilyPublicSupply" prefix NativeShieldedTokenFamilyPublicSupply_;
+import { _addBurned, _addMinted, totalBurned, totalMinted, totalSupply } from "../../extensions/NativeShieldedTokenFamilyPublicSupply" prefix NativeShieldedTokenFamilyPublicSupply_;
 
 export { ZswapCoinPublicKey, ContractAddress, Either, Maybe };
 

--- a/contracts/src/token/test/mocks/MockNativeShieldedTokenPublicSupply.compact
+++ b/contracts/src/token/test/mocks/MockNativeShieldedTokenPublicSupply.compact
@@ -9,7 +9,7 @@ pragma language_version >= 0.23.0;
 
 import CompactStandardLibrary;
 
-import "../../extensions/NativeShieldedTokenPublicSupply" prefix NativeShieldedTokenPublicSupply_;
+import { _addBurned, _addMinted, totalBurned, totalMinted, totalSupply } from "../../extensions/NativeShieldedTokenPublicSupply" prefix NativeShieldedTokenPublicSupply_;
 
 export { ZswapCoinPublicKey, ContractAddress, Either, Maybe };
 

--- a/contracts/src/token/test/mocks/MockNonFungibleToken.compact
+++ b/contracts/src/token/test/mocks/MockNonFungibleToken.compact
@@ -9,7 +9,7 @@ pragma language_version >= 0.23.0;
 
 import CompactStandardLibrary;
 
-import "../../NonFungibleToken" prefix NonFungibleToken_;
+import { _approve, _burn, _checkAuthorized, _getApproved, _isAuthorized, _mint, _ownerOf, _requireOwned, _setApprovalForAll, _setTokenURI, _transfer, _unsafeMint, _unsafeTransfer, _unsafeTransferFrom, approve, balanceOf, getApproved, initialize, isApprovedForAll, name, ownerOf, setApprovalForAll, symbol, tokenURI, transferFrom } from "../../NonFungibleToken" prefix NonFungibleToken_;
 
 export { ContractAddress, Either, Maybe };
 

--- a/contracts/src/utils/test/mocks/MockUtils.compact
+++ b/contracts/src/utils/test/mocks/MockUtils.compact
@@ -9,7 +9,7 @@ pragma language_version >= 0.23.0;
 
 import CompactStandardLibrary;
 
-import "../../Utils" prefix Utils_;
+import { UINT128_MAX, canonicalize, computeAccountId, emptyString, isContractAddress, isKeyOrAddressEqual, isKeyOrAddressZero, isKeyZero, isTargetZero, selfAsRecipient, zeroAccount } from "../../Utils" prefix Utils_;
 
 export { ZswapCoinPublicKey, ContractAddress, Either };
 

--- a/contracts/test/integration/_mocks/ComposedTokens.compact
+++ b/contracts/test/integration/_mocks/ComposedTokens.compact
@@ -16,8 +16,8 @@
 pragma language_version >= 0.23.0;
 
 import CompactStandardLibrary;
-import "../../../src/token/FungibleToken" prefix FungibleToken_;
-import "../../../src/token/NonFungibleToken" prefix NonFungibleToken_;
+import { initialize, name } from "../../../src/token/FungibleToken" prefix FungibleToken_;
+import { initialize, name } from "../../../src/token/NonFungibleToken" prefix NonFungibleToken_;
 
 export { ContractAddress, Either, Maybe };
 

--- a/contracts/test/integration/_mocks/ConfidentialFungibleTokenPublicSupply.compact
+++ b/contracts/test/integration/_mocks/ConfidentialFungibleTokenPublicSupply.compact
@@ -21,9 +21,9 @@ pragma language_version >= 0.23.0;
 
 import CompactStandardLibrary;
 
-import "../../../src/token/ConfidentialFungibleToken" prefix Token_;
-import "../../../src/token/extensions/ConfidentialFungibleTokenPublicSupply" prefix Supply_;
-import "../../../src/crypto/ElGamal" prefix ElGamal_;
+import { EscrowEntry, _balances, _burn, _burnFrom, _decimals, _encryptionKeys, _escrow, _memos, _mint, _move, _name, _pending, _symbol, allowance, approve, balanceOf, clearMemos, computeAccountId, initialize, isRegistered, pendingOf, register, sweep, transfer, transferFrom } from "../../../src/token/ConfidentialFungibleToken" prefix Token_;
+import { _addSupply, _subSupply, _totalSupply, totalSupply } from "../../../src/token/extensions/ConfidentialFungibleTokenPublicSupply" prefix Supply_;
+import { Ciphertext } from "../../../src/crypto/ElGamal" prefix ElGamal_;
 
 export { Token_EscrowEntry, ElGamal_Ciphertext };
 

--- a/contracts/test/integration/_mocks/SharedInitCollision.compact
+++ b/contracts/test/integration/_mocks/SharedInitCollision.compact
@@ -12,8 +12,8 @@
 pragma language_version >= 0.23.0;
 
 import CompactStandardLibrary;
-import "./sharedInit/ModuleA" prefix A_;
-import "./sharedInit/ModuleB" prefix B_;
+import { checkA, initA } from "./sharedInit/ModuleA" prefix A_;
+import { checkB, initB } from "./sharedInit/ModuleB" prefix B_;
 
 export circuit initA(): [] { A_initA(); }
 export circuit initB(): [] { B_initB(); }

--- a/contracts/test/integration/_mocks/sharedInit/ModuleA.compact
+++ b/contracts/test/integration/_mocks/sharedInit/ModuleA.compact
@@ -5,7 +5,7 @@ pragma language_version >= 0.23.0;
 
 module ModuleA {
   import CompactStandardLibrary;
-  import "../../../../src/security/Initializable" prefix Initializable_;
+  import { assertInitialized, initialize } from "../../../../src/security/Initializable" prefix Initializable_;
 
   export circuit initA(): [] {
     Initializable_initialize();

--- a/contracts/test/integration/_mocks/sharedInit/ModuleB.compact
+++ b/contracts/test/integration/_mocks/sharedInit/ModuleB.compact
@@ -5,7 +5,7 @@ pragma language_version >= 0.23.0;
 
 module ModuleB {
   import CompactStandardLibrary;
-  import "../../../../src/security/Initializable" prefix Initializable_;
+  import { assertInitialized, initialize } from "../../../../src/security/Initializable" prefix Initializable_;
 
   export circuit initB(): [] {
     Initializable_initialize();


### PR DESCRIPTION
## Types of changes
What types of changes does your code introduce to OpenZeppelin Midnight Contracts?

_Put an `x` in the boxes that apply_
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

Fixes #406

Convert blanket prefixed imports to named imports of used symbols only, keeping prefixes and call sites unchanged.
Before:

```compact
import "../security/Initializable" prefix Initializable_;

After:

import { initialize, assertInitialized } from "../security/Initializable" prefix Initializable_;

This follows the approach confirmed in #406: named imports for clarity, prefixes retained for readability without LSP “go to definition.”

Also:

Remove an unused Utils_ import from ShieldedAccessControl
Update NatSpec import examples in AccessControl and ShieldedAccessControl
Scope: 58 .compact files. No circuit logic or call-site changes.

PR Checklist

 I have read the [Contributing Guide](vscode-file://vscode-app/usr/share/cursor/resources/app/out/vs/code/electron-sandbox/CONTRIBUTING.md#your-first-code-contribution)

 I have added tests that prove my fix is effective or that my feature works. See [GUIDELINES.md#testing](vscode-file://vscode-app/usr/share/cursor/resources/app/out/vs/code/electron-sandbox/GUIDELINES.md#testing) for more information.

 I have added documentation for new methods or changes to existing method behavior. See [GUIDELINES.md#documentation](vscode-file://vscode-app/usr/share/cursor/resources/app/out/vs/code/electron-sandbox/GUIDELINES.md#documentation) for more information.

CI Workflows Are Passing
Further comments
No new tests were added: this is an import-only change with identical runtime behavior. Verified locally with yarn compile, **yarn test** and **yarn test:live** with docker for those 20 skipped one (1476 passed, 20 skipped live-only), and yarn lint. Will check CI Workflows Are Passing once GitHub Actions is green.

Notes:
- Pulled latest code before creating PR.
- Leave CI unchecked until checks pass, then edit the PR and tick it.
- Suggested title: **Use named imports across Compact contracts**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal module usage across contract, token, security, multisignature, and cryptographic components.
  * Reduced unnecessary imports while preserving existing functionality and interfaces.
  * Updated test support components and integration fixtures to use only the functionality they require.

* **Bug Fixes**
  * No user-facing behavior or public contract declarations changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->