### PR TITLE
fix(token): require token existence in NonFungibleToken _approve

### DIFF
--- a/contracts/src/token/NonFungibleToken.compact
+++ b/contracts/src/token/NonFungibleToken.compact
@@ -58,7 +58,7 @@ pragma language_version >= 0.23.0;
  * or in ledger writes. Canonicalization zeroes out the inactive branch of the Either,
  * ensuring that two values with the same active branch always resolve to the same map key
  * regardless of what data the inactive branch carries. Write paths are canonicalized in
- * `_update` (for `_owners` and `_balances`), `_approve` (for `_tokenApprovals`), and
+ * `_update` (for `_owners` and `_balances`), `_unsafeApprove` (for `_tokenApprovals`), and
  * `_setApprovalForAll` (for `_operatorApprovals`). Read paths are canonicalized in
  * `balanceOf`, `isApprovedForAll`, and `_isAuthorized`.
  *
@@ -338,7 +338,7 @@ module NonFungibleToken {
    * In the case of an external (non-contract) caller, the caller's identity is derived from the `wit_NonFungibleTokenSK`
    * witness as `persistentHash(secretKey)`.
    *
-   * @circuitInfo k=13, rows=3468
+   * @circuitInfo k=13, rows=3415
    *
    * Requirements:
    *
@@ -383,7 +383,7 @@ module NonFungibleToken {
    * In the case of an external (non-contract) caller, the caller's identity is derived from the `wit_NonFungibleTokenSK`
    * witness as `persistentHash(secretKey)`.
    *
-   * @circuitInfo k=13, rows=2936
+   * @circuitInfo k=13, rows=2947
    *
    * Requirements:
    *
@@ -439,7 +439,7 @@ module NonFungibleToken {
    * In the case of an external (non-contract) caller, the caller's identity is derived from the `wit_NonFungibleTokenSK`
    * witness as `persistentHash(secretKey)`.
    *
-   * @circuitInfo k=13, rows=4800
+   * @circuitInfo k=13, rows=4739
    *
    * Requirements:
    *
@@ -477,7 +477,7 @@ module NonFungibleToken {
    * are not currently supported. Tokens sent to a contract address may become irretrievable.
    * Once contract-to-contract calls are supported, this circuit may be deprecated.
    *
-   * @circuitInfo k=13, rows=4797
+   * @circuitInfo k=13, rows=4736
    *
    * Requirements:
    *
@@ -499,10 +499,13 @@ module NonFungibleToken {
                    ): [] {
     assertInitialized();
     assert(!Utils_isTargetZero(to), "NonFungibleToken: invalid receiver");
-    // Setting an "auth" argument enables the `_isAuthorized` check which verifies that the token exists
-    // (fromAddress != 0). Therefore, it is not needed to verify that the return value is not 0 here.
     const auth = left<Bytes<32>, ContractAddress>(_computeAccountId());
     const previousOwner = _update(to, tokenId, auth);
+
+    // The `_isAuthorized` check inside `_update` already implies the token exists, but that
+    // holds only while approvals are never recorded for unminted tokens. Assert it directly
+    // so a misused `_unsafeApprove` cannot turn this circuit into an unauthorized mint.
+    assert(!Utils_isTargetZero(previousOwner), "NonFungibleToken: nonexistent token");
 
     const canonFrom = Utils_canonicalize<Bytes<32>, ContractAddress>(fromAddress);
     assert(previousOwner == canonFrom, "NonFungibleToken: incorrect owner");
@@ -643,8 +646,8 @@ module NonFungibleToken {
 
     // Execute the update
     if (!Utils_isTargetZero(disclose(fromAddress))) {
-      // Clear approval. No need to re-authorize
-      _approve(Utils_zeroAccount(), tokenId, Utils_zeroAccount());
+      // Clear approval. No need to re-authorize or re-read the owner
+      _unsafeApprove(Utils_zeroAccount(), tokenId, Utils_zeroAccount(), false);
       const canonFrom = Utils_canonicalize<Bytes<32>, ContractAddress>(fromAddress);
       const newBalance = _balances.lookup(disclose(canonFrom)) - 1 as Uint<128>;
       _balances.insert(disclose(canonFrom), disclose(newBalance));
@@ -666,7 +669,7 @@ module NonFungibleToken {
   /**
    * @description Mints `tokenId` and transfers it to `to`.
    *
-   * @circuitInfo k=11, rows=1473
+   * @circuitInfo k=11, rows=1411
    *
    * Requirements:
    *
@@ -690,7 +693,7 @@ module NonFungibleToken {
   /**
    * @description Mints `tokenId` and transfers it to `to`. It does NOT check if the recipient is a ContractAddress.
    *
-   * @circuitInfo k=11, rows=1470
+   * @circuitInfo k=11, rows=1408
    *
    * Requirements:
    *
@@ -723,7 +726,7 @@ module NonFungibleToken {
    * The approval is cleared when the token is burned.
    * This circuit does not check if the sender is authorized to operate on the token.
    *
-   * @circuitInfo k=10, rows=509
+   * @circuitInfo k=10, rows=512
    *
    * Requirements:
    *
@@ -748,7 +751,7 @@ module NonFungibleToken {
    * interactions are supported in Compact. This restriction prevents assets from being inadvertently
    * locked in contracts that cannot currently handle token receipt.
    *
-   * @circuitInfo k=12, rows=2067
+   * @circuitInfo k=11, rows=2005
    *
    * Requirements:
    *
@@ -779,7 +782,7 @@ module NonFungibleToken {
    * As opposed to {_unsafeTransferFrom}, this imposes no restrictions on the caller's identity.
    * It does NOT check if the recipient is a ContractAddress.
    *
-   * @circuitInfo k=12, rows=2064
+   * @circuitInfo k=11, rows=2002
    *
    * Requirements:
    *
@@ -815,11 +818,12 @@ module NonFungibleToken {
   /**
    * @description Approve `to` to operate on `tokenId`.
    *
-   * @circuitInfo k=11, rows=1810
+   * @circuitInfo k=11, rows=1757
    *
    * Requirements:
    *
    * - The contract is initialized.
+   * - `tokenId` must exist.
    * - If `auth` is non 0, then this function will check that `auth` is either the owner of the token,
    * or approved to operate on the token (by the owner).
    *
@@ -833,6 +837,43 @@ module NonFungibleToken {
                    tokenId: Uint<128>,
                    auth: Either<Bytes<32>, ContractAddress>
                    ): [] {
+    _unsafeApprove(to, tokenId, auth, true);
+  }
+
+  /**
+   * @description Approve `to` to operate on `tokenId`, requiring the token to exist
+   * only when `isExistenceRequired` is true.
+   *
+   * @circuitInfo k=11, rows=1870
+   *
+   * @warning Passing false skips the check that `tokenId` was minted. Both
+   * `_unsafeTransferFrom` and `_update` read that invariant back, so a planted approval
+   * can mint a token nobody authorized or outlive a later mint. Pass false only where
+   * the owner has already been read, as `_update` does.
+   *
+   * @dev Counterpart to Solidity's `_approve(to, tokenId, auth, bool emitEvent)`, where
+   * the flag also suppresses the `Approval` event. Compact has no events, so it carries
+   * the existence check alone.
+   *
+   * Requirements:
+   *
+   * - The contract is initialized.
+   * - `tokenId` must exist, unless `isExistenceRequired` is false.
+   * - If `auth` is non 0, then this function will check that `auth` is either the owner of the token,
+   * or approved to operate on the token (by the owner).
+   *
+   * @param {Either<Bytes<32>, ContractAddress>} to - The target account to approve
+   * @param {Uint<128>} tokenId - The token to approve
+   * @param {Either<Bytes<32>, ContractAddress>} auth - An account authorized to operate on all tokens held by the owner of the token
+   * @param {Boolean} isExistenceRequired - Whether `tokenId` must exist
+   * @return {[]} - Empty tuple.
+   */
+  export circuit _unsafeApprove(
+                   to: Either<Bytes<32>, ContractAddress>,
+                   tokenId: Uint<128>,
+                   auth: Either<Bytes<32>, ContractAddress>,
+                   isExistenceRequired: Boolean
+                   ): [] {
     assertInitialized();
     // Canonicalize + normalize `to`
     const canonTo = Utils_canonicalize<Bytes<32>, ContractAddress>(to);
@@ -841,11 +882,14 @@ module NonFungibleToken {
     // Canonicalize auth
     const canonAuth = Utils_canonicalize<Bytes<32>, ContractAddress>(auth);
 
-    if (!Utils_isTargetZero(disclose(canonAuth))) {
+    // Avoid reading the owner unless necessary
+    if (disclose(isExistenceRequired) || !Utils_isTargetZero(disclose(canonAuth))) {
       const owner = _requireOwned(tokenId);
 
       // We do not use _isAuthorized because single-token approvals should not be able to call approve
-      assert((owner == disclose(canonAuth) || isApprovedForAll(owner, canonAuth)),
+      assert((Utils_isTargetZero(disclose(canonAuth)) ||
+              owner == disclose(canonAuth) ||
+              isApprovedForAll(owner, canonAuth)),
              "NonFungibleToken: invalid approver"
              );
     }
@@ -856,7 +900,7 @@ module NonFungibleToken {
   /**
    * @description Approve `operator` to operate on all of `owner` tokens.
    *
-   * @circuitInfo k=11, rows=1261
+   * @circuitInfo k=11, rows=1282
    *
    * Requirements:
    *

--- a/contracts/src/token/NonFungibleToken.compact
+++ b/contracts/src/token/NonFungibleToken.compact
@@ -858,7 +858,7 @@ module NonFungibleToken {
    * Requirements:
    *
    * - The contract is initialized.
-   * - `tokenId` must exist, unless `isExistenceRequired` is false.
+   * - `tokenId` must exist, unless `isExistenceRequired` is false and `auth` is zero.
    * - If `auth` is non 0, then this function will check that `auth` is either the owner of the token,
    * or approved to operate on the token (by the owner).
    *

--- a/contracts/src/token/test/mocks/MockNonFungibleToken.compact
+++ b/contracts/src/token/test/mocks/MockNonFungibleToken.compact
@@ -98,6 +98,15 @@ export circuit _approve(
   return NonFungibleToken__approve(to, tokenId, auth);
 }
 
+export circuit _unsafeApprove(
+  to: Either<Bytes<32>, ContractAddress>,
+  tokenId: Uint<128>,
+  auth: Either<Bytes<32>, ContractAddress>,
+  isExistenceRequired: Boolean
+): [] {
+  return NonFungibleToken__unsafeApprove(to, tokenId, auth, isExistenceRequired);
+}
+
 export circuit _checkAuthorized(
   owner: Either<Bytes<32>, ContractAddress>,
   spender: Either<Bytes<32>, ContractAddress>,

--- a/contracts/src/token/test/nonFungibleToken.test.ts
+++ b/contracts/src/token/test/nonFungibleToken.test.ts
@@ -826,25 +826,6 @@ describe('NonFungibleToken', () => {
         ZERO_ACCOUNT,
       );
     });
-
-    it('should not approve a token before it is minted', async () => {
-      // Plant an approval on the id OWNER is about to mint
-      await token
-        ._approve(SPENDER.either, TOKENID_1, ZERO_ACCOUNT)
-        .catch(() => undefined);
-
-      // `_update` clears approvals only when the source is non-zero, so a
-      // planted approval would survive the mint
-      await token._mint(OWNER.either, TOKENID_1);
-      expect(await token.getApproved(TOKENID_1)).toEqual(ZERO_ACCOUNT);
-
-      await token.privateState.injectSecretKey(SPENDER.secretKey);
-      await expect(
-        token.transferFrom(OWNER.either, SPENDER.either, TOKENID_1),
-      ).rejects.toThrow('NonFungibleToken: insufficient approval');
-
-      expect(await token.ownerOf(TOKENID_1)).toEqual(OWNER.either);
-    });
   });
 
   describe('_unsafeApprove', () => {
@@ -888,6 +869,20 @@ describe('NonFungibleToken', () => {
           false,
         ),
       ).rejects.toThrow('NonFungibleToken: invalid approver');
+    });
+
+    it('should leave an approval planted before the mint in place', async () => {
+      await token._unsafeApprove(
+        SPENDER.either,
+        TOKENID_1,
+        ZERO_ACCOUNT,
+        false,
+      );
+
+      // `_update` clears approvals only for a non-zero source, so a mint
+      // leaves the planted approval standing.
+      await token._mint(OWNER.either, TOKENID_1);
+      expect(await token.getApproved(TOKENID_1)).toEqual(SPENDER.either);
     });
 
     it('should not let a planted approval mint through transferFrom', async () => {

--- a/contracts/src/token/test/nonFungibleToken.test.ts
+++ b/contracts/src/token/test/nonFungibleToken.test.ts
@@ -818,6 +818,77 @@ describe('NonFungibleToken', () => {
     });
   });
 
+  // Audit finding M-04 (Midnight Foundation #02, release 0.3.0-alpha.1).
+  //
+  // `_approve` runs its approver validation only when `auth` is non-zero, so
+  // the `_requireOwned` existence check sits inside the guarded branch while
+  // the approval write executes unconditionally. `MockNonFungibleToken`
+  // exports `_approve`, so the zero-auth path is reachable without going
+  // through `approve` and its `_computeAccountId` derived auth.
+  //
+  // The module relies elsewhere on the invariant these tests pin: that a
+  // populated approval implies an existing token. The comment in
+  // `_unsafeTransferFrom` states that supplying an `auth` argument verifies
+  // token existence, and therefore skips checking the returned previous owner
+  // against zero.
+  //
+  // These tests assert the intended behaviour and FAIL on the current
+  // implementation. They are the reproduction for the finding.
+  describe('audit M-04: approvals for nonexistent tokens', () => {
+    it('should reject a zero-auth approval for a nonexistent token', async () => {
+      await expect(
+        token._approve(SPENDER.either, NON_EXISTENT_TOKEN, ZERO_ACCOUNT),
+      ).rejects.toThrow('NonFungibleToken: nonexistent token');
+
+      expect(await token._getApproved(NON_EXISTENT_TOKEN)).toEqual(
+        ZERO_ACCOUNT,
+      );
+    });
+
+    it('should not let a planted approval mint a nonexistent token', async () => {
+      // Plant the approval on an unminted identifier. Tolerated so the chain
+      // below is exercised on the current implementation; the test above pins
+      // the revert that closes it.
+      await token
+        ._approve(SPENDER.either, NON_EXISTENT_TOKEN, ZERO_ACCOUNT)
+        .catch(() => undefined);
+
+      // The stale approval satisfies `_isAuthorized`, so `_checkAuthorized`
+      // never reaches its nonexistent-token assert. `_update` then reads the
+      // owner as zero, skips the balance decrement, credits the recipient and
+      // writes the owner entry, minting the token without mint authorization
+      // and permanently blocking a later gated mint of that identifier.
+      await token.privateState.injectSecretKey(SPENDER.secretKey);
+      await expect(
+        token.transferFrom(ZERO_ACCOUNT, SPENDER.either, NON_EXISTENT_TOKEN),
+      ).rejects.toThrow('NonFungibleToken: nonexistent token');
+
+      expect(await token._ownerOf(NON_EXISTENT_TOKEN)).toEqual(ZERO_ACCOUNT);
+      expect(await token.balanceOf(SPENDER.either)).toEqual(0n);
+    });
+
+    it('should not let a planted approval survive a later mint', async () => {
+      // Plant the approval on an identifier that is about to be minted.
+      await token
+        ._approve(SPENDER.either, TOKENID_1, ZERO_ACCOUNT)
+        .catch(() => undefined);
+
+      // `_update` clears approvals only when the source is non-zero, so a mint
+      // never clears the planted approval and it outlives the legitimate mint.
+      await token._mint(OWNER.either, TOKENID_1);
+      expect(await token.getApproved(TOKENID_1)).toEqual(ZERO_ACCOUNT);
+
+      // Otherwise the planter transfers the freshly minted token away from its
+      // rightful owner.
+      await token.privateState.injectSecretKey(SPENDER.secretKey);
+      await expect(
+        token.transferFrom(OWNER.either, SPENDER.either, TOKENID_1),
+      ).rejects.toThrow('NonFungibleToken: insufficient approval');
+
+      expect(await token.ownerOf(TOKENID_1)).toEqual(OWNER.either);
+    });
+  });
+
   describe('_checkAuthorized', () => {
     it('should throw if token not minted', async () => {
       await expect(

--- a/contracts/src/token/test/nonFungibleToken.test.ts
+++ b/contracts/src/token/test/nonFungibleToken.test.ts
@@ -820,20 +820,16 @@ describe('NonFungibleToken', () => {
 
   // Audit finding M-04 (Midnight Foundation #02, release 0.3.0-alpha.1).
   //
-  // `_approve` runs its approver validation only when `auth` is non-zero, so
-  // the `_requireOwned` existence check sits inside the guarded branch while
-  // the approval write executes unconditionally. `MockNonFungibleToken`
-  // exports `_approve`, so the zero-auth path is reachable without going
-  // through `approve` and its `_computeAccountId` derived auth.
+  // Before the fix, `_approve` checked the approver only when `auth` was
+  // non-zero. That guard held the `_requireOwned` existence check, and the
+  // approval write sat outside it, so the zero-auth path recorded approvals
+  // for unminted tokens. Other circuits read the broken invariant back: a
+  // recorded approval implies the token exists.
   //
-  // The module relies elsewhere on the invariant these tests pin: that a
-  // populated approval implies an existing token. The comment in
-  // `_unsafeTransferFrom` states that supplying an `auth` argument verifies
-  // token existence, and therefore skips checking the returned previous owner
-  // against zero.
-  //
-  // These tests assert the intended behaviour and FAIL on the current
-  // implementation. They are the reproduction for the finding.
+  // Fixed by splitting the circuit the way Solidity overloads it: `_approve`
+  // always requires existence and delegates to `_unsafeApprove`, whose
+  // `isExistenceRequired` flag mirrors Solidity's `emitEvent`. These tests
+  // failed on the unfixed code and pin the intended behaviour.
   describe('audit M-04: approvals for nonexistent tokens', () => {
     it('should reject a zero-auth approval for a nonexistent token', async () => {
       await expect(
@@ -846,18 +842,19 @@ describe('NonFungibleToken', () => {
     });
 
     it('should not let a planted approval mint a nonexistent token', async () => {
-      // Plant the approval on an unminted identifier. Tolerated so the chain
-      // below is exercised on the current implementation; the test above pins
-      // the revert that closes it.
+      // Plant an approval on an id nobody minted. On the unfixed code this
+      // call succeeded; it now reverts and the chain stops right here (the
+      // first test pins that revert), so the transfer below is exercised
+      // without a stale approval.
       await token
         ._approve(SPENDER.either, NON_EXISTENT_TOKEN, ZERO_ACCOUNT)
         .catch(() => undefined);
 
-      // The stale approval satisfies `_isAuthorized`, so `_checkAuthorized`
-      // never reaches its nonexistent-token assert. `_update` then reads the
-      // owner as zero, skips the balance decrement, credits the recipient and
-      // writes the owner entry, minting the token without mint authorization
-      // and permanently blocking a later gated mint of that identifier.
+      // On the unfixed code the stale approval satisfied `_isAuthorized`, so
+      // `_checkAuthorized` never reached its nonexistent-token assert:
+      // `_update` read the owner as zero, skipped the balance decrement,
+      // credited SPENDER and wrote the owner entry, leaving SPENDER holding a
+      // token nobody minted and blocking the composer's own gated mint of it.
       await token.privateState.injectSecretKey(SPENDER.secretKey);
       await expect(
         token.transferFrom(ZERO_ACCOUNT, SPENDER.either, NON_EXISTENT_TOKEN),
@@ -868,24 +865,90 @@ describe('NonFungibleToken', () => {
     });
 
     it('should not let a planted approval survive a later mint', async () => {
-      // Plant the approval on an identifier that is about to be minted.
+      // Plant an approval on the id OWNER is about to mint. Reverts on the
+      // fixed code; succeeded on the unfixed code.
       await token
         ._approve(SPENDER.either, TOKENID_1, ZERO_ACCOUNT)
         .catch(() => undefined);
 
-      // `_update` clears approvals only when the source is non-zero, so a mint
-      // never clears the planted approval and it outlives the legitimate mint.
+      // `_update` clears approvals only when the source is non-zero, so a
+      // mint leaves any planted approval standing.
       await token._mint(OWNER.either, TOKENID_1);
       expect(await token.getApproved(TOKENID_1)).toEqual(ZERO_ACCOUNT);
 
-      // Otherwise the planter transfers the freshly minted token away from its
-      // rightful owner.
+      // On the unfixed code SPENDER then took OWNER's token on the strength
+      // of the surviving approval.
       await token.privateState.injectSecretKey(SPENDER.secretKey);
       await expect(
         token.transferFrom(OWNER.either, SPENDER.either, TOKENID_1),
       ).rejects.toThrow('NonFungibleToken: insufficient approval');
 
       expect(await token.ownerOf(TOKENID_1)).toEqual(OWNER.either);
+    });
+  });
+
+  describe('_unsafeApprove', () => {
+    it('should match _approve when existence is required', async () => {
+      await token._mint(OWNER.either, TOKENID_1);
+      await token._unsafeApprove(SPENDER.either, TOKENID_1, OWNER.either, true);
+      expect(await token.getApproved(TOKENID_1)).toEqual(SPENDER.either);
+    });
+
+    it('should reject a nonexistent token when existence is required', async () => {
+      await expect(
+        token._unsafeApprove(
+          SPENDER.either,
+          NON_EXISTENT_TOKEN,
+          ZERO_ACCOUNT,
+          true,
+        ),
+      ).rejects.toThrow('NonFungibleToken: nonexistent token');
+    });
+
+    it('should record an approval for a nonexistent token when existence is not required', async () => {
+      // The documented unsafe behaviour: no existence check, approval recorded.
+      await token._unsafeApprove(
+        SPENDER.either,
+        NON_EXISTENT_TOKEN,
+        ZERO_ACCOUNT,
+        false,
+      );
+      expect(await token._getApproved(NON_EXISTENT_TOKEN)).toEqual(
+        SPENDER.either,
+      );
+    });
+
+    it('should still check the approver when existence is not required', async () => {
+      await token._mint(OWNER.either, TOKENID_1);
+      await expect(
+        token._unsafeApprove(
+          SPENDER.either,
+          TOKENID_1,
+          UNAUTHORIZED.either,
+          false,
+        ),
+      ).rejects.toThrow('NonFungibleToken: invalid approver');
+    });
+
+    it('should not let a planted approval mint through transferFrom', async () => {
+      // Plant the approval a misused composer call would leave behind.
+      await token._unsafeApprove(
+        SPENDER.either,
+        NON_EXISTENT_TOKEN,
+        ZERO_ACCOUNT,
+        false,
+      );
+
+      // The stale approval satisfies `_isAuthorized`, so `_checkAuthorized`
+      // passes on the zero owner. The transfer must die at the previous-owner
+      // assert in `_unsafeTransferFrom` instead.
+      await token.privateState.injectSecretKey(SPENDER.secretKey);
+      await expect(
+        token.transferFrom(ZERO_ACCOUNT, SPENDER.either, NON_EXISTENT_TOKEN),
+      ).rejects.toThrow('NonFungibleToken: nonexistent token');
+
+      expect(await token._ownerOf(NON_EXISTENT_TOKEN)).toEqual(ZERO_ACCOUNT);
+      expect(await token.balanceOf(SPENDER.either)).toEqual(0n);
     });
   });
 
@@ -1512,6 +1575,7 @@ const circuitsToFail: FailingCircuits[] = [
   ['_requireOwned', [TOKENID_1]],
   ['_ownerOf', [TOKENID_1]],
   ['_approve', [OWNER.either, TOKENID_1, SPENDER.either]],
+  ['_unsafeApprove', [OWNER.either, TOKENID_1, SPENDER.either, true]],
   ['_checkAuthorized', [OWNER.either, SPENDER.either, TOKENID_1]],
   ['_isAuthorized', [OWNER.either, SPENDER.either, TOKENID_1]],
   ['_getApproved', [TOKENID_1]],

--- a/contracts/src/token/test/nonFungibleToken.test.ts
+++ b/contracts/src/token/test/nonFungibleToken.test.ts
@@ -827,22 +827,6 @@ describe('NonFungibleToken', () => {
       );
     });
 
-    it('should not approve a nonexistent token into existence', async () => {
-      // Plant an approval on a nonexistent id
-      await token
-        ._approve(SPENDER.either, NON_EXISTENT_TOKEN, ZERO_ACCOUNT)
-        .catch(() => undefined);
-
-      // Attempt to mint the nonexistent token through a transfer
-      await token.privateState.injectSecretKey(SPENDER.secretKey);
-      await expect(
-        token.transferFrom(ZERO_ACCOUNT, SPENDER.either, NON_EXISTENT_TOKEN),
-      ).rejects.toThrow('NonFungibleToken: nonexistent token');
-
-      expect(await token._ownerOf(NON_EXISTENT_TOKEN)).toEqual(ZERO_ACCOUNT);
-      expect(await token.balanceOf(SPENDER.either)).toEqual(0n);
-    });
-
     it('should not approve a token before it is minted', async () => {
       // Plant an approval on the id OWNER is about to mint
       await token

--- a/contracts/src/token/test/nonFungibleToken.test.ts
+++ b/contracts/src/token/test/nonFungibleToken.test.ts
@@ -816,22 +816,8 @@ describe('NonFungibleToken', () => {
       await token._approve(ZERO_ACCOUNT, TOKENID_1, OWNER.either);
       expect(await token.getApproved(TOKENID_1)).toEqual(ZERO_ACCOUNT);
     });
-  });
 
-  // Audit finding M-04 (Midnight Foundation #02, release 0.3.0-alpha.1).
-  //
-  // Before the fix, `_approve` checked the approver only when `auth` was
-  // non-zero. That guard held the `_requireOwned` existence check, and the
-  // approval write sat outside it, so the zero-auth path recorded approvals
-  // for unminted tokens. Other circuits read the broken invariant back: a
-  // recorded approval implies the token exists.
-  //
-  // Fixed by splitting the circuit the way Solidity overloads it: `_approve`
-  // always requires existence and delegates to `_unsafeApprove`, whose
-  // `isExistenceRequired` flag mirrors Solidity's `emitEvent`. These tests
-  // failed on the unfixed code and pin the intended behaviour.
-  describe('audit M-04: approvals for nonexistent tokens', () => {
-    it('should reject a zero-auth approval for a nonexistent token', async () => {
+    it('should throw if token does not exist and auth is zero', async () => {
       await expect(
         token._approve(SPENDER.either, NON_EXISTENT_TOKEN, ZERO_ACCOUNT),
       ).rejects.toThrow('NonFungibleToken: nonexistent token');
@@ -841,20 +827,13 @@ describe('NonFungibleToken', () => {
       );
     });
 
-    it('should not let a planted approval mint a nonexistent token', async () => {
-      // Plant an approval on an id nobody minted. On the unfixed code this
-      // call succeeded; it now reverts and the chain stops right here (the
-      // first test pins that revert), so the transfer below is exercised
-      // without a stale approval.
+    it('should not approve a nonexistent token into existence', async () => {
+      // Plant an approval on a nonexistent id
       await token
         ._approve(SPENDER.either, NON_EXISTENT_TOKEN, ZERO_ACCOUNT)
         .catch(() => undefined);
 
-      // On the unfixed code the stale approval satisfied `_isAuthorized`, so
-      // `_checkAuthorized` never reached its nonexistent-token assert:
-      // `_update` read the owner as zero, skipped the balance decrement,
-      // credited SPENDER and wrote the owner entry, leaving SPENDER holding a
-      // token nobody minted and blocking the composer's own gated mint of it.
+      // Attempt to mint the nonexistent token through a transfer
       await token.privateState.injectSecretKey(SPENDER.secretKey);
       await expect(
         token.transferFrom(ZERO_ACCOUNT, SPENDER.either, NON_EXISTENT_TOKEN),
@@ -864,20 +843,17 @@ describe('NonFungibleToken', () => {
       expect(await token.balanceOf(SPENDER.either)).toEqual(0n);
     });
 
-    it('should not let a planted approval survive a later mint', async () => {
-      // Plant an approval on the id OWNER is about to mint. Reverts on the
-      // fixed code; succeeded on the unfixed code.
+    it('should not approve a token before it is minted', async () => {
+      // Plant an approval on the id OWNER is about to mint
       await token
         ._approve(SPENDER.either, TOKENID_1, ZERO_ACCOUNT)
         .catch(() => undefined);
 
       // `_update` clears approvals only when the source is non-zero, so a
-      // mint leaves any planted approval standing.
+      // planted approval would survive the mint
       await token._mint(OWNER.either, TOKENID_1);
       expect(await token.getApproved(TOKENID_1)).toEqual(ZERO_ACCOUNT);
 
-      // On the unfixed code SPENDER then took OWNER's token on the strength
-      // of the surviving approval.
       await token.privateState.injectSecretKey(SPENDER.secretKey);
       await expect(
         token.transferFrom(OWNER.either, SPENDER.either, TOKENID_1),

--- a/contracts/src/token/test/simulators/NonFungibleTokenSimulator.ts
+++ b/contracts/src/token/test/simulators/NonFungibleTokenSimulator.ts
@@ -242,6 +242,32 @@ export class NonFungibleTokenSimulator extends NonFungibleTokenSimulatorBase {
   }
 
   /**
+   * @description Approve `to` to operate on `tokenId`, requiring the token to exist
+   * only when `isExistenceRequired` is true.
+   *
+   * WARNING: Passing false records the approval without verifying that `tokenId` was
+   * minted. See the module docs for the invariant this breaks.
+   *
+   * @param to The target account to approve
+   * @param tokenId The token to approve
+   * @param auth An account authorized to operate on all tokens held by the owner the token
+   * @param isExistenceRequired Whether `tokenId` must exist
+   */
+  public _unsafeApprove(
+    to: Either<Uint8Array, ContractAddress>,
+    tokenId: bigint,
+    auth: Either<Uint8Array, ContractAddress>,
+    isExistenceRequired: boolean,
+  ): Promise<[]> {
+    return this.circuits.impure._unsafeApprove(
+      to,
+      tokenId,
+      auth,
+      isExistenceRequired,
+    );
+  }
+
+  /**
    * @description Checks if `spender` can operate on `tokenId`, assuming the provided `owner` is the actual owner.
    * Reverts if:
    * - `spender` does not have approval from `owner` for `tokenId`.


### PR DESCRIPTION
## Types of changes

What types of changes does your code introduce to OpenZeppelin Midnight Contracts?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

Fixes audit finding M-04: `NonFungibleToken._approve` recorded approvals for non-existent tokens on the zero-`auth` path.

## PR Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md#your-first-code-contribution)
- [x] I have added tests that prove my fix is effective or that my feature works. See [GUIDELINES.md#testing](../GUIDELINES.md#testing) for more information.
- [x] I have added documentation for new methods or changes to existing method behavior. See [GUIDELINES.md#documentation](../GUIDELINES.md#documentation) for more information.
- [ ] CI Workflows Are Passing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved NFT transfer and approval validation for nonexistent tokens.
  * Prevented stale approvals and unauthorized minting through transfer flows.
  * Approval clearing now works safely when tokens no longer exist.

* **Testing**
  * Added coverage for approval authorization, token existence requirements, uninitialized circuits, and related regression scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->