### PR TITLE
test(crypto): keep mock circuits impure for live

### DIFF
--- a/contracts/package.json
+++ b/contracts/package.json
@@ -27,7 +27,7 @@
     "compile": "compact-compiler --exclude '*/archive/*'",
     "compile:access": "compact-compiler --dir access",
     "compile:archive": "compact-compiler --dir archive",
-    "compile:crypto": "compact-compiler --dir crypto --feature-zkir-v3",
+    "compile:crypto": "compact-compiler --dir crypto --exclude 'MockEcdsa.compact' && compact-compiler --dir crypto/test/mocks --exclude 'MockElGamal.compact' --exclude 'MockEcdhMask.compact' --exclude 'MockCurveOps.compact' --feature-zkir-v3",
     "compile:multisig": "compact-compiler --dir multisig --feature-zkir-v3",
     "compile:security": "compact-compiler --dir security",
     "compile:token": "compact-compiler --dir token",

--- a/contracts/src/crypto/test/CurveRuntimeInvariants.test.ts
+++ b/contracts/src/crypto/test/CurveRuntimeInvariants.test.ts
@@ -1,9 +1,9 @@
 import {
   constructJubjubPoint,
-  type JubjubPoint,
+  ecMulGenerator,
 } from '@midnight-ntwrk/compact-runtime';
-import { describe, expect, it } from 'vitest';
-import { pureCircuits } from '../../../artifacts/MockCurveOps/contract/index.js';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { CurveOpsSimulator } from './simulators/CurveOpsSimulator.js';
 
 // ---------------------------------------------------------------------------
 // RUNTIME-INVARIANTS REGRESSION TEST.
@@ -40,29 +40,26 @@ const OFF_CURVE = constructJubjubPoint(1n, 1n);
 // arbitrary coords < q, unknown structure.
 const GARBAGE = constructJubjubPoint(12345n, 67890n);
 
-// Classify a runtime call as a returned value or a trap.
-const classify = <T>(
-  fn: () => T,
-): { ok: true; value: T } | { ok: false; err: string } => {
-  try {
-    return { ok: true, value: fn() };
-  } catch (e) {
-    return { ok: false, err: (e as Error).message };
-  }
-};
+const IN_SUBGROUP = ecMulGenerator(5n);
 
-const threw = (p: JubjubPoint, fn: (p: JubjubPoint) => unknown): boolean =>
-  !classify(() => fn(p)).ok;
+// MIXED-ORDER point of order 2*ℓ: an in-subgroup point plus the order-2 point.
+// In twisted Edwards, (x,y) + (0,-1) = (-x,-y), so this is just coordinate
+// negation of a real point. It is on-curve, NOT in the prime-order subgroup,
+// and (crucially) NOT a low-order point, so it should not hit any
+// addition-formula exception. This is the realistic attack vector.
+const MIXED = constructJubjubPoint(Q - IN_SUBGROUP.x, Q - IN_SUBGROUP.y);
+
+let contract: CurveOpsSimulator;
+
+// A trap fires while the circuit is evaluated locally, before any proof, so
+// the rejections below hold on the live backend too.
+const traps = (call: Promise<unknown>): Promise<void> =>
+  expect(call).rejects.toThrow();
 
 describe('JubjubPoint subgroup enforcement (runtime invariant)', () => {
-  const inSubgroup = pureCircuits.genMul(5n); // generator-derived -> in subgroup
-
-  // MIXED-ORDER point of order 2*ℓ: an in-subgroup point plus the order-2 point.
-  // In twisted Edwards, (x,y) + (0,-1) = (-x,-y), so this is just coordinate
-  // negation of a real point. It is on-curve, NOT in the prime-order subgroup,
-  // and (crucially) NOT a low-order point, so it should not hit any
-  // addition-formula exception. This is the realistic attack vector.
-  const MIXED = constructJubjubPoint(Q - inSubgroup.x, Q - inSubgroup.y);
+  beforeAll(async () => {
+    contract = await CurveOpsSimulator.create();
+  });
 
   it('FACT: a JubjubPoint is fabricable from arbitrary coordinates', () => {
     expect(ORDER_2).toEqual({ x: 0n, y: Q - 1n });
@@ -73,14 +70,12 @@ describe('JubjubPoint subgroup enforcement (runtime invariant)', () => {
   // from "incidental low-order formula exception".
   // -------------------------------------------------------------------------
   describe('mixed-order point (order 2*ℓ) — the decisive case', () => {
-    it('TRAPS ecMul on a mixed-order point (genuine subgroup enforcement)', () => {
-      expect(classify(() => pureCircuits.doEcMul(MIXED, 3n)).ok).toBe(false);
+    it('TRAPS ecMul on a mixed-order point (genuine subgroup enforcement)', async () => {
+      await traps(contract.doEcMul(MIXED, 3n));
     });
 
-    it('TRAPS ecAdd on a mixed-order point', () => {
-      expect(classify(() => pureCircuits.doEcAdd(MIXED, inSubgroup)).ok).toBe(
-        false,
-      );
+    it('TRAPS ecAdd on a mixed-order point', async () => {
+      await traps(contract.doEcAdd(MIXED, IN_SUBGROUP));
     });
   });
 
@@ -88,20 +83,22 @@ describe('JubjubPoint subgroup enforcement (runtime invariant)', () => {
   // ecMul: does it reject non-subgroup / off-curve points?
   // -------------------------------------------------------------------------
   describe('ecMul input validation', () => {
-    it('accepts an in-subgroup point', () => {
-      expect(threw(inSubgroup, (p) => pureCircuits.doEcMul(p, 3n))).toBe(false);
+    it('accepts an in-subgroup point', async () => {
+      await expect(contract.doEcMul(IN_SUBGROUP, 3n)).resolves.toEqual(
+        ecMulGenerator(15n),
+      );
     });
 
-    it('TRAPS on an on-curve order-2 point (off-subgroup)', () => {
-      expect(threw(ORDER_2, (p) => pureCircuits.doEcMul(p, 3n))).toBe(true);
+    it('TRAPS on an on-curve order-2 point (off-subgroup)', async () => {
+      await traps(contract.doEcMul(ORDER_2, 3n));
     });
 
-    it('TRAPS on an off-curve point', () => {
-      expect(threw(OFF_CURVE, (p) => pureCircuits.doEcMul(p, 3n))).toBe(true);
+    it('TRAPS on an off-curve point', async () => {
+      await traps(contract.doEcMul(OFF_CURVE, 3n));
     });
 
-    it('TRAPS on a garbage point', () => {
-      expect(threw(GARBAGE, (p) => pureCircuits.doEcMul(p, 3n))).toBe(true);
+    it('TRAPS on a garbage point', async () => {
+      await traps(contract.doEcMul(GARBAGE, 3n));
     });
   });
 
@@ -109,28 +106,22 @@ describe('JubjubPoint subgroup enforcement (runtime invariant)', () => {
   // ecAdd: THE linchpin for encryptPoint (m flows through ecAdd, not ecMul).
   // -------------------------------------------------------------------------
   describe('ecAdd input validation', () => {
-    it('accepts two in-subgroup points', () => {
-      expect(
-        classify(() => pureCircuits.doEcAdd(inSubgroup, inSubgroup)).ok,
-      ).toBe(true);
-    });
-
-    it('TRAPS when an order-2 point is added', () => {
-      expect(classify(() => pureCircuits.doEcAdd(ORDER_2, inSubgroup)).ok).toBe(
-        false,
+    it('accepts two in-subgroup points', async () => {
+      await expect(contract.doEcAdd(IN_SUBGROUP, IN_SUBGROUP)).resolves.toEqual(
+        ecMulGenerator(10n),
       );
     });
 
-    it('TRAPS when an off-curve point is added', () => {
-      expect(
-        classify(() => pureCircuits.doEcAdd(OFF_CURVE, inSubgroup)).ok,
-      ).toBe(false);
+    it('TRAPS when an order-2 point is added', async () => {
+      await traps(contract.doEcAdd(ORDER_2, IN_SUBGROUP));
     });
 
-    it('TRAPS when a garbage point is added', () => {
-      expect(classify(() => pureCircuits.doEcAdd(GARBAGE, inSubgroup)).ok).toBe(
-        false,
-      );
+    it('TRAPS when an off-curve point is added', async () => {
+      await traps(contract.doEcAdd(OFF_CURVE, IN_SUBGROUP));
+    });
+
+    it('TRAPS when a garbage point is added', async () => {
+      await traps(contract.doEcAdd(GARBAGE, IN_SUBGROUP));
     });
   });
 
@@ -143,12 +134,14 @@ describe('JubjubPoint subgroup enforcement (runtime invariant)', () => {
   // ephemeral POINT (g^e != identity), which catches e = ell regardless.
   // -------------------------------------------------------------------------
   describe('scalar-range fault (ecMulGenerator)', () => {
-    it('accepts the maximum valid scalar (ell - 1)', () => {
-      expect(classify(() => pureCircuits.genMul(L - 1n)).ok).toBe(true);
+    it('accepts the maximum valid scalar (ell - 1)', async () => {
+      await expect(contract.genMul(L - 1n)).resolves.toEqual(
+        ecMulGenerator(L - 1n),
+      );
     });
 
-    it('TRAPS on scalar == ell (out of range)', () => {
-      expect(classify(() => pureCircuits.genMul(L)).ok).toBe(false);
+    it('TRAPS on scalar == ell (out of range)', async () => {
+      await traps(contract.genMul(L));
     });
   });
 });

--- a/contracts/src/crypto/test/EcdhMask.test.ts
+++ b/contracts/src/crypto/test/EcdhMask.test.ts
@@ -1,11 +1,9 @@
 import { ecMulGenerator } from '@midnight-ntwrk/compact-runtime';
+import { isLiveBackend } from '@openzeppelin/compact-simulator';
 import fc from 'fast-check';
-import { describe, expect, it } from 'vitest';
-import { pureCircuits } from '../../../artifacts/MockEcdhMask/contract/index.js';
-import { pureCircuits as elgamal } from '../../../artifacts/MockElGamal/contract/index.js';
-
-// The EcdhMask circuits are pure, so tests drive them directly via the compiled
-// artifact's `pureCircuits` (no proof, no simulator needed).
+import { beforeAll, describe, expect, it } from 'vitest';
+import { EcdhMaskSimulator } from './simulators/EcdhMaskSimulator.js';
+import { ElGamalSimulator } from './simulators/ElGamalSimulator.js';
 
 // Jubjub prime-order subgroup order. Valid scalars are [1, L-1]; the runtime
 // faults ecMul on scalars >= L (see crypto/ElGamal), so L-1 is the largest
@@ -25,36 +23,46 @@ const domain = (label: string): Uint8Array => {
 };
 const DOMAIN = domain('ecdh_mask_test');
 
+// Every run is a transaction on the live backend, so the property shrinks to a
+// handful of cases there and keeps its full sample space dry.
+const PROPERTY_RUNS = isLiveBackend() ? 3 : 100;
+
+let contract: EcdhMaskSimulator;
+
 describe('EcdhMask', () => {
+  beforeAll(async () => {
+    contract = await EcdhMaskSimulator.create();
+  });
+
   describe('encrypt / decrypt round-trip', () => {
-    it('recovers the encrypted value', () => {
-      const ciphertext = pureCircuits.encrypt(PK, 1000n, 42n, DOMAIN);
-      expect(pureCircuits.decrypt(ciphertext, EK, DOMAIN)).toBe(1000n);
+    it('recovers the encrypted value', async () => {
+      const ciphertext = await contract.encrypt(PK, 1000n, 42n, DOMAIN);
+      expect(await contract.decrypt(ciphertext, EK, DOMAIN)).toBe(1000n);
     });
 
-    it('round-trips zero', () => {
-      const ciphertext = pureCircuits.encrypt(PK, 0n, 42n, DOMAIN);
-      expect(pureCircuits.decrypt(ciphertext, EK, DOMAIN)).toBe(0n);
+    it('round-trips zero', async () => {
+      const ciphertext = await contract.encrypt(PK, 0n, 42n, DOMAIN);
+      expect(await contract.decrypt(ciphertext, EK, DOMAIN)).toBe(0n);
     });
 
-    it('round-trips a value far above 2^48 (no discrete-log bound)', () => {
+    it('round-trips a value far above 2^48 (no discrete-log bound)', async () => {
       // This is the whole point of the ECDH mask: values are delivered
       // directly, so there is no BSGS table and no 2^48 cap.
       const big = 1n << 120n;
-      const ciphertext = pureCircuits.encrypt(PK, big, 42n, DOMAIN);
-      expect(pureCircuits.decrypt(ciphertext, EK, DOMAIN)).toBe(big);
+      const ciphertext = await contract.encrypt(PK, big, 42n, DOMAIN);
+      expect(await contract.decrypt(ciphertext, EK, DOMAIN)).toBe(big);
     });
 
-    it('round-trips the maximum Uint<128> value', () => {
+    it('round-trips the maximum Uint<128> value', async () => {
       // Recovery is field subtraction (ct - mask), which is exact even if
       // value + mask wrapped the field modulus, so the max value round-trips
       // regardless of wrap.
       const max = (1n << 128n) - 1n;
-      const ciphertext = pureCircuits.encrypt(PK, max, 42n, DOMAIN);
-      expect(pureCircuits.decrypt(ciphertext, EK, DOMAIN)).toBe(max);
+      const ciphertext = await contract.encrypt(PK, max, 42n, DOMAIN);
+      expect(await contract.decrypt(ciphertext, EK, DOMAIN)).toBe(max);
     });
 
-    it('round-trips at the maximum valid scalar (L - 1) for key and ephemeral', () => {
+    it('round-trips at the maximum valid scalar (L - 1) for key and ephemeral', async () => {
       // Exercise the top of the valid scalar range: both the recipient key's
       // secret and the ephemeral are L - 1, the largest scalar the runtime
       // accepts (L and above fault ecMul).
@@ -62,123 +70,129 @@ describe('EcdhMask', () => {
       const e = L - 1n;
       const max = (1n << 128n) - 1n;
       const pk = ecMulGenerator(ek);
-      const ciphertext = pureCircuits.encrypt(pk, max, e, DOMAIN);
-      expect(pureCircuits.decrypt(ciphertext, ek, DOMAIN)).toBe(max);
+      const ciphertext = await contract.encrypt(pk, max, e, DOMAIN);
+      expect(await contract.decrypt(ciphertext, ek, DOMAIN)).toBe(max);
     });
 
-    it('round-trips through the real crypto/ElGamal key derivation', () => {
+    it('round-trips through the real crypto/ElGamal key derivation', async () => {
       // The CFT memo path derives the recipient pair from a Bytes<32> EK via
       // crypto/ElGamal: pk = derivePk(EK), ekScalar = secretToScalar(EK). Pin
       // that shared-key infrastructure end to end rather than using raw scalars.
+      const elgamal = await ElGamalSimulator.create();
       const ekBytes = new Uint8Array(32).fill(0x11);
-      const pk = elgamal.derivePk(ekBytes);
-      const ekScalar = elgamal.secretToScalar(ekBytes);
-      const ciphertext = pureCircuits.encrypt(pk, 4242n, 99n, DOMAIN);
-      expect(pureCircuits.decrypt(ciphertext, ekScalar, DOMAIN)).toBe(4242n);
+      const pk = await elgamal.derivePk(ekBytes);
+      const ekScalar = await elgamal.secretToScalar(ekBytes);
+      const ciphertext = await contract.encrypt(pk, 4242n, 99n, DOMAIN);
+      expect(await contract.decrypt(ciphertext, ekScalar, DOMAIN)).toBe(4242n);
     });
 
-    it('round-trips for arbitrary keys, ephemerals, and values (property)', () => {
-      fc.assert(
-        fc.property(
+    it('round-trips for arbitrary keys, ephemerals, and values (property)', async () => {
+      await fc.assert(
+        fc.asyncProperty(
           // Keys and ephemerals stay well under the Jubjub subgroup order ℓ
           // (~2^252) so they are valid scalars; values span the full Uint<128>.
           fc.bigInt({ min: 1n, max: 1n << 200n }),
           fc.bigInt({ min: 1n, max: 1n << 200n }),
           fc.bigInt({ min: 0n, max: (1n << 128n) - 1n }),
-          (ek, e, value) => {
+          async (ek, e, value) => {
             const pk = ecMulGenerator(ek);
-            const ciphertext = pureCircuits.encrypt(pk, value, e, DOMAIN);
-            expect(pureCircuits.decrypt(ciphertext, ek, DOMAIN)).toBe(value);
+            const ciphertext = await contract.encrypt(pk, value, e, DOMAIN);
+            expect(await contract.decrypt(ciphertext, ek, DOMAIN)).toBe(value);
           },
         ),
+        { numRuns: PROPERTY_RUNS },
       );
     });
   });
 
   describe('freshness / pad reuse', () => {
-    it('reusing the ephemeral to one recipient leaks the value difference', () => {
+    it('reusing the ephemeral to one recipient leaks the value difference', async () => {
       // The freshness footgun in executable form: a repeated `e` to the same
       // recipient reuses the one-time pad, so the ciphertext difference equals
       // the plaintext difference. This is exactly why `e` MUST be fresh; the
       // test also pins the pad semantics against a KDF regression.
       const e = 7n;
-      const c1 = pureCircuits.encrypt(PK, 1000n, e, DOMAIN);
-      const c2 = pureCircuits.encrypt(PK, 250n, e, DOMAIN);
+      const c1 = await contract.encrypt(PK, 1000n, e, DOMAIN);
+      const c2 = await contract.encrypt(PK, 250n, e, DOMAIN);
       expect(c1.ct - c2.ct).toBe(1000n - 250n);
     });
   });
 
   describe('weak-input guards', () => {
-    it('rejects encryption to the identity public key', () => {
+    it('rejects encryption to the identity public key', async () => {
       const identity = ecMulGenerator(0n);
-      expect(() => pureCircuits.encrypt(identity, 1000n, 42n, DOMAIN)).toThrow(
-        'identity pk',
-      );
+      await expect(
+        contract.encrypt(identity, 1000n, 42n, DOMAIN),
+      ).rejects.toThrow('identity pk');
     });
 
-    it('rejects a zero ephemeral', () => {
-      expect(() => pureCircuits.encrypt(PK, 1000n, 0n, DOMAIN)).toThrow(
+    it('rejects a zero ephemeral', async () => {
+      await expect(contract.encrypt(PK, 1000n, 0n, DOMAIN)).rejects.toThrow(
         'zero ephemeral',
       );
     });
   });
 
   describe('confidentiality / correctness properties', () => {
-    it('distinct ephemerals yield distinct ciphertexts for the same value', () => {
-      const c1 = pureCircuits.encrypt(PK, 1000n, 1n, DOMAIN);
-      const c2 = pureCircuits.encrypt(PK, 1000n, 2n, DOMAIN);
+    it('distinct ephemerals yield distinct ciphertexts for the same value', async () => {
+      const c1 = await contract.encrypt(PK, 1000n, 1n, DOMAIN);
+      const c2 = await contract.encrypt(PK, 1000n, 2n, DOMAIN);
       expect(c1.ct).not.toBe(c2.ct);
       expect(c1.ephemeralPk).not.toEqual(c2.ephemeralPk);
     });
 
-    it('distinct values yield distinct ciphertexts under the same ephemeral', () => {
-      const c1 = pureCircuits.encrypt(PK, 1000n, 5n, DOMAIN);
-      const c2 = pureCircuits.encrypt(PK, 2000n, 5n, DOMAIN);
+    it('distinct values yield distinct ciphertexts under the same ephemeral', async () => {
+      const c1 = await contract.encrypt(PK, 1000n, 5n, DOMAIN);
+      const c2 = await contract.encrypt(PK, 2000n, 5n, DOMAIN);
       expect(c1.ct).not.toBe(c2.ct);
     });
 
-    it('does not recover the value under the wrong secret key', () => {
-      const ciphertext = pureCircuits.encrypt(PK, 1000n, 42n, DOMAIN);
+    it('does not recover the value under the wrong secret key', async () => {
+      const ciphertext = await contract.encrypt(PK, 1000n, 42n, DOMAIN);
       const WRONG_EK = 999999n;
-      expect(pureCircuits.decrypt(ciphertext, WRONG_EK, DOMAIN)).not.toBe(
+      expect(await contract.decrypt(ciphertext, WRONG_EK, DOMAIN)).not.toBe(
         1000n,
       );
     });
 
-    it('does not recover the value under the wrong domain', () => {
-      const ciphertext = pureCircuits.encrypt(PK, 1000n, 42n, DOMAIN);
-      expect(pureCircuits.decrypt(ciphertext, EK, domain('other'))).not.toBe(
+    it('does not recover the value under the wrong domain', async () => {
+      const ciphertext = await contract.encrypt(PK, 1000n, 42n, DOMAIN);
+      expect(await contract.decrypt(ciphertext, EK, domain('other'))).not.toBe(
         1000n,
       );
     });
   });
 
   describe('kdf', () => {
-    it('is deterministic for the same shared point and domain', () => {
-      expect(pureCircuits.kdf(PK, DOMAIN)).toBe(pureCircuits.kdf(PK, DOMAIN));
+    it('is deterministic for the same shared point and domain', async () => {
+      expect(await contract.kdf(PK, DOMAIN)).toBe(
+        await contract.kdf(PK, DOMAIN),
+      );
     });
 
-    it('differs for distinct shared points', () => {
+    it('differs for distinct shared points', async () => {
       const other = ecMulGenerator(222n);
-      expect(pureCircuits.kdf(PK, DOMAIN)).not.toBe(
-        pureCircuits.kdf(other, DOMAIN),
+      expect(await contract.kdf(PK, DOMAIN)).not.toBe(
+        await contract.kdf(other, DOMAIN),
       );
     });
 
-    it('differs for distinct domains (domain separation)', () => {
-      expect(pureCircuits.kdf(PK, domain('a'))).not.toBe(
-        pureCircuits.kdf(PK, domain('b')),
+    it('differs for distinct domains (domain separation)', async () => {
+      expect(await contract.kdf(PK, domain('a'))).not.toBe(
+        await contract.kdf(PK, domain('b')),
       );
     });
 
-    it('produces a mask below 2^248 (hiding-margin regression)', () => {
+    it('produces a mask below 2^248 (hiding-margin regression)', async () => {
       // The module's ~2^-120 hiding margin rests on the kdf output staying in
       // [0, 2^248) (the degradeToTransient range). Pin that stdlib behavior over
       // several points so a regression surfaces here rather than silently
       // shrinking the margin.
       const bound = 1n << 248n;
       for (const s of [2n, 5n, 222n, 999999n]) {
-        expect(pureCircuits.kdf(ecMulGenerator(s), DOMAIN)).toBeLessThan(bound);
+        expect(await contract.kdf(ecMulGenerator(s), DOMAIN)).toBeLessThan(
+          bound,
+        );
       }
     });
   });

--- a/contracts/src/crypto/test/EcdhMask.test.ts
+++ b/contracts/src/crypto/test/EcdhMask.test.ts
@@ -74,17 +74,23 @@ describe('EcdhMask', () => {
       expect(await contract.decrypt(ciphertext, ek, DOMAIN)).toBe(max);
     });
 
-    it('round-trips through the real crypto/ElGamal key derivation', async () => {
-      // The CFT memo path derives the recipient pair from a Bytes<32> EK via
-      // crypto/ElGamal: pk = derivePk(EK), ekScalar = secretToScalar(EK). Pin
-      // that shared-key infrastructure end to end rather than using raw scalars.
-      const elgamal = await ElGamalSimulator.create();
-      const ekBytes = new Uint8Array(32).fill(0x11);
-      const pk = await elgamal.derivePk(ekBytes);
-      const ekScalar = await elgamal.secretToScalar(ekBytes);
-      const ciphertext = await contract.encrypt(pk, 4242n, 99n, DOMAIN);
-      expect(await contract.decrypt(ciphertext, ekScalar, DOMAIN)).toBe(4242n);
-    });
+    // Dry only: MockElGamal is over the local-node deploy block limit.
+    it.skipIf(isLiveBackend())(
+      'round-trips through the real crypto/ElGamal key derivation',
+      async () => {
+        // The CFT memo path derives the recipient pair from a Bytes<32> EK via
+        // crypto/ElGamal: pk = derivePk(EK), ekScalar = secretToScalar(EK). Pin
+        // that shared-key infrastructure end to end rather than using raw scalars.
+        const elgamal = await ElGamalSimulator.create();
+        const ekBytes = new Uint8Array(32).fill(0x11);
+        const pk = await elgamal.derivePk(ekBytes);
+        const ekScalar = await elgamal.secretToScalar(ekBytes);
+        const ciphertext = await contract.encrypt(pk, 4242n, 99n, DOMAIN);
+        expect(await contract.decrypt(ciphertext, ekScalar, DOMAIN)).toBe(
+          4242n,
+        );
+      },
+    );
 
     it('round-trips for arbitrary keys, ephemerals, and values (property)', async () => {
       await fc.assert(

--- a/contracts/src/crypto/test/Ecdsa.test.ts
+++ b/contracts/src/crypto/test/Ecdsa.test.ts
@@ -68,28 +68,28 @@ describe('Ecdsa', () => {
   // rest are the mauled twins.
   // -------------------------------------------------------------------------
   describe('isLowS', () => {
-    it('accepts the zero scalar', () => {
-      expect(EcdsaSimulator.isLowS(0n)).toBe(true);
+    it('accepts the zero scalar', async () => {
+      expect(await contract.isLowS(0n)).toBe(true);
     });
 
-    it('accepts the smallest non-zero scalar', () => {
-      expect(EcdsaSimulator.isLowS(1n)).toBe(true);
+    it('accepts the smallest non-zero scalar', async () => {
+      expect(await contract.isLowS(1n)).toBe(true);
     });
 
-    it('accepts s just below n/2', () => {
-      expect(EcdsaSimulator.isLowS(HALF_N - 1n)).toBe(true);
+    it('accepts s just below n/2', async () => {
+      expect(await contract.isLowS(HALF_N - 1n)).toBe(true);
     });
 
-    it('accepts s = n/2', () => {
-      expect(EcdsaSimulator.isLowS(HALF_N)).toBe(true);
+    it('accepts s = n/2', async () => {
+      expect(await contract.isLowS(HALF_N)).toBe(true);
     });
 
-    it('rejects s = n/2 + 1', () => {
-      expect(EcdsaSimulator.isLowS(HALF_N + 1n)).toBe(false);
+    it('rejects s = n/2 + 1', async () => {
+      expect(await contract.isLowS(HALF_N + 1n)).toBe(false);
     });
 
-    it('rejects the largest scalar', () => {
-      expect(EcdsaSimulator.isLowS(SECP256K1_N - 1n)).toBe(false);
+    it('rejects the largest scalar', async () => {
+      expect(await contract.isLowS(SECP256K1_N - 1n)).toBe(false);
     });
   });
 

--- a/contracts/src/crypto/test/mocks/MockCurveOps.compact
+++ b/contracts/src/crypto/test/mocks/MockCurveOps.compact
@@ -12,14 +12,22 @@ pragma language_version >= 0.26.0;
 
 import CompactStandardLibrary;
 
-export pure circuit doEcMul(p: JubjubPoint, k: JubjubScalar): JubjubPoint {
+// Keeps the circuits impure. Without a ledger write the compiler promotes
+// them to pure, and the artifact ships without ZKIR or proving keys, leaving
+// the code evaluated but never proven.
+ledger _invocations: Counter;
+
+export circuit doEcMul(p: JubjubPoint, k: JubjubScalar): JubjubPoint {
+  _invocations.increment(1);
   return ecMul(p, k);
 }
 
-export pure circuit doEcAdd(a: JubjubPoint, b: JubjubPoint): JubjubPoint {
+export circuit doEcAdd(a: JubjubPoint, b: JubjubPoint): JubjubPoint {
+  _invocations.increment(1);
   return ecAdd(a, b);
 }
 
-export pure circuit genMul(k: JubjubScalar): JubjubPoint {
+export circuit genMul(k: JubjubScalar): JubjubPoint {
+  _invocations.increment(1);
   return ecMulGenerator(k);
 }

--- a/contracts/src/crypto/test/mocks/MockEcdhMask.compact
+++ b/contracts/src/crypto/test/mocks/MockEcdhMask.compact
@@ -1,9 +1,8 @@
 // SPDX-License-Identifier: MIT
 
 // WARNING: FOR TESTING PURPOSES ONLY.
-// Exposes the EcdhMask module's pure circuits so they can be driven from
-// off-chain tests. DO NOT deploy or use this contract in any production
-// application.
+// Exposes the EcdhMask module's circuits so they can be driven from off-chain
+// tests. DO NOT deploy or use this contract in any production application.
 
 pragma language_version >= 0.26.0;
 
@@ -12,19 +11,27 @@ import "../../EcdhMask" prefix EcdhMask_;
 
 export { EcdhMask_Ciphertext }
 
-export pure circuit kdf(sShared: JubjubPoint, domain: Bytes<32>): Field {
+// Keeps the circuits impure. Without a ledger write the compiler promotes
+// them to pure, and the artifact ships without ZKIR or proving keys, leaving
+// the code evaluated but never proven.
+ledger _invocations: Counter;
+
+export circuit kdf(sShared: JubjubPoint, domain: Bytes<32>): Field {
+  _invocations.increment(1);
   return EcdhMask_kdf(sShared, domain);
 }
 
-export pure circuit encrypt(
+export circuit encrypt(
                       recipientPk: JubjubPoint,
                       value: Uint<128>,
                       e: JubjubScalar,
                       domain: Bytes<32>
                       ): EcdhMask_Ciphertext {
+  _invocations.increment(1);
   return EcdhMask_encrypt(recipientPk, value, e, domain);
 }
 
-export pure circuit decrypt(ciphertext: EcdhMask_Ciphertext, ekScalar: JubjubScalar, domain: Bytes<32>): Field {
+export circuit decrypt(ciphertext: EcdhMask_Ciphertext, ekScalar: JubjubScalar, domain: Bytes<32>): Field {
+  _invocations.increment(1);
   return EcdhMask_decrypt(ciphertext, ekScalar, domain);
 }

--- a/contracts/src/crypto/test/mocks/MockEcdsa.compact
+++ b/contracts/src/crypto/test/mocks/MockEcdsa.compact
@@ -11,12 +11,13 @@ import CompactStandardLibrary;
 
 import "../../Ecdsa" prefix Ecdsa_;
 
-// Keeps assertLowS and secp256k1EcdsaVerifyLowS impure. Without a ledger
-// write the compiler promotes them to pure, and the artifact ships without
-// ZKIR or proving keys, leaving the low-s path evaluated but never proven.
+// Keeps the circuits impure. Without a ledger write the compiler promotes
+// them to pure, and the artifact ships without ZKIR or proving keys, leaving
+// the code evaluated but never proven.
 ledger _invocations: Counter;
 
-export pure circuit isLowS(s: Secp256k1Scalar): Boolean {
+export circuit isLowS(s: Secp256k1Scalar): Boolean {
+  _invocations.increment(1);
   return Ecdsa_isLowS(s);
 }
 

--- a/contracts/src/crypto/test/mocks/MockElGamal.compact
+++ b/contracts/src/crypto/test/mocks/MockElGamal.compact
@@ -13,107 +13,128 @@ import "../../ElGamal" prefix ElGamal_;
 
 export { ElGamal_Ciphertext }
 
-export pure circuit secretToScalar(secret: Bytes<32>): JubjubScalar {
+// Keeps the circuits impure. Without a ledger write the compiler promotes
+// them to pure, and the artifact ships without ZKIR or proving keys, leaving
+// the code evaluated but never proven.
+ledger _invocations: Counter;
+
+export circuit secretToScalar(secret: Bytes<32>): JubjubScalar {
+  _invocations.increment(1);
   return ElGamal_secretToScalar(secret);
 }
 
-export pure circuit derivePk(ek: Bytes<32>): JubjubPoint {
+export circuit derivePk(ek: Bytes<32>): JubjubPoint {
+  _invocations.increment(1);
   return ElGamal_derivePk(ek);
 }
 
-export pure circuit expandRandomness(seed: Bytes<32>, tag: Bytes<32>): JubjubScalar {
+export circuit expandRandomness(seed: Bytes<32>, tag: Bytes<32>): JubjubScalar {
+  _invocations.increment(1);
   return ElGamal_expandRandomness(seed, tag);
 }
 
-export pure circuit encryptZero(): ElGamal_Ciphertext {
+export circuit encryptZero(): ElGamal_Ciphertext {
+  _invocations.increment(1);
   return ElGamal_encryptZero();
 }
 
-export pure circuit encryptPoint(
+export circuit encryptPoint(
                       pk: JubjubPoint,
                       m: JubjubPoint,
                       r: JubjubScalar
                       ): ElGamal_Ciphertext {
+  _invocations.increment(1);
   return ElGamal_encryptPoint(pk, m, r);
 }
 
-export pure circuit encrypt(
+export circuit encrypt(
                       pk: JubjubPoint,
                       value: Uint<128>,
                       r: JubjubScalar
                       ): ElGamal_Ciphertext {
+  _invocations.increment(1);
   return ElGamal_encrypt(pk, value, r);
 }
 
-export pure circuit negate(ct: ElGamal_Ciphertext): ElGamal_Ciphertext {
+export circuit negate(ct: ElGamal_Ciphertext): ElGamal_Ciphertext {
+  _invocations.increment(1);
   return ElGamal_negate(ct);
 }
 
-export pure circuit add(
+export circuit add(
                       a: ElGamal_Ciphertext,
                       b: ElGamal_Ciphertext
                       ): ElGamal_Ciphertext {
+  _invocations.increment(1);
   return ElGamal_add(a, b);
 }
 
-export pure circuit sub(
+export circuit sub(
                       a: ElGamal_Ciphertext,
                       b: ElGamal_Ciphertext
                       ): ElGamal_Ciphertext {
+  _invocations.increment(1);
   return ElGamal_sub(a, b);
 }
 
-export pure circuit scalarMul(
+export circuit scalarMul(
                       ct: ElGamal_Ciphertext,
                       k: JubjubScalar
                       ): ElGamal_Ciphertext {
+  _invocations.increment(1);
   return ElGamal_scalarMul(ct, k);
 }
 
-export pure circuit addEncrypted(
+export circuit addEncrypted(
                       old: ElGamal_Ciphertext,
                       pk: JubjubPoint,
                       value: Uint<128>,
                       r: JubjubScalar
                       ): ElGamal_Ciphertext {
+  _invocations.increment(1);
   return ElGamal_addEncrypted(old, pk, value, r);
 }
 
-export pure circuit subEncrypted(
+export circuit subEncrypted(
                       old: ElGamal_Ciphertext,
                       pk: JubjubPoint,
                       value: Uint<128>,
                       r: JubjubScalar
                       ): ElGamal_Ciphertext {
+  _invocations.increment(1);
   return ElGamal_subEncrypted(old, pk, value, r);
 }
 
-export pure circuit rerandomize(
+export circuit rerandomize(
                       ct: ElGamal_Ciphertext,
                       pk: JubjubPoint,
                       r: JubjubScalar
                       ): ElGamal_Ciphertext {
+  _invocations.increment(1);
   return ElGamal_rerandomize(ct, pk, r);
 }
 
-export pure circuit assertKeyPair(pk: JubjubPoint, ek: Bytes<32>): [] {
+export circuit assertKeyPair(pk: JubjubPoint, ek: Bytes<32>): [] {
+  _invocations.increment(1);
   ElGamal_assertKeyPair(pk, ek);
 }
 
-export pure circuit assertDecryptsToPoint(
+export circuit assertDecryptsToPoint(
                  ct: ElGamal_Ciphertext,
                  pk: JubjubPoint,
                  ek: Bytes<32>,
                  m: JubjubPoint
                  ): [] {
+  _invocations.increment(1);
   ElGamal_assertDecryptsToPoint(ct, pk, ek, m);
 }
 
-export pure circuit assertDecryptsTo(
+export circuit assertDecryptsTo(
                  ct: ElGamal_Ciphertext,
                  pk: JubjubPoint,
                  ek: Bytes<32>,
                  claimedValue: Uint<128>
                  ): [] {
+  _invocations.increment(1);
   ElGamal_assertDecryptsTo(ct, pk, ek, claimedValue);
 }

--- a/contracts/src/crypto/test/simulators/CurveOpsSimulator.ts
+++ b/contracts/src/crypto/test/simulators/CurveOpsSimulator.ts
@@ -1,0 +1,74 @@
+import type { JubjubPoint } from '@midnight-ntwrk/compact-runtime';
+import {
+  createSimulator,
+  type SimulatorOptions,
+} from '@openzeppelin/compact-simulator';
+import {
+  ledger,
+  Contract as MockCurveOps,
+} from '../../../../artifacts/MockCurveOps/contract/index.js';
+
+// The mock wraps stdlib curve built-ins and declares no witnesses, so the
+// private state and witness set are both empty.
+export type CurveOpsPrivateState = Record<string, never>;
+export const CurveOpsPrivateState: CurveOpsPrivateState = {};
+export const CurveOpsWitnesses = () => ({});
+
+/**
+ * Type constructor args
+ */
+type CurveOpsArgs = readonly [];
+
+const CurveOpsSimulatorBase = createSimulator<
+  CurveOpsPrivateState,
+  ReturnType<typeof ledger>,
+  ReturnType<typeof CurveOpsWitnesses>,
+  MockCurveOps<CurveOpsPrivateState>,
+  CurveOpsArgs
+>({
+  contractFactory: (witnesses) =>
+    new MockCurveOps<CurveOpsPrivateState>(witnesses),
+  defaultPrivateState: () => CurveOpsPrivateState,
+  contractArgs: () => [],
+  ledgerExtractor: (state) => ledger(state),
+  witnessesFactory: () => CurveOpsWitnesses(),
+  artifactName: 'MockCurveOps',
+});
+
+/**
+ * CurveOps Simulator
+ *
+ * Each method is a thin pass-through to the mock's matching circuit.
+ */
+export class CurveOpsSimulator extends CurveOpsSimulatorBase {
+  static async create(
+    options: SimulatorOptions<
+      CurveOpsPrivateState,
+      ReturnType<typeof CurveOpsWitnesses>
+    > = {},
+  ): Promise<CurveOpsSimulator> {
+    // biome-ignore lint/complexity/noThisInStatic: super.create must keep the subclass `this`
+    return super.create([], options) as Promise<CurveOpsSimulator>;
+  }
+
+  /**
+   * @description Scalar-multiplies `p` by `k`.
+   */
+  public doEcMul(p: JubjubPoint, k: bigint): Promise<JubjubPoint> {
+    return this.circuits.impure.doEcMul(p, k);
+  }
+
+  /**
+   * @description Adds two curve points.
+   */
+  public doEcAdd(a: JubjubPoint, b: JubjubPoint): Promise<JubjubPoint> {
+    return this.circuits.impure.doEcAdd(a, b);
+  }
+
+  /**
+   * @description Scalar-multiplies the Jubjub generator by `k`.
+   */
+  public genMul(k: bigint): Promise<JubjubPoint> {
+    return this.circuits.impure.genMul(k);
+  }
+}

--- a/contracts/src/crypto/test/simulators/EcdhMaskSimulator.ts
+++ b/contracts/src/crypto/test/simulators/EcdhMaskSimulator.ts
@@ -1,0 +1,89 @@
+import type { JubjubPoint } from '@midnight-ntwrk/compact-runtime';
+import {
+  createSimulator,
+  type SimulatorOptions,
+} from '@openzeppelin/compact-simulator';
+import {
+  type EcdhMask_Ciphertext as Ciphertext,
+  ledger,
+  Contract as MockEcdhMask,
+} from '../../../../artifacts/MockEcdhMask/contract/index.js';
+
+export type { Ciphertext };
+
+// The EcdhMask module is stateless and declares no witnesses, so the private
+// state and witness set are both empty.
+export type EcdhMaskPrivateState = Record<string, never>;
+export const EcdhMaskPrivateState: EcdhMaskPrivateState = {};
+export const EcdhMaskWitnesses = () => ({});
+
+/**
+ * Type constructor args
+ */
+type EcdhMaskArgs = readonly [];
+
+const EcdhMaskSimulatorBase = createSimulator<
+  EcdhMaskPrivateState,
+  ReturnType<typeof ledger>,
+  ReturnType<typeof EcdhMaskWitnesses>,
+  MockEcdhMask<EcdhMaskPrivateState>,
+  EcdhMaskArgs
+>({
+  contractFactory: (witnesses) =>
+    new MockEcdhMask<EcdhMaskPrivateState>(witnesses),
+  defaultPrivateState: () => EcdhMaskPrivateState,
+  contractArgs: () => [],
+  ledgerExtractor: (state) => ledger(state),
+  witnessesFactory: () => EcdhMaskWitnesses(),
+  artifactName: 'MockEcdhMask',
+});
+
+/**
+ * EcdhMask Simulator
+ *
+ * Each method is a thin pass-through to the mock's matching circuit.
+ */
+export class EcdhMaskSimulator extends EcdhMaskSimulatorBase {
+  static async create(
+    options: SimulatorOptions<
+      EcdhMaskPrivateState,
+      ReturnType<typeof EcdhMaskWitnesses>
+    > = {},
+  ): Promise<EcdhMaskSimulator> {
+    // biome-ignore lint/complexity/noThisInStatic: super.create must keep the subclass `this`
+    return super.create([], options) as Promise<EcdhMaskSimulator>;
+  }
+
+  /**
+   * @description Derives the masking field element from the ECDH shared point
+   * and a domain-separation tag.
+   */
+  public kdf(sShared: JubjubPoint, domain: Uint8Array): Promise<bigint> {
+    return this.circuits.impure.kdf(sShared, domain);
+  }
+
+  /**
+   * @description Masks `value` for `recipientPk` under ephemeral scalar `e`.
+   * `e` must be fresh per ciphertext.
+   */
+  public encrypt(
+    recipientPk: JubjubPoint,
+    value: bigint,
+    e: bigint,
+    domain: Uint8Array,
+  ): Promise<Ciphertext> {
+    return this.circuits.impure.encrypt(recipientPk, value, e, domain);
+  }
+
+  /**
+   * @description Recovers the masked value using the recipient's secret scalar.
+   * `domain` must match the one used to encrypt.
+   */
+  public decrypt(
+    ciphertext: Ciphertext,
+    ekScalar: bigint,
+    domain: Uint8Array,
+  ): Promise<bigint> {
+    return this.circuits.impure.decrypt(ciphertext, ekScalar, domain);
+  }
+}

--- a/contracts/src/crypto/test/simulators/EcdsaSimulator.ts
+++ b/contracts/src/crypto/test/simulators/EcdsaSimulator.ts
@@ -7,7 +7,6 @@ import type { EcdsaSignature } from '#test-utils/fixtures/ecdsa.js';
 import {
   ledger,
   Contract as MockEcdsa,
-  pureCircuits,
 } from '../../../../artifacts/MockEcdsa/contract/index.js';
 
 // The Ecdsa module is stateless and declares no witnesses, so the private
@@ -52,10 +51,9 @@ export class EcdsaSimulator extends EcdsaSimulatorBase {
 
   /**
    * @description Whether `s <= n/2`, the canonical half of the scalar range.
-   * Pure, so callers can classify a signature without a deploy.
    */
-  public static isLowS(s: bigint): boolean {
-    return pureCircuits.isLowS(s);
+  public isLowS(s: bigint): Promise<boolean> {
+    return this.circuits.impure.isLowS(s);
   }
 
   /**

--- a/contracts/src/crypto/test/simulators/ElGamalSimulator.ts
+++ b/contracts/src/crypto/test/simulators/ElGamalSimulator.ts
@@ -39,8 +39,7 @@ const ElGamalSimulatorBase = createSimulator<
 /**
  * ElGamal Simulator
  *
- * Every ElGamal circuit is pure (no ledger, no witnesses), so each method is a
- * thin pass-through to the compiled pure circuit.
+ * Each method is a thin pass-through to the mock's matching circuit.
  */
 export class ElGamalSimulator extends ElGamalSimulatorBase {
   static async create(
@@ -57,14 +56,14 @@ export class ElGamalSimulator extends ElGamalSimulatorBase {
    * @description Maps a 32-byte secret to a valid Jubjub scalar.
    */
   public secretToScalar(secret: Uint8Array): Promise<bigint> {
-    return this.circuits.pure.secretToScalar(secret);
+    return this.circuits.impure.secretToScalar(secret);
   }
 
   /**
    * @description Derives the ElGamal public key `pk = g^secretToScalar(ek)`.
    */
   public derivePk(ek: Uint8Array): Promise<JubjubPoint> {
-    return this.circuits.pure.derivePk(ek);
+    return this.circuits.impure.derivePk(ek);
   }
 
   /**
@@ -72,14 +71,14 @@ export class ElGamalSimulator extends ElGamalSimulatorBase {
    * by `tag`.
    */
   public expandRandomness(seed: Uint8Array, tag: Uint8Array): Promise<bigint> {
-    return this.circuits.pure.expandRandomness(seed, tag);
+    return this.circuits.impure.expandRandomness(seed, tag);
   }
 
   /**
    * @description The identity ciphertext `Enc(0)`.
    */
   public encryptZero(): Promise<Ciphertext> {
-    return this.circuits.pure.encryptZero();
+    return this.circuits.impure.encryptZero();
   }
 
   /**
@@ -91,7 +90,7 @@ export class ElGamalSimulator extends ElGamalSimulatorBase {
     m: JubjubPoint,
     r: bigint,
   ): Promise<Ciphertext> {
-    return this.circuits.pure.encryptPoint(pk, m, r);
+    return this.circuits.impure.encryptPoint(pk, m, r);
   }
 
   /**
@@ -102,28 +101,28 @@ export class ElGamalSimulator extends ElGamalSimulatorBase {
     value: bigint,
     r: bigint,
   ): Promise<Ciphertext> {
-    return this.circuits.pure.encrypt(pk, value, r);
+    return this.circuits.impure.encrypt(pk, value, r);
   }
 
   /**
    * @description Negates a ciphertext componentwise (encrypts `-v`).
    */
   public negate(ct: Ciphertext): Promise<Ciphertext> {
-    return this.circuits.pure.negate(ct);
+    return this.circuits.impure.negate(ct);
   }
 
   /**
    * @description Homomorphically adds two ciphertexts: `Enc(a) + Enc(b)`.
    */
   public add(a: Ciphertext, b: Ciphertext): Promise<Ciphertext> {
-    return this.circuits.pure.add(a, b);
+    return this.circuits.impure.add(a, b);
   }
 
   /**
    * @description Homomorphically subtracts two ciphertexts: `Enc(a) - Enc(b)`.
    */
   public sub(a: Ciphertext, b: Ciphertext): Promise<Ciphertext> {
-    return this.circuits.pure.sub(a, b);
+    return this.circuits.impure.sub(a, b);
   }
 
   /**
@@ -131,7 +130,7 @@ export class ElGamalSimulator extends ElGamalSimulatorBase {
    * `k`: `Enc(v)` becomes `Enc(k * v)`.
    */
   public scalarMul(ct: Ciphertext, k: bigint): Promise<Ciphertext> {
-    return this.circuits.pure.scalarMul(ct, k);
+    return this.circuits.impure.scalarMul(ct, k);
   }
 
   /**
@@ -143,7 +142,7 @@ export class ElGamalSimulator extends ElGamalSimulatorBase {
     value: bigint,
     r: bigint,
   ): Promise<Ciphertext> {
-    return this.circuits.pure.addEncrypted(old, pk, value, r);
+    return this.circuits.impure.addEncrypted(old, pk, value, r);
   }
 
   /**
@@ -155,7 +154,7 @@ export class ElGamalSimulator extends ElGamalSimulatorBase {
     value: bigint,
     r: bigint,
   ): Promise<Ciphertext> {
-    return this.circuits.pure.subEncrypted(old, pk, value, r);
+    return this.circuits.impure.subEncrypted(old, pk, value, r);
   }
 
   /**
@@ -167,14 +166,14 @@ export class ElGamalSimulator extends ElGamalSimulatorBase {
     pk: JubjubPoint,
     r: bigint,
   ): Promise<Ciphertext> {
-    return this.circuits.pure.rerandomize(ct, pk, r);
+    return this.circuits.impure.rerandomize(ct, pk, r);
   }
 
   /**
    * @description Asserts `ek` is the secret for `pk`. Throws on mismatch.
    */
   public assertKeyPair(pk: JubjubPoint, ek: Uint8Array): Promise<[]> {
-    return this.circuits.pure.assertKeyPair(pk, ek);
+    return this.circuits.impure.assertKeyPair(pk, ek);
   }
 
   /**
@@ -187,7 +186,7 @@ export class ElGamalSimulator extends ElGamalSimulatorBase {
     ek: Uint8Array,
     m: JubjubPoint,
   ): Promise<[]> {
-    return this.circuits.pure.assertDecryptsToPoint(ct, pk, ek, m);
+    return this.circuits.impure.assertDecryptsToPoint(ct, pk, ek, m);
   }
 
   /**
@@ -200,6 +199,6 @@ export class ElGamalSimulator extends ElGamalSimulatorBase {
     ek: Uint8Array,
     claimedValue: bigint,
   ): Promise<[]> {
-    return this.circuits.pure.assertDecryptsTo(ct, pk, ek, claimedValue);
+    return this.circuits.impure.assertDecryptsTo(ct, pk, ek, claimedValue);
   }
 }

--- a/contracts/src/token/test/ConfidentialFungibleToken.test.ts
+++ b/contracts/src/token/test/ConfidentialFungibleToken.test.ts
@@ -6,13 +6,11 @@ import {
   persistentHash,
 } from '@midnight-ntwrk/compact-runtime';
 import { isLiveBackend } from '@openzeppelin/compact-simulator';
-import { beforeEach, describe, expect, it } from 'vitest';
-import { pureCircuits as ecdhMask } from '../../../artifacts/MockEcdhMask/contract/index.js';
-// The ElGamal pure circuits double as an off-circuit "mirror." They let a test
-// predict a ciphertext the contract will produce internally (e.g. the
-// post-refund balance in `approve`) so its plaintext can be cached ahead of the
-// witness query. They are pure (no proof), so this is cheap.
-import { pureCircuits as elgamal } from '../../../artifacts/MockElGamal/contract/index.js';
+import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
+// The crypto simulators double as an off-chain mirror to predict ciphertexts
+// the contract derives internally.
+import { EcdhMaskSimulator } from '../../crypto/test/simulators/EcdhMaskSimulator.js';
+import { ElGamalSimulator } from '../../crypto/test/simulators/ElGamalSimulator.js';
 import { ConfidentialFungibleTokenSimulator } from './simulators/ConfidentialFungibleTokenSimulator.js';
 import { ConfidentialFungibleTokenPrivateState } from './witnesses/ConfidentialFungibleTokenWitnesses.js';
 
@@ -78,6 +76,15 @@ const SYMBOL = 'CT';
 const DECIMALS = 6n;
 
 let cft: ConfidentialFungibleTokenSimulator;
+let elgamal: ElGamalSimulator;
+let ecdhMask: EcdhMaskSimulator;
+
+// `create()` deploys on the live backend, and every mirror call site is dry-only.
+beforeAll(async () => {
+  if (isLiveBackend()) return;
+  elgamal = await ElGamalSimulator.create();
+  ecdhMask = await EcdhMaskSimulator.create();
+});
 
 describe.skipIf(isLiveBackend())(
   'ConfidentialFungibleToken: registration',
@@ -488,7 +495,7 @@ describe.skipIf(isLiveBackend())(
       );
       const ownerCt = (await cft.allowance(ALICE.accountId, BOB.accountId))
         .ownerCt;
-      const refunded = elgamal.add(
+      const refunded = await elgamal.add(
         await cft.balanceOf(ALICE.accountId),
         ownerCt,
       );
@@ -636,7 +643,7 @@ describe.skipIf(isLiveBackend())(
       const escrowOwnerCt = (
         await cft.allowance(ALICE.accountId, BOB.accountId)
       ).ownerCt;
-      const refunded = elgamal.add(
+      const refunded = await elgamal.add(
         await cft.balanceOf(ALICE.accountId),
         escrowOwnerCt,
       );
@@ -678,8 +685,8 @@ describe.skipIf(isLiveBackend())(
         ALICE.encryptionKey,
       );
       const escrow = await cft.allowance(ALICE.accountId, BOB.accountId);
-      const aliceEk = elgamal.secretToScalar(ALICE.encryptionKey);
-      const remaining = ecdhMask.decrypt(
+      const aliceEk = await elgamal.secretToScalar(ALICE.encryptionKey);
+      const remaining = await ecdhMask.decrypt(
         escrow.ownerMemo,
         aliceEk,
         OWNER_MEMO_DOMAIN,
@@ -688,7 +695,7 @@ describe.skipIf(isLiveBackend())(
 
       // She proves the post-refund balance (spendable 60 + refunded remaining 15 =
       // 75) using the decrypted remaining, then re-approves Bob for 20
-      const refunded = elgamal.add(
+      const refunded = await elgamal.add(
         await cft.balanceOf(ALICE.accountId),
         escrow.ownerCt,
       );
@@ -720,7 +727,7 @@ describe.skipIf(isLiveBackend())(
         ALICE.encryptionKey,
       );
       const escrow = await cft.allowance(ALICE.accountId, BOB.accountId);
-      const refunded = elgamal.add(
+      const refunded = await elgamal.add(
         await cft.balanceOf(ALICE.accountId),
         escrow.ownerCt,
       );
@@ -734,7 +741,7 @@ describe.skipIf(isLiveBackend())(
       await approveBob(100n, 40n);
 
       const escrow = await cft.allowance(ALICE.accountId, BOB.accountId);
-      const refunded = elgamal.add(
+      const refunded = await elgamal.add(
         await cft.balanceOf(ALICE.accountId),
         escrow.ownerCt,
       );
@@ -1005,9 +1012,9 @@ describe.skipIf(isLiveBackend())(
       const memos = [...memoList];
       expect(memos.length).toBe(1);
 
-      const bobEk = elgamal.secretToScalar(BOB.encryptionKey);
+      const bobEk = await elgamal.secretToScalar(BOB.encryptionKey);
       expect(
-        ecdhMask.decrypt(memos[0], bobEk, padTag('OZ_CFT_ecdh_memo_v1')),
+        await ecdhMask.decrypt(memos[0], bobEk, padTag('OZ_CFT_ecdh_memo_v1')),
       ).toBe(250n);
     });
 
@@ -1032,9 +1039,9 @@ describe.skipIf(isLiveBackend())(
       const memoList = (await cft.getPublicState()).CFT__memos.lookup(
         BOB.accountId,
       );
-      const bobEk = elgamal.secretToScalar(BOB.encryptionKey);
+      const bobEk = await elgamal.secretToScalar(BOB.encryptionKey);
       expect(
-        ecdhMask.decrypt(
+        await ecdhMask.decrypt(
           [...memoList][0],
           bobEk,
           padTag('OZ_CFT_ecdh_memo_v1'),
@@ -1133,9 +1140,9 @@ describe('ConfidentialFungibleToken: receive-path smoke', () => {
       const memoList = (await cft.getPublicState()).CFT__memos.lookup(
         ALICE.accountId,
       );
-      const aliceEk = elgamal.secretToScalar(ALICE.encryptionKey);
+      const aliceEk = await elgamal.secretToScalar(ALICE.encryptionKey);
       expect(
-        ecdhMask.decrypt(
+        await ecdhMask.decrypt(
           [...memoList][0],
           aliceEk,
           padTag('OZ_CFT_ecdh_memo_v1'),

--- a/contracts/test-utils/harness/funding.ts
+++ b/contracts/test-utils/harness/funding.ts
@@ -67,7 +67,7 @@ async function transferNight(
     { ttl, payFees: true },
   );
   // Spending unshielded UTXOs needs the owner's signature before finalizing.
-  const signed = await from.wallet.signRecipe(recipe, (payload) =>
+  const signed = await from.wallet.signRecipe(recipe, async (payload) =>
     from.unshieldedKeystore.signData(payload),
   );
   const finalized = await from.wallet.finalizeRecipe(signed);


### PR DESCRIPTION
## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

Same technique already applied to `MockEcdsa` in #842; this finishes it for the jubjub mocks and for `isLowS`.

Not visible in the diff:

- Every crypto mock circuit was pure, so the artifacts shipped no `keys/` or `zkir/` and the specs passed on `unit-live` without proving anything. The `_invocations` counter is the only lever that forces impurity. Nothing stays pure: none of these circuits is an oracle recomputing an expected value.
- The counter is underscore-prefixed so it stays out of the generated `ledger()` reader. `getPublicState()` is still `{}` and the simulator ledger types are unchanged.
- `compile:crypto` becomes two passes. Under `--feature-zkir-v3`, keygen of the impure `MockElGamal` hits the ZKIR v3 blockers listed in the release notes (compact#616, compact#757). Only `MockEcdsa` needs v3, so the jubjub mocks compile under the default ZKIR v2 and `MockEcdsa` alone gets the flag.
- The CFT spec predicted ciphertexts through the ElGamal / EcdhMask mock `pureCircuits`. Those exports are gone, so it now drives the same circuits through the crypto simulators, dry-only.
- `funding.ts` is a harness fix, not crypto: wallet-sdk `4.0.0-beta.2` needs a Promise-returning signer callback, and without it no `unit-live` worker gets past setup since #841. Kept here because the live run below could not happen without it.

Live run against the local stack (`unit-live`, 3 workers):

- `CurveRuntimeInvariants` 13/13, `Ecdsa` 14/14, `EcdhMask` 17/17, all with real proofs. The one EcdhMask test that derives keys through `MockElGamal` is gated to the dry backend.
- `MockElGamal` (16 circuits) is rejected at deploy with `Transaction would exhaust the block limits`, which fails the whole `ElGamal` file on live. That is the known local-node ceiling and the deployer tool is picking it up; the mock is not split here.

## PR Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md#your-first-code-contribution)
- [x] I have added tests that prove my fix is effective or that my feature works. See [GUIDELINES.md#testing](../GUIDELINES.md#testing) for more information.
- [ ] I have added documentation for new methods or changes to existing method behavior. See [GUIDELINES.md#documentation](../GUIDELINES.md#documentation) for more information.
- [ ] CI Workflows Are Passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
